### PR TITLE
Change Examples SRC_PATH to src directory

### DIFF
--- a/examples/AdWords/Auth/init.php
+++ b/examples/AdWords/Auth/init.php
@@ -29,7 +29,7 @@
 error_reporting(E_STRICT | E_ALL);
 
 $depth = '/../../../';
-define('SRC_PATH', dirname(__FILE__) . $depth . 'lib/');
+define('SRC_PATH', dirname(__FILE__) . $depth . 'src/');
 define('LIB_PATH', 'Google/Api/Ads/AdWords/Lib');
 
 // Configure include path.


### PR DESCRIPTION
Previous SRC_PATH points to a non-existent lib path that causes the example scripts to be un-runnable.
