### PR TITLE
Adding branch alias to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "5.2.x-dev"
+            "dev-master": "5.4.x-dev"
         }
     }
 }


### PR DESCRIPTION
Adding branch alias to prevent version conflict when using latest master version. See [Aliases](https://getcomposer.org/doc/articles/aliases.md) for more information.
