### PR TITLE
Pseudo namespaced build results for #48 / #45

### DIFF
--- a/build_lib/build.xml
+++ b/build_lib/build.xml
@@ -4,6 +4,9 @@
 <!-- ======================================================================= -->
 <project basedir="../" default="generate-src" name="adsapi_php">
 
+  <property file="src/Google/Api/Ads/AdWords/Lib/api.properties" />
+  <property file="src/Google/Api/Ads/Dfp/Lib/api.properties" />
+
   <property name="classpath" value="" />
   <property name="out.dir" value="${project.basedir}/src" />
   <property name="product" value="${lib.product}" />

--- a/src/Google/Api/Ads/AdWords/Lib/api.properties
+++ b/src/Google/Api/Ads/AdWords/Lib/api.properties
@@ -8,7 +8,7 @@ lib.package=GoogleApiAdsAdWords
 wsdl2php.proxy=
 ;; If enabled, class names (but not service names) will be prefixed with the
 ;; package name. Ex) Google\Api\Ads\AdWords\Campaign
-wsdl2php.enableNamespaces=False
+wsdl2php.enableNamespaces=True
 ;; Class map to be used if namespace support is not enabled, to work around
 ;; common conflicts, in JSON format.
 wsdl2php.conflictClassmap={"DateTime":"AdWordsDateTime", "SoapHeader":"SoapRequestHeader"}

--- a/src/Google/Api/Ads/AdWords/v201309/AdGroupAdService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdGroupAdService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Ad", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Ad", false)) {
   /**
    * The base class of all ad types. To update basic ad fields,
    * you can construct an {@code Ad} object (instead of
@@ -133,7 +133,7 @@ if (!class_exists("Ad", false)) {
   }
 }
 
-if (!class_exists("AdGroupAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAd", false)) {
   /**
    * Represents an ad in an ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -222,7 +222,7 @@ if (!class_exists("AdGroupAd", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for an AdGroupAd
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -277,7 +277,7 @@ if (!class_exists("AdGroupAdExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdUnionId", false)) {
   /**
    * Represents an id indicating a grouping of Ads under some heuristic.
    * @package Google_Api_Ads_AdWords_v201309
@@ -356,7 +356,7 @@ if (!class_exists("AdUnionId", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -453,7 +453,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -532,7 +532,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -577,7 +577,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -622,7 +622,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -667,7 +667,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -712,7 +712,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -757,7 +757,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -802,7 +802,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -850,7 +850,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DeprecatedAd", false)) {
   /**
    * Represents a deprecated ad.
    * 
@@ -906,7 +906,7 @@ if (!class_exists("DeprecatedAd", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -953,7 +953,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -998,7 +998,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1072,7 +1072,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -1118,7 +1118,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1158,7 +1158,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -1204,7 +1204,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1249,7 +1249,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("ImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageAd", false)) {
   /**
    * Represents an ImageAd.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1310,7 +1310,7 @@ if (!class_exists("ImageAd", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1355,7 +1355,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1402,7 +1402,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1474,7 +1474,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1616,7 +1616,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1661,7 +1661,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -1709,7 +1709,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -1757,7 +1757,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("MobileAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAd", false)) {
   /**
    * Represents a mobile ad.
    * 
@@ -1895,7 +1895,7 @@ if (!class_exists("MobileAd", false)) {
   }
 }
 
-if (!class_exists("MobileImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileImageAd", false)) {
   /**
    * Represents a mobile image ad.
    * 
@@ -1960,7 +1960,7 @@ if (!class_exists("MobileImageAd", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2005,7 +2005,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2050,7 +2050,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2095,7 +2095,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2140,7 +2140,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -2220,7 +2220,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2265,7 +2265,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2312,7 +2312,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2391,7 +2391,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -2440,7 +2440,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2486,7 +2486,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -2577,7 +2577,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2624,7 +2624,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -2672,7 +2672,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2726,7 +2726,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("ProductAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductAd", false)) {
   /**
    * Represents a product ad (known as a <a href=
    * "//support.google.com/adwords/bin/answer.py?answer=2456103">product
@@ -2785,7 +2785,7 @@ if (!class_exists("ProductAd", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2837,7 +2837,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2882,7 +2882,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2927,7 +2927,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2993,7 +2993,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3038,7 +3038,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3084,7 +3084,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3129,7 +3129,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("RichMediaAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAd", false)) {
   /**
    * Data associated with a rich media ad.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3232,7 +3232,7 @@ if (!class_exists("RichMediaAd", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3300,7 +3300,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3345,7 +3345,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3390,7 +3390,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3465,7 +3465,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3533,7 +3533,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3578,7 +3578,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3624,7 +3624,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -3672,7 +3672,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TempAdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TempAdUnionId", false)) {
   /**
    * Represents the temporary id for an ad union id, which the user can specify.
    * The temporary id can be used to group ads together during ad creation.
@@ -3709,7 +3709,7 @@ if (!class_exists("TempAdUnionId", false)) {
   }
 }
 
-if (!class_exists("TemplateAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateAd", false)) {
   /**
    * Represents a <a href=
    * "//www.google.com/adwords/displaynetwork/plan-creative-campaigns/display-ad-builder.html"
@@ -3803,7 +3803,7 @@ if (!class_exists("TemplateAd", false)) {
   }
 }
 
-if (!class_exists("TemplateElement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElement", false)) {
   /**
    * Represents an element in a template. Each template element is composed
    * of a list of fields (actual value data).
@@ -3851,7 +3851,7 @@ if (!class_exists("TemplateElement", false)) {
   }
 }
 
-if (!class_exists("TemplateElementField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElementField", false)) {
   /**
    * Represents a field in a template element.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3912,7 +3912,7 @@ if (!class_exists("TemplateElementField", false)) {
   }
 }
 
-if (!class_exists("TextAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TextAd", false)) {
   /**
    * Represents a TextAd.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3973,7 +3973,7 @@ if (!class_exists("TextAd", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAd", false)) {
   /**
    * Data associated with rich media extension attributes.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4052,7 +4052,7 @@ if (!class_exists("ThirdPartyRedirectAd", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4139,7 +4139,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DynamicSearchAd", false)) {
   /**
    * Represents a dynamic search ad. This ad will have its headline and
    * destination URL auto-generated at serving time according to domain name
@@ -4223,7 +4223,7 @@ if (!class_exists("DynamicSearchAd", false)) {
   }
 }
 
-if (!class_exists("AdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4256,7 +4256,7 @@ if (!class_exists("AdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdApprovalStatus", false)) {
   /**
    * Represents the possible approval statuses.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4289,7 +4289,7 @@ if (!class_exists("AdGroupAdApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdStatus", false)) {
   /**
    * The current status of an Ad.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4322,7 +4322,7 @@ if (!class_exists("AdGroupAdStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4355,7 +4355,7 @@ if (!class_exists("AdGroupAdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4388,7 +4388,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4421,7 +4421,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4454,7 +4454,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4487,7 +4487,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -4521,7 +4521,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4554,7 +4554,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4587,7 +4587,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DeprecatedAdType", false)) {
   /**
    * Video ad.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4620,7 +4620,7 @@ if (!class_exists("DeprecatedAdType", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4653,7 +4653,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4686,7 +4686,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -4720,7 +4720,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4753,7 +4753,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4786,7 +4786,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4819,7 +4819,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4852,7 +4852,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4885,7 +4885,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4918,7 +4918,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MarkupLanguageType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MarkupLanguageType", false)) {
   /**
    * Markup languages to use for mobile ads.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4951,7 +4951,7 @@ if (!class_exists("MarkupLanguageType", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201309
@@ -4984,7 +4984,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201309
@@ -5017,7 +5017,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201309
@@ -5050,7 +5050,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5083,7 +5083,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5116,7 +5116,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5149,7 +5149,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5182,7 +5182,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5215,7 +5215,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5248,7 +5248,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5281,7 +5281,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5314,7 +5314,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5347,7 +5347,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5380,7 +5380,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -5414,7 +5414,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5447,7 +5447,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5480,7 +5480,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5513,7 +5513,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5546,7 +5546,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5579,7 +5579,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdAdAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAdAdAttribute", false)) {
   /**
    * A set of attributes that describe the rich media ad capabilities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5612,7 +5612,7 @@ if (!class_exists("RichMediaAdAdAttribute", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdRichMediaAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAdRichMediaAdType", false)) {
   /**
    * Different types of rich media ad that are available to customers.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5645,7 +5645,7 @@ if (!class_exists("RichMediaAdRichMediaAdType", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5678,7 +5678,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5711,7 +5711,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5744,7 +5744,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5777,7 +5777,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5810,7 +5810,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TemplateElementFieldType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElementFieldType", false)) {
   /**
    * Possible field types of template element fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5843,7 +5843,7 @@ if (!class_exists("TemplateElementFieldType", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAdExpandingDirection", false)) {
   /**
    * Allowed expanding directions for ads that are expandable.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5876,7 +5876,7 @@ if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
   }
 }
 
-if (!class_exists("VideoType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\VideoType", false)) {
   /**
    * VideoType enum values that are permitted for video filterable
    * creative attribute IDs.
@@ -5910,7 +5910,7 @@ if (!class_exists("VideoType", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5959,7 +5959,7 @@ if (!class_exists("AdGroupAdServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5999,7 +5999,7 @@ if (!class_exists("AdGroupAdServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -6066,7 +6066,7 @@ if (!class_exists("AdGroupAdServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -6106,7 +6106,7 @@ if (!class_exists("AdGroupAdServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -6154,7 +6154,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -6194,7 +6194,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdError", false)) {
   /**
    * Base error class for Ad Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6239,7 +6239,7 @@ if (!class_exists("AdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdCountLimitExceeded", false)) {
   /**
    * Indicates too many ads were added/enabled under the specified adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6278,7 +6278,7 @@ if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdError", false)) {
   /**
    * Error information for AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6323,7 +6323,7 @@ if (!class_exists("AdGroupAdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdOperation", false)) {
   /**
    * AdGroupAd service operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6373,7 +6373,7 @@ if (!class_exists("AdGroupAdOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdPage", false)) {
   /**
    * Represents a page of {@link AdGroupAd}s resulting from the query done by
    * {@link AdGroupAdService}.
@@ -6417,7 +6417,7 @@ if (!class_exists("AdGroupAdPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdReturnValue", false)) {
   /**
    * A container for return values from the AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6466,7 +6466,7 @@ if (!class_exists("AdGroupAdReturnValue", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6511,7 +6511,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6554,7 +6554,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6620,7 +6620,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -6679,7 +6679,7 @@ if (!class_exists("AdGroupAdService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdGroupAdService extends AdWordsSoapClient {
+  class AdGroupAdService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupAdService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -6696,143 +6696,143 @@ if (!class_exists("AdGroupAdService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Ad" => "Ad",
-      "AdError" => "AdError",
-      "AdGroupAd" => "AdGroupAd",
-      "AdGroupAdCountLimitExceeded" => "AdGroupAdCountLimitExceeded",
-      "AdGroupAdError" => "AdGroupAdError",
-      "AdGroupAdExperimentData" => "AdGroupAdExperimentData",
-      "AdGroupAdOperation" => "AdGroupAdOperation",
-      "AdGroupAdPage" => "AdGroupAdPage",
-      "AdGroupAdReturnValue" => "AdGroupAdReturnValue",
-      "AdUnionId" => "AdUnionId",
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Audio" => "Audio",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DeprecatedAd" => "DeprecatedAd",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageAd" => "ImageAd",
-      "ImageError" => "ImageError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "Media" => "Media",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "MobileAd" => "MobileAd",
-      "MobileImageAd" => "MobileImageAd",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "ProductAd" => "ProductAd",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "RichMediaAd" => "RichMediaAd",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TempAdUnionId" => "TempAdUnionId",
-      "TemplateAd" => "TemplateAd",
-      "TemplateElement" => "TemplateElement",
-      "TemplateElementField" => "TemplateElementField",
-      "TextAd" => "TextAd",
-      "ThirdPartyRedirectAd" => "ThirdPartyRedirectAd",
-      "Video" => "Video",
-      "DynamicSearchAd" => "DynamicSearchAd",
-      "AdError.Reason" => "AdErrorReason",
-      "AdGroupAd.ApprovalStatus" => "AdGroupAdApprovalStatus",
-      "AdGroupAd.Status" => "AdGroupAdStatus",
-      "AdGroupAdError.Reason" => "AdGroupAdErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DeprecatedAd.Type" => "DeprecatedAdType",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MarkupLanguageType" => "MarkupLanguageType",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "RichMediaAd.AdAttribute" => "RichMediaAdAdAttribute",
-      "RichMediaAd.RichMediaAdType" => "RichMediaAdRichMediaAdType",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TemplateElementField.Type" => "TemplateElementFieldType",
-      "ThirdPartyRedirectAd.ExpandingDirection" => "ThirdPartyRedirectAdExpandingDirection",
-      "VideoType" => "VideoType",
-      "get" => "AdGroupAdServiceGet",
-      "getResponse" => "AdGroupAdServiceGetResponse",
-      "mutate" => "AdGroupAdServiceMutate",
-      "mutateResponse" => "AdGroupAdServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "Ad" => "Google_Api_Ads_AdWords_v201309\\Ad",
+      "AdError" => "Google_Api_Ads_AdWords_v201309\\AdError",
+      "AdGroupAd" => "Google_Api_Ads_AdWords_v201309\\AdGroupAd",
+      "AdGroupAdCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdCountLimitExceeded",
+      "AdGroupAdError" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdError",
+      "AdGroupAdExperimentData" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdExperimentData",
+      "AdGroupAdOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdOperation",
+      "AdGroupAdPage" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdPage",
+      "AdGroupAdReturnValue" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdReturnValue",
+      "AdUnionId" => "Google_Api_Ads_AdWords_v201309\\AdUnionId",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Audio" => "Google_Api_Ads_AdWords_v201309\\Audio",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DeprecatedAd" => "Google_Api_Ads_AdWords_v201309\\DeprecatedAd",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201309\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201309\\ExemptionRequest",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201309\\Image",
+      "ImageAd" => "Google_Api_Ads_AdWords_v201309\\ImageAd",
+      "ImageError" => "Google_Api_Ads_AdWords_v201309\\ImageError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Media" => "Google_Api_Ads_AdWords_v201309\\Media",
+      "MediaError" => "Google_Api_Ads_AdWords_v201309\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry",
+      "MobileAd" => "Google_Api_Ads_AdWords_v201309\\MobileAd",
+      "MobileImageAd" => "Google_Api_Ads_AdWords_v201309\\MobileImageAd",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "ProductAd" => "Google_Api_Ads_AdWords_v201309\\ProductAd",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "RichMediaAd" => "Google_Api_Ads_AdWords_v201309\\RichMediaAd",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "TempAdUnionId" => "Google_Api_Ads_AdWords_v201309\\TempAdUnionId",
+      "TemplateAd" => "Google_Api_Ads_AdWords_v201309\\TemplateAd",
+      "TemplateElement" => "Google_Api_Ads_AdWords_v201309\\TemplateElement",
+      "TemplateElementField" => "Google_Api_Ads_AdWords_v201309\\TemplateElementField",
+      "TextAd" => "Google_Api_Ads_AdWords_v201309\\TextAd",
+      "ThirdPartyRedirectAd" => "Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAd",
+      "Video" => "Google_Api_Ads_AdWords_v201309\\Video",
+      "DynamicSearchAd" => "Google_Api_Ads_AdWords_v201309\\DynamicSearchAd",
+      "AdError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdErrorReason",
+      "AdGroupAd.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdApprovalStatus",
+      "AdGroupAd.Status" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdStatus",
+      "AdGroupAdError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DeprecatedAd.Type" => "Google_Api_Ads_AdWords_v201309\\DeprecatedAdType",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201309\\ImageErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "MarkupLanguageType" => "Google_Api_Ads_AdWords_v201309\\MarkupLanguageType",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201309\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201309\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201309\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201309\\MediaErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "RichMediaAd.AdAttribute" => "Google_Api_Ads_AdWords_v201309\\RichMediaAdAdAttribute",
+      "RichMediaAd.RichMediaAdType" => "Google_Api_Ads_AdWords_v201309\\RichMediaAdRichMediaAdType",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "TemplateElementField.Type" => "Google_Api_Ads_AdWords_v201309\\TemplateElementFieldType",
+      "ThirdPartyRedirectAd.ExpandingDirection" => "Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAdExpandingDirection",
+      "VideoType" => "Google_Api_Ads_AdWords_v201309\\VideoType",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201309\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201309\\QueryResponse",
     );
 
 
@@ -6916,3 +6916,4 @@ if (!class_exists("AdGroupAdService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdGroupBidModifierService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdGroupBidModifierService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -468,7 +468,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -547,7 +547,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -615,7 +615,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -702,7 +702,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifier", false)) {
   /**
    * Represents an adgroup level bid modifier override for campaign level criterion
    * bid modifier values.
@@ -771,7 +771,7 @@ if (!class_exists("AdGroupBidModifier", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -843,7 +843,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -923,7 +923,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1002,7 +1002,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1035,7 +1035,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1068,7 +1068,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidModifierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidModifierSource", false)) {
   /**
    * Enumerates possible sources for bid modifier.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1101,7 +1101,7 @@ if (!class_exists("BidModifierSource", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1135,7 +1135,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1168,7 +1168,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1201,7 +1201,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1234,7 +1234,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1267,7 +1267,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1301,7 +1301,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1334,7 +1334,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1367,7 +1367,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1400,7 +1400,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1433,7 +1433,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1466,7 +1466,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1499,7 +1499,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1532,7 +1532,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1565,7 +1565,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1599,7 +1599,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1632,7 +1632,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1665,7 +1665,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1698,7 +1698,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1731,7 +1731,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1764,7 +1764,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1797,7 +1797,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1830,7 +1830,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1863,7 +1863,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1896,7 +1896,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1944,7 +1944,7 @@ if (!class_exists("AdGroupBidModifierServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1984,7 +1984,7 @@ if (!class_exists("AdGroupBidModifierServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2035,7 +2035,7 @@ if (!class_exists("AdGroupBidModifierServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2075,7 +2075,7 @@ if (!class_exists("AdGroupBidModifierServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2120,7 +2120,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2165,7 +2165,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2210,7 +2210,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2255,7 +2255,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2300,7 +2300,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2346,7 +2346,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2391,7 +2391,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2438,7 +2438,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2483,7 +2483,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2528,7 +2528,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2573,7 +2573,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2618,10 +2618,10 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2664,7 +2664,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2709,7 +2709,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2754,7 +2754,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2820,7 +2820,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2865,7 +2865,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2911,7 +2911,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2956,7 +2956,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3001,7 +3001,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3046,7 +3046,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3092,7 +3092,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3137,7 +3137,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3180,7 +3180,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierOperation", false)) {
   /**
    * Operation used to create or mutate a AdGroupBidModifier.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3223,7 +3223,7 @@ if (!class_exists("AdGroupBidModifierOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierPage", false)) {
   /**
    * Contains a subset of adgroup bid modifiers resulting from a call to
    * {@link AdGroupBidModifierService#get}.
@@ -3267,7 +3267,7 @@ if (!class_exists("AdGroupBidModifierPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierReturnValue", false)) {
   /**
    * A container for return values from the AdGroupBidModifierService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3322,7 +3322,7 @@ if (!class_exists("AdGroupBidModifierService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdGroupBidModifierService extends AdWordsSoapClient {
+  class AdGroupBidModifierService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupBidModifierService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3339,78 +3339,78 @@ if (!class_exists("AdGroupBidModifierService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CriterionError" => "CriterionError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Platform" => "Platform",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Criterion" => "Criterion",
-      "AdGroupBidModifier" => "AdGroupBidModifier",
-      "AdGroupBidModifierOperation" => "AdGroupBidModifierOperation",
-      "AdGroupBidModifierPage" => "AdGroupBidModifierPage",
-      "AdGroupBidModifierReturnValue" => "AdGroupBidModifierReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BidModifierSource" => "BidModifierSource",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupBidModifierServiceGet",
-      "getResponse" => "AdGroupBidModifierServiceGetResponse",
-      "mutate" => "AdGroupBidModifierServiceMutate",
-      "mutateResponse" => "AdGroupBidModifierServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Platform" => "Google_Api_Ads_AdWords_v201309\\Platform",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "AdGroupBidModifier" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifier",
+      "AdGroupBidModifierOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierOperation",
+      "AdGroupBidModifierPage" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierPage",
+      "AdGroupBidModifierReturnValue" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BidModifierSource" => "Google_Api_Ads_AdWords_v201309\\BidModifierSource",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierServiceMutateResponse",
     );
 
 
@@ -3461,3 +3461,4 @@ if (!class_exists("AdGroupBidModifierService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdGroupCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdGroupCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterion", false)) {
   /**
    * Represents a criterion in an ad group, used with AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -130,7 +130,7 @@ if (!class_exists("AdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * Bid multiplier used to modify the bid of a criterion while running
    * an experiment.
@@ -204,7 +204,7 @@ if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -301,7 +301,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -380,7 +380,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -425,7 +425,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -470,7 +470,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -515,7 +515,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -555,7 +555,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -603,7 +603,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterion", false)) {
   /**
    * A biddable (positive) criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -719,7 +719,7 @@ if (!class_exists("BiddableAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterionExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this {@link BiddableAdGroupCriterion}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -780,7 +780,7 @@ if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -825,7 +825,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -870,7 +870,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -943,7 +943,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -1035,7 +1035,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1107,7 +1107,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -1158,7 +1158,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1203,7 +1203,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1275,7 +1275,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -1338,7 +1338,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1380,7 +1380,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1436,7 +1436,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1485,7 +1485,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1572,7 +1572,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1617,7 +1617,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1689,7 +1689,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1734,7 +1734,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1779,7 +1779,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -1827,7 +1827,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1872,7 +1872,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -1911,7 +1911,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1956,7 +1956,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2030,7 +2030,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2076,7 +2076,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2116,7 +2116,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -2162,10 +2162,10 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2208,7 +2208,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2253,7 +2253,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2300,7 +2300,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -2352,7 +2352,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2424,7 +2424,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * AdGroupCriterion level bid multiplier used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2474,7 +2474,7 @@ if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2517,7 +2517,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2553,7 +2553,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -2607,7 +2607,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2659,7 +2659,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2701,7 +2701,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NegativeAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeAdGroupCriterion", false)) {
   /**
    * A negative criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2740,7 +2740,7 @@ if (!class_exists("NegativeAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2785,7 +2785,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2830,7 +2830,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2875,7 +2875,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2920,7 +2920,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2955,7 +2955,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -3035,7 +3035,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3080,7 +3080,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3127,7 +3127,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3206,7 +3206,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -3285,7 +3285,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -3334,7 +3334,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -3380,7 +3380,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3429,7 +3429,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -3470,7 +3470,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -3516,7 +3516,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -3607,7 +3607,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3654,7 +3654,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -3702,7 +3702,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3756,7 +3756,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -3811,7 +3811,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -3859,7 +3859,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3899,7 +3899,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QualityInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QualityInfo", false)) {
   /**
    * Container for criterion quality information.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3960,7 +3960,7 @@ if (!class_exists("QualityInfo", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4012,7 +4012,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4057,7 +4057,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4102,7 +4102,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4168,7 +4168,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4213,7 +4213,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4258,7 +4258,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -4304,7 +4304,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4349,7 +4349,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4417,7 +4417,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4462,7 +4462,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4507,7 +4507,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4582,7 +4582,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4650,7 +4650,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4695,7 +4695,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4741,7 +4741,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -4789,7 +4789,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -4842,7 +4842,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -4894,7 +4894,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4946,7 +4946,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -5005,7 +5005,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -5068,7 +5068,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -5128,7 +5128,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -5180,7 +5180,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -5230,7 +5230,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5263,7 +5263,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5296,7 +5296,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5329,7 +5329,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -5362,7 +5362,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("ApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApprovalStatus", false)) {
   /**
    * Approval status for the criterion.
    * Note: there are more states involved but we only expose two to users.
@@ -5396,7 +5396,7 @@ if (!class_exists("ApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5429,7 +5429,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5462,7 +5462,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5495,7 +5495,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -5529,7 +5529,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5562,7 +5562,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5595,7 +5595,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5628,7 +5628,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5661,7 +5661,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -5695,7 +5695,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5728,7 +5728,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5761,7 +5761,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5794,7 +5794,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5827,7 +5827,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUse", false)) {
   /**
    * The way a criterion is used - biddable or negative.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5860,7 +5860,7 @@ if (!class_exists("CriterionUse", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5893,7 +5893,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5926,7 +5926,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5959,7 +5959,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5992,7 +5992,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6025,7 +6025,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -6059,7 +6059,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6092,7 +6092,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6125,7 +6125,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6158,7 +6158,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -6191,7 +6191,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6224,7 +6224,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6257,7 +6257,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -6291,7 +6291,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("MultiplierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MultiplierSource", false)) {
   /**
    * Denotes whether the bid multiplier is derived from the adgroup
    * or the criterion
@@ -6325,7 +6325,7 @@ if (!class_exists("MultiplierSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6358,7 +6358,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6391,7 +6391,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6424,7 +6424,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6457,7 +6457,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6490,7 +6490,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6523,9 +6523,9 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -6556,7 +6556,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6589,7 +6589,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6622,7 +6622,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6655,7 +6655,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -6689,7 +6689,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6722,7 +6722,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6755,7 +6755,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6788,7 +6788,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6821,7 +6821,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6854,7 +6854,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6887,7 +6887,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6920,7 +6920,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6953,7 +6953,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6986,7 +6986,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7019,7 +7019,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7052,7 +7052,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("SystemServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SystemServingStatus", false)) {
   /**
    * Reported by system to reflect the criterion's serving status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7085,7 +7085,7 @@ if (!class_exists("SystemServingStatus", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7118,7 +7118,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("UserStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserStatus", false)) {
   /**
    * Specified by user to pause or unpause a criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7151,7 +7151,7 @@ if (!class_exists("UserStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7184,7 +7184,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7232,7 +7232,7 @@ if (!class_exists("AdGroupCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -7272,7 +7272,7 @@ if (!class_exists("AdGroupCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -7325,7 +7325,7 @@ if (!class_exists("AdGroupCriterionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -7365,7 +7365,7 @@ if (!class_exists("AdGroupCriterionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7413,7 +7413,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -7453,7 +7453,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7498,7 +7498,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7544,7 +7544,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionOperation", false)) {
   /**
    * Operation (add, remove and set) on adgroup criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7594,7 +7594,7 @@ if (!class_exists("AdGroupCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionPage", false)) {
   /**
    * Contains a subset of adgroup criteria resulting from a
    * {@link AdGroupCriterionService#get} call.
@@ -7638,7 +7638,7 @@ if (!class_exists("AdGroupCriterionPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionReturnValue", false)) {
   /**
    * A container for return values from the AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7687,7 +7687,7 @@ if (!class_exists("AdGroupCriterionReturnValue", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7732,10 +7732,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -7778,7 +7778,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7821,7 +7821,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7861,7 +7861,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7902,7 +7902,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7949,7 +7949,7 @@ if (!class_exists("AdGroupCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdGroupCriterionService extends AdWordsSoapClient {
+  class AdGroupCriterionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -7966,177 +7966,177 @@ if (!class_exists("AdGroupCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupCriterion" => "AdGroupCriterion",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionExperimentBidMultiplier" => "AdGroupCriterionExperimentBidMultiplier",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdGroupCriterionOperation" => "AdGroupCriterionOperation",
-      "AdGroupCriterionPage" => "AdGroupCriterionPage",
-      "AdGroupCriterionReturnValue" => "AdGroupCriterionReturnValue",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "BiddableAdGroupCriterion" => "BiddableAdGroupCriterion",
-      "BiddableAdGroupCriterionExperimentData" => "BiddableAdGroupCriterionExperimentData",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "Gender" => "Gender",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "ListReturnValue" => "ListReturnValue",
-      "LongValue" => "LongValue",
-      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "ManualCPCAdGroupCriterionExperimentBidMultiplier",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NegativeAdGroupCriterion" => "NegativeAdGroupCriterion",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Placement" => "Placement",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QualityInfo" => "QualityInfo",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "ApprovalStatus" => "ApprovalStatus",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "CriterionUse" => "CriterionUse",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "MultiplierSource" => "MultiplierSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "SystemServingStatus" => "SystemServingStatus",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "UserStatus" => "UserStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "AdGroupCriterionServiceGet",
-      "getResponse" => "AdGroupCriterionServiceGetResponse",
-      "mutate" => "AdGroupCriterionServiceMutate",
-      "mutateResponse" => "AdGroupCriterionServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterion",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError",
+      "AdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionExperimentBidMultiplier",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded",
+      "AdGroupCriterionOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionOperation",
+      "AdGroupCriterionPage" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionPage",
+      "AdGroupCriterionReturnValue" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionReturnValue",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201309\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "Bid" => "Google_Api_Ads_AdWords_v201309\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201309\\BidMultiplier",
+      "BiddableAdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterion",
+      "BiddableAdGroupCriterionExperimentData" => "Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterionExperimentData",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201309\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201309\\BiddingErrors",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration",
+      "Bids" => "Google_Api_Ads_AdWords_v201309\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201309\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201309\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201309\\CpmBid",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201309\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDenied",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201309\\ExemptionRequest",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError",
+      "Gender" => "Google_Api_Ads_AdWords_v201309\\Gender",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupCriterionExperimentBidMultiplier",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NegativeAdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\NegativeAdGroupCriterion",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QualityInfo" => "Google_Api_Ads_AdWords_v201309\\QualityInfo",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType",
+      "ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\ApprovalStatus",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201309\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "CriterionUse" => "Google_Api_Ads_AdWords_v201309\\CriterionUse",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201309\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "MultiplierSource" => "Google_Api_Ads_AdWords_v201309\\MultiplierSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "SystemServingStatus" => "Google_Api_Ads_AdWords_v201309\\SystemServingStatus",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "UserStatus" => "Google_Api_Ads_AdWords_v201309\\UserStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201309\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201309\\QueryResponse",
     );
 
 
@@ -8205,3 +8205,4 @@ if (!class_exists("AdGroupCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdGroupFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdGroupFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdGroupFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeed", false)) {
   /**
    * AdGroupFeeds are used to link a feed to an adgroup using a matching function,
    * making the feed's feed items available in the adgroup's ads for substitution.
@@ -99,7 +99,7 @@ if (!class_exists("AdGroupFeed", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -196,7 +196,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -275,7 +275,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -320,7 +320,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -365,7 +365,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -410,7 +410,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -455,7 +455,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -501,7 +501,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -546,7 +546,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -594,7 +594,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -639,7 +639,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -713,7 +713,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -759,7 +759,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -843,7 +843,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -888,7 +888,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -933,7 +933,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -980,7 +980,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1052,7 +1052,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1097,7 +1097,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1142,7 +1142,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1187,7 +1187,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1259,7 +1259,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1339,7 +1339,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1384,7 +1384,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1431,7 +1431,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1510,7 +1510,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1559,7 +1559,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1613,7 +1613,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1658,7 +1658,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1703,7 +1703,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1769,7 +1769,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1814,7 +1814,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestContextOperand", false)) {
   /**
    * An operand in a function referring to a value in the request context.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1856,7 +1856,7 @@ if (!class_exists("RequestContextOperand", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1902,7 +1902,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1947,7 +1947,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2015,7 +2015,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2060,7 +2060,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2105,7 +2105,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2180,7 +2180,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2248,7 +2248,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2294,7 +2294,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedStatus", false)) {
   /**
    * Status of the AdGroupFeed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2327,7 +2327,7 @@ if (!class_exists("AdGroupFeedStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2360,7 +2360,7 @@ if (!class_exists("AdGroupFeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2393,7 +2393,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2426,7 +2426,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2459,7 +2459,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2493,7 +2493,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2526,7 +2526,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantOperandConstantType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConstantOperandConstantType", false)) {
   /**
    * The types of constant operands.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2559,7 +2559,7 @@ if (!class_exists("ConstantOperandConstantType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2592,7 +2592,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2625,7 +2625,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2658,7 +2658,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2692,7 +2692,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2725,7 +2725,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2758,7 +2758,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2791,7 +2791,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2824,7 +2824,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2857,7 +2857,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2890,7 +2890,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2923,7 +2923,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2956,7 +2956,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2989,7 +2989,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3022,7 +3022,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3056,7 +3056,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3089,7 +3089,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3122,7 +3122,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3155,7 +3155,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperandContextType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestContextOperandContextType", false)) {
   /**
    * Campaign Id in the request context.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3188,7 +3188,7 @@ if (!class_exists("RequestContextOperandContextType", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3221,7 +3221,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3254,7 +3254,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3287,7 +3287,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3320,7 +3320,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3353,7 +3353,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3386,7 +3386,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3435,7 +3435,7 @@ if (!class_exists("AdGroupFeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3475,7 +3475,7 @@ if (!class_exists("AdGroupFeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -3525,7 +3525,7 @@ if (!class_exists("AdGroupFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3565,7 +3565,7 @@ if (!class_exists("AdGroupFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedError", false)) {
   /**
    * Represents an error for the AdGroupFeedService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3610,7 +3610,7 @@ if (!class_exists("AdGroupFeedError", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedOperation", false)) {
   /**
    * Operation used to create or mutate an AdGroupFeed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3653,7 +3653,7 @@ if (!class_exists("AdGroupFeedOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedReturnValue", false)) {
   /**
    * The result of a call to AdGroupFeedService#mutate.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3695,7 +3695,7 @@ if (!class_exists("AdGroupFeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3738,7 +3738,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ConstantOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConstantOperand", false)) {
   /**
    * A constant operand in a matching function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3808,7 +3808,7 @@ if (!class_exists("ConstantOperand", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedAttributeOperand", false)) {
   /**
    * Represents a feed attribute reference to use in a function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3857,7 +3857,7 @@ if (!class_exists("FeedAttributeOperand", false)) {
   }
 }
 
-if (!class_exists("FunctionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionOperand", false)) {
   /**
    * A function operand in a matching function.
    * Used to represent nested functions.
@@ -3900,7 +3900,7 @@ if (!class_exists("FunctionOperand", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3936,7 +3936,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupFeedPage", false)) {
   /**
    * The result of a call to AdGroupFeedService#get. Contains a list of
    * associations between ad groups and feeds.
@@ -3984,7 +3984,7 @@ if (!class_exists("AdGroupFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdGroupFeedService extends AdWordsSoapClient {
+  class AdGroupFeedService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -4001,93 +4001,93 @@ if (!class_exists("AdGroupFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupFeed" => "AdGroupFeed",
-      "AdGroupFeedError" => "AdGroupFeedError",
-      "AdGroupFeedOperation" => "AdGroupFeedOperation",
-      "AdGroupFeedPage" => "AdGroupFeedPage",
-      "AdGroupFeedReturnValue" => "AdGroupFeedReturnValue",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ConstantOperand" => "ConstantOperand",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttributeOperand" => "FeedAttributeOperand",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "FunctionOperand" => "FunctionOperand",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NullStatsPage" => "NullStatsPage",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestContextOperand" => "RequestContextOperand",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "AdGroupFeed.Status" => "AdGroupFeedStatus",
-      "AdGroupFeedError.Reason" => "AdGroupFeedErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "ConstantOperand.ConstantType" => "ConstantOperandConstantType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestContextOperand.ContextType" => "RequestContextOperandContextType",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupFeedServiceGet",
-      "getResponse" => "AdGroupFeedServiceGetResponse",
-      "mutate" => "AdGroupFeedServiceMutate",
-      "mutateResponse" => "AdGroupFeedServiceMutateResponse",
+      "AdGroupFeed" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeed",
+      "AdGroupFeedError" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedError",
+      "AdGroupFeedOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedOperation",
+      "AdGroupFeedPage" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedPage",
+      "AdGroupFeedReturnValue" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedReturnValue",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "ConstantOperand" => "Google_Api_Ads_AdWords_v201309\\ConstantOperand",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "FeedAttributeOperand" => "Google_Api_Ads_AdWords_v201309\\FeedAttributeOperand",
+      "Function" => "Google_Api_Ads_AdWords_v201309\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201309\\FunctionError",
+      "FunctionOperand" => "Google_Api_Ads_AdWords_v201309\\FunctionOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201309\\FunctionArgumentOperand",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestContextOperand" => "Google_Api_Ads_AdWords_v201309\\RequestContextOperand",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "AdGroupFeed.Status" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedStatus",
+      "AdGroupFeedError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "ConstantOperand.ConstantType" => "Google_Api_Ads_AdWords_v201309\\ConstantOperandConstantType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201309\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201309\\FunctionErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestContextOperand.ContextType" => "Google_Api_Ads_AdWords_v201309\\RequestContextOperandContextType",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupFeedServiceMutateResponse",
     );
 
 
@@ -4138,3 +4138,4 @@ if (!class_exists("AdGroupFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdGroupService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdGroupService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -419,7 +419,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TargetingSettingDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingSettingDetail", false)) {
   /**
    * Specifies if criteria of this type group should be used to restrict
    * targeting, or if ads can serve anywhere and criteria are only used in
@@ -468,7 +468,7 @@ if (!class_exists("TargetingSettingDetail", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -540,7 +540,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -612,7 +612,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -709,7 +709,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -788,7 +788,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -828,7 +828,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -876,7 +876,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -948,7 +948,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1016,7 +1016,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupExperimentBidMultipliers", false)) {
   /**
    * Bid multiplier used to modify the bid of an adgroup while running
    * an experiment.
@@ -1090,7 +1090,7 @@ if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this adgroup.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1152,7 +1152,7 @@ if (!class_exists("AdGroupExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1225,7 +1225,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -1317,7 +1317,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("AdGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroup", false)) {
   /**
    * Represents an ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1420,7 +1420,7 @@ if (!class_exists("AdGroup", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1492,7 +1492,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1572,7 +1572,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1651,7 +1651,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceErrorReason", false)) {
   /**
    * The reasons for the adgroup service error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1684,7 +1684,7 @@ if (!class_exists("AdGroupServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupStatus", false)) {
   /**
    * Status of this ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1717,7 +1717,7 @@ if (!class_exists("AdGroupStatus", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1750,7 +1750,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1783,7 +1783,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1816,7 +1816,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1849,7 +1849,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -1883,7 +1883,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1916,7 +1916,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1949,7 +1949,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1982,7 +1982,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2015,7 +2015,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2049,7 +2049,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2082,7 +2082,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2115,7 +2115,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("CriterionTypeGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionTypeGroup", false)) {
   /**
    * The list of groupings of criteria types.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2148,7 +2148,7 @@ if (!class_exists("CriterionTypeGroup", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2181,7 +2181,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2214,7 +2214,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2247,7 +2247,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2280,7 +2280,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2314,7 +2314,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2347,7 +2347,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2380,7 +2380,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2413,7 +2413,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2446,7 +2446,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2479,7 +2479,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2512,7 +2512,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2545,7 +2545,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2578,7 +2578,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2611,7 +2611,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2644,7 +2644,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2677,7 +2677,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2710,9 +2710,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -2743,7 +2743,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2776,7 +2776,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2809,7 +2809,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2843,7 +2843,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2876,7 +2876,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2909,7 +2909,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2942,7 +2942,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2975,7 +2975,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3008,7 +3008,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3041,7 +3041,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3074,7 +3074,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3107,7 +3107,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3140,7 +3140,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3173,7 +3173,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3206,7 +3206,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3239,7 +3239,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3272,7 +3272,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3321,7 +3321,7 @@ if (!class_exists("AdGroupServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3361,7 +3361,7 @@ if (!class_exists("AdGroupServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -3371,10 +3371,10 @@ if (!class_exists("AdGroupServiceMutate", false)) {
    * 
    * 
    * 
-   * Adds, updates, or deletes ad groups.
+   * Adds, updates, or removes ad groups.
    * <p class="note"><b>Note:</b> {@link AdGroupOperation} does not support the
-   * {@code REMOVE} operator. To delete an ad group, set its
-   * {@link AdGroup#status status} to {@code DELETED}.</p>
+   * {@code REMOVE} operator. To remove an ad group, set its
+   * {@link AdGroup#status status} to {@code REMOVED}.</p>
    * 
    * @param operations List of unique operations. The same ad group cannot be
    * specified in more than one operation.
@@ -3416,7 +3416,7 @@ if (!class_exists("AdGroupServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3456,7 +3456,7 @@ if (!class_exists("AdGroupServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3504,7 +3504,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3544,7 +3544,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceError", false)) {
   /**
    * Represents possible error codes in AdGroupService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3596,7 +3596,7 @@ if (!class_exists("AdGroupServiceError", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3641,7 +3641,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3686,7 +3686,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3731,7 +3731,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3776,7 +3776,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3821,7 +3821,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3866,7 +3866,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3911,7 +3911,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -3974,7 +3974,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4019,7 +4019,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4064,7 +4064,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4103,7 +4103,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4177,7 +4177,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4223,7 +4223,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExplorerAutoOptimizerSetting", false)) {
   /**
    * Settings for Explorer (GDN Auto Optimizer).
    * @package Google_Api_Ads_AdWords_v201309
@@ -4265,7 +4265,7 @@ if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -4311,7 +4311,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4356,7 +4356,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -4403,7 +4403,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -4446,7 +4446,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4482,7 +4482,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4524,7 +4524,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4569,7 +4569,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4614,7 +4614,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4659,7 +4659,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4704,7 +4704,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4739,7 +4739,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4784,7 +4784,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4829,7 +4829,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4878,7 +4878,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -4919,7 +4919,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4971,7 +4971,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5016,7 +5016,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5068,7 +5068,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5113,7 +5113,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5179,7 +5179,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5224,7 +5224,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5269,7 +5269,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -5315,7 +5315,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5360,7 +5360,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5405,7 +5405,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5450,7 +5450,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5495,7 +5495,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5540,7 +5540,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -5586,7 +5586,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingSetting", false)) {
   /**
    * Setting for targeting related features.
    * This is applicable at Campaign and AdGroup level.
@@ -5629,7 +5629,7 @@ if (!class_exists("TargetingSetting", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5671,7 +5671,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5727,7 +5727,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5776,7 +5776,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5821,7 +5821,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -5900,7 +5900,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -5953,7 +5953,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -6005,7 +6005,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6048,7 +6048,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -6099,7 +6099,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6149,7 +6149,7 @@ if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPMAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPM bidding strategy.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6192,7 +6192,7 @@ if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupOperation", false)) {
   /**
    * AdGroup operations for adding/updating/removing adgroups.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6235,7 +6235,7 @@ if (!class_exists("AdGroupOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupPage", false)) {
   /**
    * Contains a subset of adgroup resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.adgroup.AdGroupService#get} call
@@ -6279,7 +6279,7 @@ if (!class_exists("AdGroupPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupReturnValue", false)) {
   /**
    * A container for return values from the AdGroupService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6328,7 +6328,7 @@ if (!class_exists("AdGroupReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6369,7 +6369,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6416,7 +6416,7 @@ if (!class_exists("AdGroupService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdGroupService extends AdWordsSoapClient {
+  class AdGroupService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -6433,146 +6433,146 @@ if (!class_exists("AdGroupService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupServiceError" => "AdGroupServiceError",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExplorerAutoOptimizerSetting" => "ExplorerAutoOptimizerSetting",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SettingError" => "SettingError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetingSettingDetail" => "TargetingSettingDetail",
-      "TargetingSetting" => "TargetingSetting",
-      "ComparableValue" => "ComparableValue",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Setting" => "Setting",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "ManualCPCAdGroupExperimentBidMultipliers" => "ManualCPCAdGroupExperimentBidMultipliers",
-      "ManualCPMAdGroupExperimentBidMultipliers" => "ManualCPMAdGroupExperimentBidMultipliers",
-      "Selector" => "Selector",
-      "AdGroupExperimentBidMultipliers" => "AdGroupExperimentBidMultipliers",
-      "AdGroupExperimentData" => "AdGroupExperimentData",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "AdGroup" => "AdGroup",
-      "AdGroupOperation" => "AdGroupOperation",
-      "AdGroupPage" => "AdGroupPage",
-      "AdGroupReturnValue" => "AdGroupReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdGroupServiceError.Reason" => "AdGroupServiceErrorReason",
-      "AdGroup.Status" => "AdGroupStatus",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "CriterionTypeGroup" => "CriterionTypeGroup",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupServiceGet",
-      "getResponse" => "AdGroupServiceGetResponse",
-      "mutate" => "AdGroupServiceMutate",
-      "mutateResponse" => "AdGroupServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdGroupServiceError" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceError",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201309\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201309\\BiddingErrors",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ExplorerAutoOptimizerSetting" => "Google_Api_Ads_AdWords_v201309\\ExplorerAutoOptimizerSetting",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201309\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SettingError" => "Google_Api_Ads_AdWords_v201309\\SettingError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "TargetingSettingDetail" => "Google_Api_Ads_AdWords_v201309\\TargetingSettingDetail",
+      "TargetingSetting" => "Google_Api_Ads_AdWords_v201309\\TargetingSetting",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201309\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201309\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201309\\CpmBid",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme",
+      "Setting" => "Google_Api_Ads_AdWords_v201309\\Setting",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Bid" => "Google_Api_Ads_AdWords_v201309\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201309\\BidMultiplier",
+      "Bids" => "Google_Api_Ads_AdWords_v201309\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme",
+      "ManualCPCAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupExperimentBidMultipliers",
+      "ManualCPMAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\ManualCPMAdGroupExperimentBidMultipliers",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\AdGroupExperimentBidMultipliers",
+      "AdGroupExperimentData" => "Google_Api_Ads_AdWords_v201309\\AdGroupExperimentData",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration",
+      "AdGroup" => "Google_Api_Ads_AdWords_v201309\\AdGroup",
+      "AdGroupOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupOperation",
+      "AdGroupPage" => "Google_Api_Ads_AdWords_v201309\\AdGroupPage",
+      "AdGroupReturnValue" => "Google_Api_Ads_AdWords_v201309\\AdGroupReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AdGroupServiceError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceErrorReason",
+      "AdGroup.Status" => "Google_Api_Ads_AdWords_v201309\\AdGroupStatus",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201309\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode",
+      "CriterionTypeGroup" => "Google_Api_Ads_AdWords_v201309\\CriterionTypeGroup",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201309\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201309\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201309\\QueryResponse",
     );
 
 
@@ -6612,10 +6612,10 @@ if (!class_exists("AdGroupService", false)) {
      * 
      * 
      * 
-     * Adds, updates, or deletes ad groups.
+     * Adds, updates, or removes ad groups.
      * <p class="note"><b>Note:</b> {@link AdGroupOperation} does not support the
-     * {@code REMOVE} operator. To delete an ad group, set its
-     * {@link AdGroup#status status} to {@code DELETED}.</p>
+     * {@code REMOVE} operator. To remove an ad group, set its
+     * {@link AdGroup#status status} to {@code REMOVED}.</p>
      * 
      * @param operations List of unique operations. The same ad group cannot be
      * specified in more than one operation.
@@ -6644,3 +6644,4 @@ if (!class_exists("AdGroupService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdParamService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdParamService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdParam", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParam", false)) {
   /**
    * Represents an ad parameter.  Use ad parameters to update numeric values
    * (such as prices or inventory levels) in any line of a text ad, including
@@ -103,7 +103,7 @@ if (!class_exists("AdParam", false)) {
   }
 }
 
-if (!class_exists("AdParamPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamPage", false)) {
   /**
    * Represents a page of AdParams returned by the {@link AdParamService}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -150,7 +150,7 @@ if (!class_exists("AdParamPage", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -198,7 +198,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -278,7 +278,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -325,7 +325,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -374,7 +374,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -421,7 +421,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -469,7 +469,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -523,7 +523,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -598,7 +598,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -666,7 +666,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -763,7 +763,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -842,7 +842,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -910,7 +910,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdParamErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamErrorReason", false)) {
   /**
    * The same ad param cannot be specified in multiple operations
    * @package Google_Api_Ads_AdWords_v201309
@@ -943,7 +943,7 @@ if (!class_exists("AdParamErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -976,7 +976,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1009,7 +1009,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1042,7 +1042,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1076,7 +1076,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1109,7 +1109,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1142,7 +1142,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1175,7 +1175,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1208,7 +1208,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1241,7 +1241,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1274,7 +1274,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1307,7 +1307,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1340,7 +1340,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1373,7 +1373,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1406,7 +1406,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1439,7 +1439,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1473,7 +1473,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1506,7 +1506,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1539,7 +1539,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1572,7 +1572,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1605,7 +1605,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1638,7 +1638,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1671,7 +1671,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1704,7 +1704,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1737,7 +1737,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1770,7 +1770,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1818,7 +1818,7 @@ if (!class_exists("AdParamServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1858,7 +1858,7 @@ if (!class_exists("AdParamServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -1921,7 +1921,7 @@ if (!class_exists("AdParamServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1961,7 +1961,7 @@ if (!class_exists("AdParamServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdParamError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamError", false)) {
   /**
    * Errors for AdParamService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2006,7 +2006,7 @@ if (!class_exists("AdParamError", false)) {
   }
 }
 
-if (!class_exists("AdParamOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamOperation", false)) {
   /**
    * Represents an operation on an {@link AdParam}. The supported operators
    * are {@code SET} and {@code REMOVE}.
@@ -2050,7 +2050,7 @@ if (!class_exists("AdParamOperation", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2095,7 +2095,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2140,7 +2140,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2185,7 +2185,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2230,7 +2230,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2275,7 +2275,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2320,7 +2320,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2367,7 +2367,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2412,7 +2412,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2457,7 +2457,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2502,7 +2502,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2547,7 +2547,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2592,7 +2592,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2637,7 +2637,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2682,7 +2682,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2748,7 +2748,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2793,7 +2793,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2839,7 +2839,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2884,7 +2884,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2929,7 +2929,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2974,7 +2974,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3020,7 +3020,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3065,7 +3065,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -3156,7 +3156,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3199,7 +3199,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AdParamPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdParamPolicyError", false)) {
   /**
    * Policy violation for an AdParam.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3245,7 +3245,7 @@ if (!class_exists("AdParamService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdParamService extends AdWordsSoapClient {
+  class AdParamService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdParamService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3262,77 +3262,77 @@ if (!class_exists("AdParamService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdParam" => "AdParam",
-      "AdParamError" => "AdParamError",
-      "AdParamOperation" => "AdParamOperation",
-      "AdParamPage" => "AdParamPage",
-      "AdParamPolicyError" => "AdParamPolicyError",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "PolicyViolationError" => "PolicyViolationError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AdParamError.Reason" => "AdParamErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdParamServiceGet",
-      "getResponse" => "AdParamServiceGetResponse",
-      "mutate" => "AdParamServiceMutate",
-      "mutateResponse" => "AdParamServiceMutateResponse",
+      "AdParam" => "Google_Api_Ads_AdWords_v201309\\AdParam",
+      "AdParamError" => "Google_Api_Ads_AdWords_v201309\\AdParamError",
+      "AdParamOperation" => "Google_Api_Ads_AdWords_v201309\\AdParamOperation",
+      "AdParamPage" => "Google_Api_Ads_AdWords_v201309\\AdParamPage",
+      "AdParamPolicyError" => "Google_Api_Ads_AdWords_v201309\\AdParamPolicyError",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AdParamError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdParamErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdParamServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdParamServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdParamServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdParamServiceMutateResponse",
     );
 
 
@@ -3395,3 +3395,4 @@ if (!class_exists("AdParamService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AdwordsUserListService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AdwordsUserListService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -82,7 +82,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -133,7 +133,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -186,7 +186,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -244,7 +244,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -323,7 +323,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -395,7 +395,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -496,7 +496,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -579,7 +579,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -651,7 +651,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * 
@@ -727,7 +727,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -811,7 +811,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -894,7 +894,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -931,7 +931,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -968,7 +968,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -1005,7 +1005,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1042,7 +1042,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1079,7 +1079,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1117,7 +1117,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1154,7 +1154,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1191,7 +1191,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -1228,7 +1228,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1265,7 +1265,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -1302,7 +1302,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1339,7 +1339,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1376,7 +1376,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1413,7 +1413,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1451,7 +1451,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1488,7 +1488,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1525,7 +1525,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1562,7 +1562,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1599,7 +1599,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1636,7 +1636,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1673,7 +1673,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1710,7 +1710,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1747,7 +1747,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1784,7 +1784,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1830,7 +1830,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("UserListConversionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListConversionType", false)) {
   /**
    * Represents a conversion type used for building remarketing user lists.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1884,7 +1884,7 @@ if (!class_exists("UserListConversionType", false)) {
   }
 }
 
-if (!class_exists("LogicalUserListOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LogicalUserListOperand", false)) {
   /**
    * An interface for a logical user list operand. A logical user list is a
    * combination of logical rules. Each rule is defined as a logical operator and
@@ -1926,7 +1926,7 @@ if (!class_exists("LogicalUserListOperand", false)) {
   }
 }
 
-if (!class_exists("UserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserList", false)) {
   /**
    * Represents a UserList object that is sent over the wire.
    * This is a list of users an account may target.
@@ -2090,7 +2090,7 @@ if (!class_exists("UserList", false)) {
   }
 }
 
-if (!class_exists("UserListError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListError", false)) {
   /**
    * Represents possible error codes in UserListService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2135,7 +2135,7 @@ if (!class_exists("UserListError", false)) {
   }
 }
 
-if (!class_exists("UserListLogicalRule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListLogicalRule", false)) {
   /**
    * A user list logical rule. A rule has a logical operator (and/or/not) and a
    * list of operands that can be user lists or user interests.
@@ -2183,7 +2183,7 @@ if (!class_exists("UserListLogicalRule", false)) {
   }
 }
 
-if (!class_exists("UserListOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListOperation", false)) {
   /**
    * UserList operations for adding/updating UserList entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2226,7 +2226,7 @@ if (!class_exists("UserListOperation", false)) {
   }
 }
 
-if (!class_exists("UserListPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListPage", false)) {
   /**
    * Contains a list of user lists resulting from the filtering and paging of the
    * {@link UserListService#get} call.
@@ -2270,7 +2270,7 @@ if (!class_exists("UserListPage", false)) {
   }
 }
 
-if (!class_exists("UserListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListReturnValue", false)) {
   /**
    * A container for return values from the UserListService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2312,7 +2312,7 @@ if (!class_exists("UserListReturnValue", false)) {
   }
 }
 
-if (!class_exists("AccessReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AccessReason", false)) {
   /**
    * This indicates the way the entity such as UserList is related to a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2345,7 +2345,7 @@ if (!class_exists("AccessReason", false)) {
   }
 }
 
-if (!class_exists("AccountUserListStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AccountUserListStatus", false)) {
   /**
    * Status in the AccountUserListStatus table. This indicates if the user list share or
    * the licensing of the userlist is still active.
@@ -2379,7 +2379,7 @@ if (!class_exists("AccountUserListStatus", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2412,7 +2412,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("UserListConversionTypeCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListConversionTypeCategory", false)) {
   /**
    * User can create only BOOMERANG_EVENT conversion types. For all other types
    * UserListService service will return OTHER.
@@ -2446,7 +2446,7 @@ if (!class_exists("UserListConversionTypeCategory", false)) {
   }
 }
 
-if (!class_exists("SizeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeRange", false)) {
   /**
    * Size range in terms of number of users of a UserList/UserInterest.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2479,7 +2479,7 @@ if (!class_exists("SizeRange", false)) {
   }
 }
 
-if (!class_exists("UserListErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListErrorReason", false)) {
   /**
    * Creating and updating external remarketing user lists is not supported.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2512,7 +2512,7 @@ if (!class_exists("UserListErrorReason", false)) {
   }
 }
 
-if (!class_exists("UserListLogicalRuleOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListLogicalRuleOperator", false)) {
   /**
    * And - all of the operands.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2545,7 +2545,7 @@ if (!class_exists("UserListLogicalRuleOperator", false)) {
   }
 }
 
-if (!class_exists("UserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserListMembershipStatus", false)) {
   /**
    * Membership status of the user list. This status indicates whether a user list
    * can accumulate more users and may be targeted to.
@@ -2579,7 +2579,7 @@ if (!class_exists("UserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2627,7 +2627,7 @@ if (!class_exists("AdwordsUserListServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2667,7 +2667,7 @@ if (!class_exists("AdwordsUserListServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceMutate", false)) {
   /**
    * <span class="constraint CollectionSize">The minimum size of this collection is 1. The maximum size of this collection is 10000.</span>
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
@@ -2720,7 +2720,7 @@ if (!class_exists("AdwordsUserListServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2760,7 +2760,7 @@ if (!class_exists("AdwordsUserListServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2809,7 +2809,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2858,7 +2858,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -2907,7 +2907,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -2956,7 +2956,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -3006,7 +3006,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3057,7 +3057,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -3106,7 +3106,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -3155,7 +3155,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -3204,7 +3204,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -3253,7 +3253,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -3302,7 +3302,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3351,7 +3351,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3400,7 +3400,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3470,7 +3470,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3519,7 +3519,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3568,7 +3568,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3617,7 +3617,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3666,7 +3666,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3715,7 +3715,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3765,7 +3765,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3814,7 +3814,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3861,7 +3861,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ExternalRemarketingUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExternalRemarketingUserList", false)) {
   /**
    * User lists created in the DoubleClick platform that are mapped
    * from DoubleClick to AdWords.
@@ -3910,7 +3910,7 @@ if (!class_exists("ExternalRemarketingUserList", false)) {
   }
 }
 
-if (!class_exists("LogicalUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LogicalUserList", false)) {
   /**
    * Represents a user list that is a custom combination of user lists and user
    * interests.
@@ -3966,7 +3966,7 @@ if (!class_exists("LogicalUserList", false)) {
   }
 }
 
-if (!class_exists("BasicUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BasicUserList", false)) {
   /**
    * User list targeting as a collection of conversion types.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4027,7 +4027,7 @@ if (!class_exists("AdwordsUserListService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AdwordsUserListService extends AdWordsSoapClient {
+  class AdwordsUserListService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdwordsUserListService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/rm/v201309";
@@ -4044,88 +4044,88 @@ if (!class_exists("AdwordsUserListService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ExternalRemarketingUserList" => "ExternalRemarketingUserList",
-      "CollectionSizeError" => "CollectionSizeError",
-      "UserListConversionType" => "UserListConversionType",
-      "LogicalUserList" => "LogicalUserList",
-      "LogicalUserListOperand" => "LogicalUserListOperand",
-      "BasicUserList" => "BasicUserList",
-      "UserList" => "UserList",
-      "UserListError" => "UserListError",
-      "UserListLogicalRule" => "UserListLogicalRule",
-      "UserListOperation" => "UserListOperation",
-      "UserListPage" => "UserListPage",
-      "UserListReturnValue" => "UserListReturnValue",
-      "AccessReason" => "AccessReason",
-      "AccountUserListStatus" => "AccountUserListStatus",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "UserListConversionType.Category" => "UserListConversionTypeCategory",
-      "SizeRange" => "SizeRange",
-      "UserListError.Reason" => "UserListErrorReason",
-      "UserListLogicalRule.Operator" => "UserListLogicalRuleOperator",
-      "UserListMembershipStatus" => "UserListMembershipStatus",
-      "get" => "AdwordsUserListServiceGet",
-      "getResponse" => "AdwordsUserListServiceGetResponse",
-      "mutate" => "AdwordsUserListServiceMutate",
-      "mutateResponse" => "AdwordsUserListServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "ExternalRemarketingUserList" => "Google_Api_Ads_AdWords_v201309\\ExternalRemarketingUserList",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "UserListConversionType" => "Google_Api_Ads_AdWords_v201309\\UserListConversionType",
+      "LogicalUserList" => "Google_Api_Ads_AdWords_v201309\\LogicalUserList",
+      "LogicalUserListOperand" => "Google_Api_Ads_AdWords_v201309\\LogicalUserListOperand",
+      "BasicUserList" => "Google_Api_Ads_AdWords_v201309\\BasicUserList",
+      "UserList" => "Google_Api_Ads_AdWords_v201309\\UserList",
+      "UserListError" => "Google_Api_Ads_AdWords_v201309\\UserListError",
+      "UserListLogicalRule" => "Google_Api_Ads_AdWords_v201309\\UserListLogicalRule",
+      "UserListOperation" => "Google_Api_Ads_AdWords_v201309\\UserListOperation",
+      "UserListPage" => "Google_Api_Ads_AdWords_v201309\\UserListPage",
+      "UserListReturnValue" => "Google_Api_Ads_AdWords_v201309\\UserListReturnValue",
+      "AccessReason" => "Google_Api_Ads_AdWords_v201309\\AccessReason",
+      "AccountUserListStatus" => "Google_Api_Ads_AdWords_v201309\\AccountUserListStatus",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "UserListConversionType.Category" => "Google_Api_Ads_AdWords_v201309\\UserListConversionTypeCategory",
+      "SizeRange" => "Google_Api_Ads_AdWords_v201309\\SizeRange",
+      "UserListError.Reason" => "Google_Api_Ads_AdWords_v201309\\UserListErrorReason",
+      "UserListLogicalRule.Operator" => "Google_Api_Ads_AdWords_v201309\\UserListLogicalRuleOperator",
+      "UserListMembershipStatus" => "Google_Api_Ads_AdWords_v201309\\UserListMembershipStatus",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\AdwordsUserListServiceMutateResponse",
     );
 
 
@@ -4178,3 +4178,4 @@ if (!class_exists("AdwordsUserListService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/AlertService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/AlertService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -83,7 +83,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -162,7 +162,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -234,7 +234,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -335,7 +335,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -418,7 +418,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -501,7 +501,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -538,7 +538,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -575,7 +575,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -613,7 +613,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -650,7 +650,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -687,7 +687,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -724,7 +724,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -761,7 +761,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -798,7 +798,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -835,7 +835,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -873,7 +873,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -910,7 +910,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -947,7 +947,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -984,7 +984,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1021,7 +1021,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1058,7 +1058,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1095,7 +1095,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1132,7 +1132,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AlertError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertError", false)) {
   /**
    * Errors that can occur when using {@link AlertService}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1177,7 +1177,7 @@ if (!class_exists("AlertError", false)) {
   }
 }
 
-if (!class_exists("AlertQuery", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertQuery", false)) {
   /**
    * Querying criteria for getting alerts.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1259,7 +1259,7 @@ if (!class_exists("AlertQuery", false)) {
   }
 }
 
-if (!class_exists("Detail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Detail", false)) {
   /**
    * Detail refers to a single event or condition that triggered its owning {@link Alert}.
    * Multiple details can cause the same {@code Alert} to occur.
@@ -1300,7 +1300,7 @@ if (!class_exists("Detail", false)) {
   }
 }
 
-if (!class_exists("Alert", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Alert", false)) {
   /**
    * Alert for a single client. Triggering events are grouped by {@link AlertType} into the same alert
    * with multiple {@link Details}.
@@ -1362,7 +1362,7 @@ if (!class_exists("Alert", false)) {
   }
 }
 
-if (!class_exists("AlertSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertSelector", false)) {
   /**
    * Selector for querying for alerts.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1409,7 +1409,7 @@ if (!class_exists("AlertSelector", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1445,7 +1445,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("AlertErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertErrorReason", false)) {
   /**
    * The possible reasons for an {@link AlertError} to occur.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1478,7 +1478,7 @@ if (!class_exists("AlertErrorReason", false)) {
   }
 }
 
-if (!class_exists("AlertSeverity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertSeverity", false)) {
   /**
    * Severity of an alert, represented as a "color".
    * @package Google_Api_Ads_AdWords_v201309
@@ -1511,7 +1511,7 @@ if (!class_exists("AlertSeverity", false)) {
   }
 }
 
-if (!class_exists("AlertType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertType", false)) {
   /**
    * Type of an alert.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1544,7 +1544,7 @@ if (!class_exists("AlertType", false)) {
   }
 }
 
-if (!class_exists("ClientSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientSpec", false)) {
   /**
    * Specification of which managed accounts a client manager is interested in.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1577,7 +1577,7 @@ if (!class_exists("ClientSpec", false)) {
   }
 }
 
-if (!class_exists("FilterSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FilterSpec", false)) {
   /**
    * Describes how a result set of alerts should be filtered based on the triggering account's
    * ability to manage clients.
@@ -1611,7 +1611,7 @@ if (!class_exists("FilterSpec", false)) {
   }
 }
 
-if (!class_exists("TriggerTimeSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TriggerTimeSpec", false)) {
   /**
    * Specification of what trigger time alerts should match.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1644,7 +1644,7 @@ if (!class_exists("TriggerTimeSpec", false)) {
   }
 }
 
-if (!class_exists("AlertServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1692,7 +1692,7 @@ if (!class_exists("AlertServiceGet", false)) {
   }
 }
 
-if (!class_exists("AlertServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1732,7 +1732,7 @@ if (!class_exists("AlertServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -1781,7 +1781,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -1830,7 +1830,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -1879,7 +1879,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -1928,7 +1928,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -1977,7 +1977,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -2026,7 +2026,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2077,7 +2077,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -2126,7 +2126,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2175,7 +2175,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2224,7 +2224,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2294,7 +2294,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2343,7 +2343,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2393,7 +2393,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2442,7 +2442,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2491,7 +2491,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2541,7 +2541,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -2590,7 +2590,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -2637,7 +2637,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AlertPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AlertPage", false)) {
   /**
    * Contains a subset of {@link Alert}s resulting from the filtering and paging,
    * returned by {@link AlertService#get(AlertSelector)}.
@@ -2685,7 +2685,7 @@ if (!class_exists("AlertService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class AlertService extends AdWordsSoapClient {
+  class AlertService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AlertService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201309";
@@ -2702,62 +2702,62 @@ if (!class_exists("AlertService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "Paging" => "Paging",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "AlertError" => "AlertError",
-      "AlertQuery" => "AlertQuery",
-      "Detail" => "Detail",
-      "Alert" => "Alert",
-      "AlertPage" => "AlertPage",
-      "AlertSelector" => "AlertSelector",
-      "NoStatsPage" => "NoStatsPage",
-      "AlertError.Reason" => "AlertErrorReason",
-      "AlertSeverity" => "AlertSeverity",
-      "AlertType" => "AlertType",
-      "ClientSpec" => "ClientSpec",
-      "FilterSpec" => "FilterSpec",
-      "TriggerTimeSpec" => "TriggerTimeSpec",
-      "get" => "AlertServiceGet",
-      "getResponse" => "AlertServiceGetResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "AlertError" => "Google_Api_Ads_AdWords_v201309\\AlertError",
+      "AlertQuery" => "Google_Api_Ads_AdWords_v201309\\AlertQuery",
+      "Detail" => "Google_Api_Ads_AdWords_v201309\\Detail",
+      "Alert" => "Google_Api_Ads_AdWords_v201309\\Alert",
+      "AlertPage" => "Google_Api_Ads_AdWords_v201309\\AlertPage",
+      "AlertSelector" => "Google_Api_Ads_AdWords_v201309\\AlertSelector",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "AlertError.Reason" => "Google_Api_Ads_AdWords_v201309\\AlertErrorReason",
+      "AlertSeverity" => "Google_Api_Ads_AdWords_v201309\\AlertSeverity",
+      "AlertType" => "Google_Api_Ads_AdWords_v201309\\AlertType",
+      "ClientSpec" => "Google_Api_Ads_AdWords_v201309\\ClientSpec",
+      "FilterSpec" => "Google_Api_Ads_AdWords_v201309\\FilterSpec",
+      "TriggerTimeSpec" => "Google_Api_Ads_AdWords_v201309\\TriggerTimeSpec",
+      "get" => "Google_Api_Ads_AdWords_v201309\\AlertServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\AlertServiceGetResponse",
     );
 
 
@@ -2789,3 +2789,4 @@ if (!class_exists("AlertService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/BiddingStrategyService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/BiddingStrategyService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -443,7 +443,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -540,7 +540,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -619,7 +619,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -687,7 +687,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -760,7 +760,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("SharedBiddingStrategy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedBiddingStrategy", false)) {
   /**
    * Bidding strategies store shared bidding configuration data and are account-level objects.
    * @package Google_Api_Ads_AdWords_v201309
@@ -828,7 +828,7 @@ if (!class_exists("SharedBiddingStrategy", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -900,7 +900,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -980,7 +980,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1059,7 +1059,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1092,7 +1092,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1125,7 +1125,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1158,7 +1158,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1191,7 +1191,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1224,7 +1224,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("SharedBiddingStrategyBiddingStrategyStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedBiddingStrategyBiddingStrategyStatus", false)) {
   /**
    * Status of the bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1257,7 +1257,7 @@ if (!class_exists("SharedBiddingStrategyBiddingStrategyStatus", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyErrorReason", false)) {
   /**
    * Each bidding strategy must have a unique name.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1290,7 +1290,7 @@ if (!class_exists("BiddingStrategyErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1323,7 +1323,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1357,7 +1357,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1390,7 +1390,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1423,7 +1423,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1456,7 +1456,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1489,7 +1489,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1522,7 +1522,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1555,7 +1555,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1589,7 +1589,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1622,7 +1622,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1655,7 +1655,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1688,7 +1688,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1721,7 +1721,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1754,7 +1754,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1787,7 +1787,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1820,9 +1820,9 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -1853,7 +1853,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1886,7 +1886,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1920,7 +1920,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1953,7 +1953,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1986,7 +1986,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2019,7 +2019,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2052,7 +2052,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2085,7 +2085,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2118,7 +2118,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2151,7 +2151,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2184,7 +2184,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2217,7 +2217,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2250,7 +2250,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2298,7 +2298,7 @@ if (!class_exists("BiddingStrategyServiceGet", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2338,7 +2338,7 @@ if (!class_exists("BiddingStrategyServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2388,7 +2388,7 @@ if (!class_exists("BiddingStrategyServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2428,7 +2428,7 @@ if (!class_exists("BiddingStrategyServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2473,7 +2473,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2518,7 +2518,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2563,7 +2563,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2608,7 +2608,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2653,7 +2653,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyError", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2698,7 +2698,7 @@ if (!class_exists("BiddingStrategyError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2743,7 +2743,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -2806,7 +2806,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2851,7 +2851,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2896,7 +2896,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -2935,7 +2935,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -3009,7 +3009,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -3055,7 +3055,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3100,7 +3100,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3147,7 +3147,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -3190,7 +3190,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3226,7 +3226,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3268,7 +3268,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3313,7 +3313,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3358,7 +3358,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3403,7 +3403,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3448,7 +3448,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3483,7 +3483,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -3524,7 +3524,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3569,7 +3569,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3614,7 +3614,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3680,7 +3680,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3725,7 +3725,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3770,7 +3770,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3816,7 +3816,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3861,7 +3861,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3906,7 +3906,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3951,7 +3951,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3997,7 +3997,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4042,7 +4042,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -4121,7 +4121,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -4174,7 +4174,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -4226,7 +4226,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4269,7 +4269,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -4320,7 +4320,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyOperation", false)) {
   /**
    * Operations for adding/updating bidding strategies.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4363,7 +4363,7 @@ if (!class_exists("BiddingStrategyOperation", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyPage", false)) {
   /**
    * Contains a list of bidding strategies resulting from the filtering and paging
    * of {@link BiddingStrategy#get} call.
@@ -4407,7 +4407,7 @@ if (!class_exists("BiddingStrategyPage", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyReturnValue", false)) {
   /**
    * A container for return values from the {@link BiddingStrategyService#mutate} call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4449,7 +4449,7 @@ if (!class_exists("BiddingStrategyReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4490,7 +4490,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4537,7 +4537,7 @@ if (!class_exists("BiddingStrategyService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class BiddingStrategyService extends AdWordsSoapClient {
+  class BiddingStrategyService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BiddingStrategyService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -4554,106 +4554,106 @@ if (!class_exists("BiddingStrategyService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingStrategyError" => "BiddingStrategyError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "Selector" => "Selector",
-      "BiddingScheme" => "BiddingScheme",
-      "SharedBiddingStrategy" => "SharedBiddingStrategy",
-      "BiddingStrategyOperation" => "BiddingStrategyOperation",
-      "BiddingStrategyPage" => "BiddingStrategyPage",
-      "BiddingStrategyReturnValue" => "BiddingStrategyReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "SharedBiddingStrategy.BiddingStrategyStatus" => "SharedBiddingStrategyBiddingStrategyStatus",
-      "BiddingStrategyError.Reason" => "BiddingStrategyErrorReason",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "BiddingStrategyServiceGet",
-      "getResponse" => "BiddingStrategyServiceGetResponse",
-      "mutate" => "BiddingStrategyServiceMutate",
-      "mutateResponse" => "BiddingStrategyServiceMutateResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201309\\BiddingErrors",
+      "BiddingStrategyError" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BiddingScheme",
+      "SharedBiddingStrategy" => "Google_Api_Ads_AdWords_v201309\\SharedBiddingStrategy",
+      "BiddingStrategyOperation" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyOperation",
+      "BiddingStrategyPage" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyPage",
+      "BiddingStrategyReturnValue" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason",
+      "SharedBiddingStrategy.BiddingStrategyStatus" => "Google_Api_Ads_AdWords_v201309\\SharedBiddingStrategyBiddingStrategyStatus",
+      "BiddingStrategyError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyErrorReason",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyServiceMutateResponse",
     );
 
 
@@ -4703,3 +4703,4 @@ if (!class_exists("BiddingStrategyService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/BudgetOrderService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/BudgetOrderService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -135,7 +135,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -222,7 +222,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -275,7 +275,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -381,7 +381,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -461,7 +461,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -514,7 +514,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -567,7 +567,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -623,7 +623,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -676,7 +676,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -730,7 +730,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -783,7 +783,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -838,7 +838,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * 
@@ -918,7 +918,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -968,7 +968,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * 
@@ -1021,7 +1021,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1074,7 +1074,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1127,7 +1127,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1180,7 +1180,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1223,7 +1223,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1311,7 +1311,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1364,7 +1364,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1417,7 +1417,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1472,7 +1472,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1559,7 +1559,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1616,7 +1616,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -1670,7 +1670,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -1732,7 +1732,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1785,7 +1785,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1838,7 +1838,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1912,7 +1912,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -1965,7 +1965,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2019,7 +2019,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2072,7 +2072,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2148,7 +2148,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2201,7 +2201,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2254,7 +2254,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2337,7 +2337,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2413,7 +2413,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * 
@@ -2466,7 +2466,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2520,7 +2520,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -2561,7 +2561,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2602,7 +2602,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2644,7 +2644,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2685,7 +2685,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2726,7 +2726,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -2767,7 +2767,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2809,7 +2809,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2850,7 +2850,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -2891,7 +2891,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * 
@@ -2932,7 +2932,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -2973,7 +2973,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -3014,7 +3014,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3055,7 +3055,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3096,7 +3096,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -3137,7 +3137,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3178,7 +3178,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * 
@@ -3219,7 +3219,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -3260,7 +3260,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3302,7 +3302,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3343,7 +3343,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3384,7 +3384,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3425,7 +3425,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3466,7 +3466,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3507,7 +3507,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3548,7 +3548,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -3589,7 +3589,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -3630,7 +3630,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * 
@@ -3671,7 +3671,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3712,7 +3712,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BillingAccount", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BillingAccount", false)) {
   /**
    * Represents an BillingAccount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3780,7 +3780,7 @@ if (!class_exists("BillingAccount", false)) {
   }
 }
 
-if (!class_exists("BudgetOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrder", false)) {
   /**
    * A {@link BudgetOrder} links an account wide budget with a {@link BillingAccount}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3890,7 +3890,7 @@ if (!class_exists("BudgetOrder", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderError", false)) {
   /**
    * Error information for BudgetOrderService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3935,7 +3935,7 @@ if (!class_exists("BudgetOrderError", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderOperation", false)) {
   /**
    * Operation for {@link BudgetOrder}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3978,7 +3978,7 @@ if (!class_exists("BudgetOrderOperation", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderPage", false)) {
   /**
    * A page of {@link BudgetOrder}s from {@link BudgetOrderService#get}
    * method.
@@ -4022,7 +4022,7 @@ if (!class_exists("BudgetOrderPage", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderRequest", false)) {
   /**
    * Holds fields that provide information on the last set of values that were passed in through
    * the parent BudgetOrder for mutate.add and mutate.set.
@@ -4113,7 +4113,7 @@ if (!class_exists("BudgetOrderRequest", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderReturnValue", false)) {
   /**
    * A container for return values from the {@link BudgetOrderService#mutate}
    * method.
@@ -4156,7 +4156,7 @@ if (!class_exists("BudgetOrderReturnValue", false)) {
   }
 }
 
-if (!class_exists("CustomerOrderLineError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerOrderLineError", false)) {
   /**
    * Error information returned for CustomerOrderLineService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4201,7 +4201,7 @@ if (!class_exists("CustomerOrderLineError", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderErrorReason", false)) {
   /**
    * Customer is not whitelisted for new billing.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4234,7 +4234,7 @@ if (!class_exists("BudgetOrderErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderRequestStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderRequestStatus", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -4267,7 +4267,7 @@ if (!class_exists("BudgetOrderRequestStatus", false)) {
   }
 }
 
-if (!class_exists("CustomerOrderLineErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerOrderLineErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during a CustomerOrderLine mutate
    * operation.
@@ -4301,7 +4301,7 @@ if (!class_exists("CustomerOrderLineErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4349,7 +4349,7 @@ if (!class_exists("BudgetOrderServiceGet", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4389,7 +4389,7 @@ if (!class_exists("BudgetOrderServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetBillingAccounts", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetBillingAccounts", false)) {
   /**
    * Returns all the open/active BillingAccounts associated with the current
    * manager.
@@ -4425,7 +4425,7 @@ if (!class_exists("GetBillingAccounts", false)) {
   }
 }
 
-if (!class_exists("GetBillingAccountsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetBillingAccountsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4465,7 +4465,7 @@ if (!class_exists("GetBillingAccountsResponse", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -4524,7 +4524,7 @@ if (!class_exists("BudgetOrderServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4564,7 +4564,7 @@ if (!class_exists("BudgetOrderServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4615,7 +4615,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -4664,7 +4664,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -4719,7 +4719,7 @@ if (!class_exists("BudgetOrderService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class BudgetOrderService extends AdWordsSoapClient {
+  class BudgetOrderService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BudgetOrderService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/billing/v201309";
@@ -4736,96 +4736,96 @@ if (!class_exists("BudgetOrderService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "BillingAccount" => "BillingAccount",
-      "BudgetOrder" => "BudgetOrder",
-      "BudgetOrderError" => "BudgetOrderError",
-      "BudgetOrderOperation" => "BudgetOrderOperation",
-      "BudgetOrderPage" => "BudgetOrderPage",
-      "BudgetOrderRequest" => "BudgetOrderRequest",
-      "BudgetOrderReturnValue" => "BudgetOrderReturnValue",
-      "CustomerOrderLineError" => "CustomerOrderLineError",
-      "BudgetOrderError.Reason" => "BudgetOrderErrorReason",
-      "BudgetOrderRequest.Status" => "BudgetOrderRequestStatus",
-      "CustomerOrderLineError.Reason" => "CustomerOrderLineErrorReason",
-      "get" => "BudgetOrderServiceGet",
-      "getResponse" => "BudgetOrderServiceGetResponse",
-      "getBillingAccounts" => "GetBillingAccounts",
-      "getBillingAccountsResponse" => "GetBillingAccountsResponse",
-      "mutate" => "BudgetOrderServiceMutate",
-      "mutateResponse" => "BudgetOrderServiceMutateResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "BillingAccount" => "Google_Api_Ads_AdWords_v201309\\BillingAccount",
+      "BudgetOrder" => "Google_Api_Ads_AdWords_v201309\\BudgetOrder",
+      "BudgetOrderError" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderError",
+      "BudgetOrderOperation" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderOperation",
+      "BudgetOrderPage" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderPage",
+      "BudgetOrderRequest" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderRequest",
+      "BudgetOrderReturnValue" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderReturnValue",
+      "CustomerOrderLineError" => "Google_Api_Ads_AdWords_v201309\\CustomerOrderLineError",
+      "BudgetOrderError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderErrorReason",
+      "BudgetOrderRequest.Status" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderRequestStatus",
+      "CustomerOrderLineError.Reason" => "Google_Api_Ads_AdWords_v201309\\CustomerOrderLineErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceGetResponse",
+      "getBillingAccounts" => "Google_Api_Ads_AdWords_v201309\\GetBillingAccounts",
+      "getBillingAccountsResponse" => "Google_Api_Ads_AdWords_v201309\\GetBillingAccountsResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\BudgetOrderServiceMutateResponse",
     );
 
 
@@ -4895,3 +4895,4 @@ if (!class_exists("BudgetOrderService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/BudgetService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/BudgetService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -443,7 +443,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -540,7 +540,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -619,7 +619,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -687,7 +687,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201309
@@ -776,7 +776,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -848,7 +848,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -928,7 +928,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1007,7 +1007,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1040,7 +1040,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1073,7 +1073,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1106,7 +1106,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1139,7 +1139,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1172,7 +1172,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1205,7 +1205,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1239,7 +1239,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1272,7 +1272,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1305,7 +1305,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1338,7 +1338,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1371,7 +1371,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1405,7 +1405,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1438,7 +1438,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1471,7 +1471,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1504,7 +1504,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1537,7 +1537,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1570,7 +1570,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1603,7 +1603,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1636,7 +1636,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1669,7 +1669,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1702,7 +1702,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1736,7 +1736,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1769,7 +1769,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1802,7 +1802,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1835,7 +1835,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1868,7 +1868,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1901,7 +1901,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1934,7 +1934,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1967,7 +1967,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2000,7 +2000,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2033,7 +2033,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2066,7 +2066,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2114,7 +2114,7 @@ if (!class_exists("BudgetServiceGet", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2154,7 +2154,7 @@ if (!class_exists("BudgetServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2205,7 +2205,7 @@ if (!class_exists("BudgetServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2245,7 +2245,7 @@ if (!class_exists("BudgetServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2290,7 +2290,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2335,7 +2335,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2380,7 +2380,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2425,7 +2425,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2470,7 +2470,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2515,7 +2515,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2589,7 +2589,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2635,7 +2635,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2680,7 +2680,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2727,7 +2727,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2769,7 +2769,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2814,7 +2814,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2859,7 +2859,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2904,7 +2904,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2949,7 +2949,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2984,7 +2984,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3029,7 +3029,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3074,7 +3074,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3119,7 +3119,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3185,7 +3185,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3230,7 +3230,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3275,7 +3275,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3321,7 +3321,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3366,7 +3366,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3411,7 +3411,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3456,7 +3456,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3502,7 +3502,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3547,7 +3547,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3590,7 +3590,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOperation", false)) {
   /**
    * Operations for adding/updating Budget entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3633,7 +3633,7 @@ if (!class_exists("BudgetOperation", false)) {
   }
 }
 
-if (!class_exists("BudgetPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetPage", false)) {
   /**
    * Contains a list of budgets resulting from the filtering and paging of
    * {@link BudgetService#get} call.
@@ -3677,7 +3677,7 @@ if (!class_exists("BudgetPage", false)) {
   }
 }
 
-if (!class_exists("BudgetReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetReturnValue", false)) {
   /**
    * A container for return values from the {@link BudgetService#mutate} call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3726,7 +3726,7 @@ if (!class_exists("BudgetReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3767,7 +3767,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3814,7 +3814,7 @@ if (!class_exists("BudgetService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class BudgetService extends AdWordsSoapClient {
+  class BudgetService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BudgetService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3831,90 +3831,90 @@ if (!class_exists("BudgetService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Budget" => "Budget",
-      "BudgetOperation" => "BudgetOperation",
-      "BudgetPage" => "BudgetPage",
-      "BudgetReturnValue" => "BudgetReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "BudgetServiceGet",
-      "getResponse" => "BudgetServiceGetResponse",
-      "mutate" => "BudgetServiceMutate",
-      "mutateResponse" => "BudgetServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201309\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Budget" => "Google_Api_Ads_AdWords_v201309\\Budget",
+      "BudgetOperation" => "Google_Api_Ads_AdWords_v201309\\BudgetOperation",
+      "BudgetPage" => "Google_Api_Ads_AdWords_v201309\\BudgetPage",
+      "BudgetReturnValue" => "Google_Api_Ads_AdWords_v201309\\BudgetReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\BudgetServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\BudgetServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\BudgetServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\BudgetServiceMutateResponse",
     );
 
 
@@ -3965,3 +3965,4 @@ if (!class_exists("BudgetService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CampaignAdExtensionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CampaignAdExtensionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201309
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -160,7 +160,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201309
@@ -207,7 +207,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("OAuthInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OAuthInfo", false)) {
   /**
    * Data used for authorization using OAuth.
    * For more information about OAuth, see:
@@ -263,7 +263,7 @@ if (!class_exists("OAuthInfo", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -310,7 +310,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -359,7 +359,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -413,7 +413,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Sitelink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Sitelink", false)) {
   /**
    * Class to represent a single sitelink
    * @package Google_Api_Ads_AdWords_v201309
@@ -460,7 +460,7 @@ if (!class_exists("Sitelink", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -535,7 +535,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -603,7 +603,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -700,7 +700,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -779,7 +779,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -847,7 +847,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtension", false)) {
   /**
    * Base class for AdExtension objects. An AdExtension is an extension to
    * an existing ad or metadata that will process into an extension.
@@ -927,7 +927,7 @@ if (!class_exists("AdExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtension", false)) {
   /**
    * Represents a campaign level ad extension. A campaign ad extension specifies
    * a campaign and an ad extension which can extend any ad under that campaign.
@@ -989,7 +989,7 @@ if (!class_exists("CampaignAdExtension", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1061,7 +1061,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1141,7 +1141,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1220,7 +1220,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionErrorReason", false)) {
   /**
    * Account has been deleted
    * @package Google_Api_Ads_AdWords_v201309
@@ -1253,7 +1253,7 @@ if (!class_exists("AdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1286,7 +1286,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1319,7 +1319,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1352,7 +1352,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1385,7 +1385,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionApprovalStatus", false)) {
   /**
    * Approval status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1418,7 +1418,7 @@ if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionStatus", false)) {
   /**
    * Status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1451,7 +1451,7 @@ if (!class_exists("CampaignAdExtensionStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionErrorReason", false)) {
   /**
    * Cannot operate on an adextensions under the wrong campaign
    * @package Google_Api_Ads_AdWords_v201309
@@ -1484,7 +1484,7 @@ if (!class_exists("CampaignAdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1518,7 +1518,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1551,7 +1551,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1584,7 +1584,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1617,7 +1617,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1651,7 +1651,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1684,7 +1684,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InAppLinkExtensionAppStore", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InAppLinkExtensionAppStore", false)) {
   /**
    * The AppStore this extension will render for.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1717,7 +1717,7 @@ if (!class_exists("InAppLinkExtensionAppStore", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1750,7 +1750,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("LocationExtensionSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationExtensionSource", false)) {
   /**
    * From manual entry in adwords frontend
    * @package Google_Api_Ads_AdWords_v201309
@@ -1783,7 +1783,7 @@ if (!class_exists("LocationExtensionSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1816,7 +1816,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1849,7 +1849,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1882,7 +1882,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1915,7 +1915,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1948,7 +1948,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1981,7 +1981,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2014,7 +2014,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2047,7 +2047,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2080,7 +2080,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2114,7 +2114,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2147,7 +2147,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2180,7 +2180,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2213,7 +2213,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2246,7 +2246,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2279,7 +2279,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2312,7 +2312,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2345,7 +2345,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2378,7 +2378,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2411,7 +2411,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2444,7 +2444,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2477,7 +2477,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2526,7 +2526,7 @@ if (!class_exists("CampaignAdExtensionServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2566,7 +2566,7 @@ if (!class_exists("CampaignAdExtensionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2616,7 +2616,7 @@ if (!class_exists("CampaignAdExtensionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2656,7 +2656,7 @@ if (!class_exists("CampaignAdExtensionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionError", false)) {
   /**
    * AdExtension errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2701,7 +2701,7 @@ if (!class_exists("AdExtensionError", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2746,7 +2746,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2791,7 +2791,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2836,7 +2836,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2881,7 +2881,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionError", false)) {
   /**
    * CampaignAdExtension errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2926,7 +2926,7 @@ if (!class_exists("CampaignAdExtensionError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2971,7 +2971,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3016,10 +3016,9 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("DomainInfoExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DomainInfoExtension", false)) {
   /**
    * Domain extension, which adds domain info to ads.
-   * <span class="constraint Beta">This is a beta feature.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -3067,7 +3066,7 @@ if (!class_exists("DomainInfoExtension", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -3141,7 +3140,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -3187,7 +3186,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3232,7 +3231,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InAppLinkExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InAppLinkExtension", false)) {
   /**
    * <p>This extension is useful for advertisers who wish to provide users with a
    * link that points to the advertiser's mobile application in addition to their
@@ -3244,7 +3243,6 @@ if (!class_exists("InAppLinkExtension", false)) {
    * Only the extension for a given {@code AppStore} will render on the device
    * relevant to that {@code AppStore} (e.g. iPhones for {@code AppStore.ITUNES}
    * and Android phones for {@code AppStore.GOOGLE_PLAY}).
-   * <span class="constraint Beta">This is a beta feature.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -3306,7 +3304,7 @@ if (!class_exists("InAppLinkExtension", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3353,7 +3351,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("MobileExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileExtension", false)) {
   /**
    * Represents a phone extension.
    * 
@@ -3428,7 +3426,7 @@ if (!class_exists("MobileExtension", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3473,7 +3471,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3518,7 +3516,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3563,7 +3561,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3608,7 +3606,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3653,7 +3651,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3698,7 +3696,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -3744,7 +3742,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3789,7 +3787,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3834,7 +3832,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3900,7 +3898,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3945,7 +3943,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3990,7 +3988,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4035,7 +4033,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -4081,7 +4079,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4126,7 +4124,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4171,7 +4169,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SitelinksExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SitelinksExtension", false)) {
   /**
    * Class to represent a set of sitelinks and their order of preference.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4214,7 +4212,7 @@ if (!class_exists("SitelinksExtension", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4259,7 +4257,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4305,7 +4303,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4350,7 +4348,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("LocationExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationExtension", false)) {
   /**
    * Location based ad extension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4442,7 +4440,7 @@ if (!class_exists("LocationExtension", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4485,7 +4483,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("LocationSyncExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationSyncExtension", false)) {
   /**
    * Local business center(LBC) sync extension that ties a LBC account with a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4556,7 +4554,7 @@ if (!class_exists("LocationSyncExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionOperation", false)) {
   /**
    * CampaignAdExtension service operation. <b>Note:</b> The {@code SET} operator
    * is not supported.
@@ -4600,7 +4598,7 @@ if (!class_exists("CampaignAdExtensionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionPage", false)) {
   /**
    * Represents a page of {@link CampaignAdExtension}s resulting from the query
    * done by {@link CampaignAdExtensionService}.
@@ -4644,7 +4642,7 @@ if (!class_exists("CampaignAdExtensionPage", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionReturnValue", false)) {
   /**
    * A container for return values from the CampaignAdExtensionService.mutate().
    * @package Google_Api_Ads_AdWords_v201309
@@ -4699,7 +4697,7 @@ if (!class_exists("CampaignAdExtensionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CampaignAdExtensionService extends AdWordsSoapClient {
+  class CampaignAdExtensionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignAdExtensionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -4716,107 +4714,107 @@ if (!class_exists("CampaignAdExtensionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdExtensionError" => "AdExtensionError",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "CampaignAdExtensionError" => "CampaignAdExtensionError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DomainInfoExtension" => "DomainInfoExtension",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InAppLinkExtension" => "InAppLinkExtension",
-      "InternalApiError" => "InternalApiError",
-      "MobileExtension" => "MobileExtension",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OAuthInfo" => "OAuthInfo",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "Sitelink" => "Sitelink",
-      "SitelinksExtension" => "SitelinksExtension",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "LocationExtension" => "LocationExtension",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "LocationSyncExtension" => "LocationSyncExtension",
-      "Selector" => "Selector",
-      "AdExtension" => "AdExtension",
-      "CampaignAdExtension" => "CampaignAdExtension",
-      "CampaignAdExtensionOperation" => "CampaignAdExtensionOperation",
-      "CampaignAdExtensionPage" => "CampaignAdExtensionPage",
-      "CampaignAdExtensionReturnValue" => "CampaignAdExtensionReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdExtensionError.Reason" => "AdExtensionErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "CampaignAdExtension.ApprovalStatus" => "CampaignAdExtensionApprovalStatus",
-      "CampaignAdExtension.Status" => "CampaignAdExtensionStatus",
-      "CampaignAdExtensionError.Reason" => "CampaignAdExtensionErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InAppLinkExtension.AppStore" => "InAppLinkExtensionAppStore",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "LocationExtension.Source" => "LocationExtensionSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CampaignAdExtensionServiceGet",
-      "getResponse" => "CampaignAdExtensionServiceGetResponse",
-      "mutate" => "CampaignAdExtensionServiceMutate",
-      "mutateResponse" => "CampaignAdExtensionServiceMutateResponse",
+      "AdExtensionError" => "Google_Api_Ads_AdWords_v201309\\AdExtensionError",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "CampaignAdExtensionError" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DomainInfoExtension" => "Google_Api_Ads_AdWords_v201309\\DomainInfoExtension",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InAppLinkExtension" => "Google_Api_Ads_AdWords_v201309\\InAppLinkExtension",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "MobileExtension" => "Google_Api_Ads_AdWords_v201309\\MobileExtension",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OAuthInfo" => "Google_Api_Ads_AdWords_v201309\\OAuthInfo",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "Sitelink" => "Google_Api_Ads_AdWords_v201309\\Sitelink",
+      "SitelinksExtension" => "Google_Api_Ads_AdWords_v201309\\SitelinksExtension",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "LocationExtension" => "Google_Api_Ads_AdWords_v201309\\LocationExtension",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "LocationSyncExtension" => "Google_Api_Ads_AdWords_v201309\\LocationSyncExtension",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AdExtension" => "Google_Api_Ads_AdWords_v201309\\AdExtension",
+      "CampaignAdExtension" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtension",
+      "CampaignAdExtensionOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionOperation",
+      "CampaignAdExtensionPage" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionPage",
+      "CampaignAdExtensionReturnValue" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdExtensionErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "CampaignAdExtension.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionApprovalStatus",
+      "CampaignAdExtension.Status" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionStatus",
+      "CampaignAdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InAppLinkExtension.AppStore" => "Google_Api_Ads_AdWords_v201309\\InAppLinkExtensionAppStore",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "LocationExtension.Source" => "Google_Api_Ads_AdWords_v201309\\LocationExtensionSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionServiceMutateResponse",
     );
 
 
@@ -4867,3 +4865,4 @@ if (!class_exists("CampaignAdExtensionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CampaignCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CampaignCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201309
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -209,7 +209,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -288,7 +288,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -333,7 +333,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -378,7 +378,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -423,7 +423,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterion", false)) {
   /**
    * Represents a campaign level criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -530,7 +530,7 @@ if (!class_exists("CampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionError", false)) {
   /**
    * Base error class for Campaign Criterion Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -575,7 +575,7 @@ if (!class_exists("CampaignCriterionError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -620,7 +620,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -707,7 +707,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -752,7 +752,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201309
@@ -824,7 +824,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -869,7 +869,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -917,7 +917,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -962,7 +962,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1036,7 +1036,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -1082,7 +1082,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Gender", false)) {
   /**
    * Represents a Gender criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
@@ -1128,7 +1128,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1175,7 +1175,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1220,7 +1220,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1267,7 +1267,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1319,7 +1319,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -1372,7 +1372,7 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1444,7 +1444,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
@@ -1511,7 +1511,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1565,7 +1565,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1617,7 +1617,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -1684,7 +1684,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("NegativeCampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeCampaignCriterion", false)) {
   /**
    * A negative campaign criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1724,7 +1724,7 @@ if (!class_exists("NegativeCampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1769,7 +1769,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1814,7 +1814,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1859,7 +1859,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1904,7 +1904,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -1971,7 +1971,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -2051,7 +2051,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2096,7 +2096,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2141,7 +2141,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2188,7 +2188,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2267,7 +2267,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -2316,7 +2316,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2362,7 +2362,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -2408,7 +2408,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Platform", false)) {
   /**
    * Represents Platform criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -2454,7 +2454,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2508,7 +2508,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2563,7 +2563,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2611,7 +2611,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2651,7 +2651,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -2723,7 +2723,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2775,7 +2775,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2820,7 +2820,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2865,7 +2865,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2931,7 +2931,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2976,7 +2976,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3021,7 +3021,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3067,7 +3067,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3112,7 +3112,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3180,7 +3180,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3225,7 +3225,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3270,7 +3270,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3345,7 +3345,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3413,7 +3413,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3459,7 +3459,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -3507,7 +3507,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3559,7 +3559,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3618,7 +3618,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -3681,7 +3681,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -3741,7 +3741,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -3793,7 +3793,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -3843,7 +3843,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3876,7 +3876,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3909,7 +3909,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3942,7 +3942,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3975,7 +3975,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4008,7 +4008,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4041,7 +4041,7 @@ if (!class_exists("CampaignCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4074,7 +4074,7 @@ if (!class_exists("CampaignCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -4108,7 +4108,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ContentLabelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ContentLabelType", false)) {
   /**
    * Content label type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4141,7 +4141,7 @@ if (!class_exists("ContentLabelType", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4174,7 +4174,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4207,7 +4207,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4240,7 +4240,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4273,7 +4273,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4306,7 +4306,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4339,7 +4339,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -4373,7 +4373,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4406,7 +4406,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4439,7 +4439,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4472,7 +4472,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -4506,7 +4506,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4539,7 +4539,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201309
@@ -4572,7 +4572,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4605,7 +4605,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4638,7 +4638,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4671,7 +4671,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4704,7 +4704,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4737,7 +4737,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4770,7 +4770,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4803,7 +4803,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4836,7 +4836,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4869,7 +4869,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4902,7 +4902,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4935,7 +4935,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4968,7 +4968,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5001,7 +5001,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -5035,7 +5035,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5068,7 +5068,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5101,7 +5101,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5134,7 +5134,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5167,7 +5167,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5200,7 +5200,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5233,7 +5233,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5266,7 +5266,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5299,7 +5299,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5332,7 +5332,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5365,7 +5365,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5398,7 +5398,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5431,7 +5431,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5479,7 +5479,7 @@ if (!class_exists("CampaignCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5519,7 +5519,7 @@ if (!class_exists("CampaignCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -5571,7 +5571,7 @@ if (!class_exists("CampaignCriterionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5611,7 +5611,7 @@ if (!class_exists("CampaignCriterionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5659,7 +5659,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5699,7 +5699,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdSchedule", false)) {
   /**
    * Represents an AdSchedule Criterion.
    * AdSchedule is specified as day and time of the week criteria to target
@@ -5776,7 +5776,7 @@ if (!class_exists("AdSchedule", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5821,7 +5821,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
@@ -5867,7 +5867,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5910,7 +5910,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceeded", false)) {
   /**
    * Error to indicate that too many negative criteria added to some campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5956,7 +5956,7 @@ if (!class_exists("CampaignCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionOperation", false)) {
   /**
    * Generic operation (add, remove and set) for campaign criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5999,7 +5999,7 @@ if (!class_exists("CampaignCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionPage", false)) {
   /**
    * Contains a subset of campaign criteria resulting from a call to
    * {@link CampaignCriterionService#get}.
@@ -6043,7 +6043,7 @@ if (!class_exists("CampaignCriterionPage", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionReturnValue", false)) {
   /**
    * A container for return values from the CampaignCriterionService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6092,7 +6092,7 @@ if (!class_exists("CampaignCriterionReturnValue", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -6145,7 +6145,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ContentLabel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ContentLabel", false)) {
   /**
    * Content Label for category exclusion.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -6196,7 +6196,7 @@ if (!class_exists("CampaignCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CampaignCriterionService extends AdWordsSoapClient {
+  class CampaignCriterionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -6213,139 +6213,139 @@ if (!class_exists("CampaignCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdSchedule" => "AdSchedule",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "CampaignCriterion" => "CampaignCriterion",
-      "CampaignCriterionError" => "CampaignCriterionError",
-      "CampaignCriterionLimitExceeded" => "CampaignCriterionLimitExceeded",
-      "CampaignCriterionOperation" => "CampaignCriterionOperation",
-      "CampaignCriterionPage" => "CampaignCriterionPage",
-      "CampaignCriterionReturnValue" => "CampaignCriterionReturnValue",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "ContentLabel" => "ContentLabel",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "Gender" => "Gender",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "ListReturnValue" => "ListReturnValue",
-      "Location" => "Location",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "NegativeCampaignCriterion" => "NegativeCampaignCriterion",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Placement" => "Placement",
-      "Platform" => "Platform",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "Proximity" => "Proximity",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "CampaignCriterionError.Reason" => "CampaignCriterionErrorReason",
-      "CampaignCriterionLimitExceeded.CriteriaLimitType" => "CampaignCriterionLimitExceededCriteriaLimitType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ContentLabelType" => "ContentLabelType",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "MinuteOfHour" => "MinuteOfHour",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "CampaignCriterionServiceGet",
-      "getResponse" => "CampaignCriterionServiceGetResponse",
-      "mutate" => "CampaignCriterionServiceMutate",
-      "mutateResponse" => "CampaignCriterionServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdSchedule" => "Google_Api_Ads_AdWords_v201309\\AdSchedule",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201309\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "CampaignCriterion" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterion",
+      "CampaignCriterionError" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionError",
+      "CampaignCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceeded",
+      "CampaignCriterionOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionOperation",
+      "CampaignCriterionPage" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionPage",
+      "CampaignCriterionReturnValue" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionReturnValue",
+      "Carrier" => "Google_Api_Ads_AdWords_v201309\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ContentLabel" => "Google_Api_Ads_AdWords_v201309\\ContentLabel",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "Gender" => "Google_Api_Ads_AdWords_v201309\\Gender",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201309\\MobileDevice",
+      "NegativeCampaignCriterion" => "Google_Api_Ads_AdWords_v201309\\NegativeCampaignCriterion",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Platform" => "Google_Api_Ads_AdWords_v201309\\Platform",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "Proximity" => "Google_Api_Ads_AdWords_v201309\\Proximity",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "CampaignCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionErrorReason",
+      "CampaignCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceededCriteriaLimitType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ContentLabelType" => "Google_Api_Ads_AdWords_v201309\\ContentLabelType",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201309\\DayOfWeek",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201309\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201309\\MinuteOfHour",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201309\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201309\\QueryResponse",
     );
 
 
@@ -6413,3 +6413,4 @@ if (!class_exists("CampaignCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CampaignFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CampaignFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -127,7 +127,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -206,7 +206,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -251,7 +251,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -296,7 +296,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("CampaignFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeed", false)) {
   /**
    * CampaignFeeds are used to link a feed to a campaign using a matching function,
    * making the feed's feed items available in the campaign's ads for substitution.
@@ -365,7 +365,7 @@ if (!class_exists("CampaignFeed", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedError", false)) {
   /**
    * Represents an error for the CampaignFeedService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -410,7 +410,7 @@ if (!class_exists("CampaignFeedError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -455,7 +455,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -501,7 +501,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -546,7 +546,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -594,7 +594,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -639,7 +639,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -713,7 +713,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -759,7 +759,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -843,7 +843,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -888,7 +888,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -933,7 +933,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -980,7 +980,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1052,7 +1052,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1097,7 +1097,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1142,7 +1142,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1187,7 +1187,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1259,7 +1259,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1339,7 +1339,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1384,7 +1384,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1431,7 +1431,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1510,7 +1510,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1559,7 +1559,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1613,7 +1613,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1658,7 +1658,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1703,7 +1703,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1769,7 +1769,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1814,7 +1814,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestContextOperand", false)) {
   /**
    * An operand in a function referring to a value in the request context.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1856,7 +1856,7 @@ if (!class_exists("RequestContextOperand", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1902,7 +1902,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1947,7 +1947,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2015,7 +2015,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2060,7 +2060,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2105,7 +2105,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2180,7 +2180,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2248,7 +2248,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2294,7 +2294,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2327,7 +2327,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2360,7 +2360,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedStatus", false)) {
   /**
    * Status of the CampaignFeed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2393,7 +2393,7 @@ if (!class_exists("CampaignFeedStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2426,7 +2426,7 @@ if (!class_exists("CampaignFeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2460,7 +2460,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2493,7 +2493,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantOperandConstantType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConstantOperandConstantType", false)) {
   /**
    * The types of constant operands.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2526,7 +2526,7 @@ if (!class_exists("ConstantOperandConstantType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2559,7 +2559,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2592,7 +2592,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2625,7 +2625,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2659,7 +2659,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2692,7 +2692,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2725,7 +2725,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2758,7 +2758,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2791,7 +2791,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2824,7 +2824,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2857,7 +2857,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2890,7 +2890,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2923,7 +2923,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2956,7 +2956,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2989,7 +2989,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3023,7 +3023,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3056,7 +3056,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3089,7 +3089,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3122,7 +3122,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperandContextType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestContextOperandContextType", false)) {
   /**
    * Campaign Id in the request context.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3155,7 +3155,7 @@ if (!class_exists("RequestContextOperandContextType", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3188,7 +3188,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3221,7 +3221,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3254,7 +3254,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3287,7 +3287,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3320,7 +3320,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3353,7 +3353,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3402,7 +3402,7 @@ if (!class_exists("CampaignFeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3442,7 +3442,7 @@ if (!class_exists("CampaignFeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -3493,7 +3493,7 @@ if (!class_exists("CampaignFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3533,7 +3533,7 @@ if (!class_exists("CampaignFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3576,7 +3576,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedOperation", false)) {
   /**
    * Operation used to create or mutate a CampaignFeed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3619,7 +3619,7 @@ if (!class_exists("CampaignFeedOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedReturnValue", false)) {
   /**
    * The result of a call to {@link CampaignFeedService#mutate}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3661,7 +3661,7 @@ if (!class_exists("CampaignFeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("ConstantOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConstantOperand", false)) {
   /**
    * A constant operand in a matching function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3731,7 +3731,7 @@ if (!class_exists("ConstantOperand", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedAttributeOperand", false)) {
   /**
    * Represents a feed attribute reference to use in a function.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3780,7 +3780,7 @@ if (!class_exists("FeedAttributeOperand", false)) {
   }
 }
 
-if (!class_exists("FunctionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FunctionOperand", false)) {
   /**
    * A function operand in a matching function.
    * Used to represent nested functions.
@@ -3823,7 +3823,7 @@ if (!class_exists("FunctionOperand", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3859,7 +3859,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignFeedPage", false)) {
   /**
    * The result of a call to {@link CampaignFeedService#get}. Contains a list of
    * associations between campaign and feeds.
@@ -3907,7 +3907,7 @@ if (!class_exists("CampaignFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CampaignFeedService extends AdWordsSoapClient {
+  class CampaignFeedService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3924,91 +3924,91 @@ if (!class_exists("CampaignFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "CampaignFeed" => "CampaignFeed",
-      "CampaignFeedError" => "CampaignFeedError",
-      "CampaignFeedOperation" => "CampaignFeedOperation",
-      "CampaignFeedPage" => "CampaignFeedPage",
-      "CampaignFeedReturnValue" => "CampaignFeedReturnValue",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ConstantOperand" => "ConstantOperand",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttributeOperand" => "FeedAttributeOperand",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "FunctionOperand" => "FunctionOperand",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NullStatsPage" => "NullStatsPage",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestContextOperand" => "RequestContextOperand",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "CampaignFeed.Status" => "CampaignFeedStatus",
-      "CampaignFeedError.Reason" => "CampaignFeedErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "ConstantOperand.ConstantType" => "ConstantOperandConstantType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestContextOperand.ContextType" => "RequestContextOperandContextType",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CampaignFeedServiceGet",
-      "getResponse" => "CampaignFeedServiceGetResponse",
-      "mutate" => "CampaignFeedServiceMutate",
-      "mutateResponse" => "CampaignFeedServiceMutateResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "CampaignFeed" => "Google_Api_Ads_AdWords_v201309\\CampaignFeed",
+      "CampaignFeedError" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedError",
+      "CampaignFeedOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedOperation",
+      "CampaignFeedPage" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedPage",
+      "CampaignFeedReturnValue" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedReturnValue",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "ConstantOperand" => "Google_Api_Ads_AdWords_v201309\\ConstantOperand",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "FeedAttributeOperand" => "Google_Api_Ads_AdWords_v201309\\FeedAttributeOperand",
+      "Function" => "Google_Api_Ads_AdWords_v201309\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201309\\FunctionError",
+      "FunctionOperand" => "Google_Api_Ads_AdWords_v201309\\FunctionOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201309\\FunctionArgumentOperand",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestContextOperand" => "Google_Api_Ads_AdWords_v201309\\RequestContextOperand",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "CampaignFeed.Status" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedStatus",
+      "CampaignFeedError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "ConstantOperand.ConstantType" => "Google_Api_Ads_AdWords_v201309\\ConstantOperandConstantType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201309\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201309\\FunctionErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestContextOperand.ContextType" => "Google_Api_Ads_AdWords_v201309\\RequestContextOperandContextType",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignFeedServiceMutateResponse",
     );
 
 
@@ -4060,3 +4060,4 @@ if (!class_exists("CampaignFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CampaignService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CampaignService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ConversionOptimizerEligibility", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibility", false)) {
   /**
    * Eligibility data for Campaign to transition to Conversion Optimizer
    * @package Google_Api_Ads_AdWords_v201309
@@ -77,7 +77,7 @@ if (!class_exists("ConversionOptimizerEligibility", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -125,7 +125,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FrequencyCap", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FrequencyCap", false)) {
   /**
    * A frequency cap is the maximum number of times an ad (or some set of ads) can
    * be shown to a user over a particular time period.
@@ -180,7 +180,7 @@ if (!class_exists("FrequencyCap", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -241,7 +241,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -288,7 +288,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -337,7 +337,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -391,7 +391,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -466,7 +466,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -534,7 +534,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -582,7 +582,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -654,7 +654,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -726,7 +726,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -823,7 +823,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -902,7 +902,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -974,7 +974,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1042,7 +1042,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1115,7 +1115,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -1207,7 +1207,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1296,7 +1296,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("Campaign", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Campaign", false)) {
   /**
    * Data representing an AdWords campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1427,7 +1427,7 @@ if (!class_exists("Campaign", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1499,7 +1499,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1579,7 +1579,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1658,7 +1658,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdServingOptimizationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdServingOptimizationStatus", false)) {
   /**
    * Ad serving status of campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1691,7 +1691,7 @@ if (!class_exists("AdServingOptimizationStatus", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1724,7 +1724,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1757,7 +1757,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1790,7 +1790,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1823,7 +1823,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -1857,7 +1857,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1890,7 +1890,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1923,7 +1923,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1956,7 +1956,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1989,7 +1989,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingTransitionErrorReason", false)) {
   /**
    * Reason for bidding transition error.
    * It is used by capability service as denial reasons, for bidding transition
@@ -2024,7 +2024,7 @@ if (!class_exists("BiddingTransitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2057,7 +2057,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2090,7 +2090,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2123,7 +2123,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2156,7 +2156,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2189,7 +2189,7 @@ if (!class_exists("CampaignErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignStatus", false)) {
   /**
    * Campaign status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2222,7 +2222,7 @@ if (!class_exists("CampaignStatus", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2256,7 +2256,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2289,7 +2289,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2322,7 +2322,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibilityRejectionReason", false)) {
   /**
    * Campaign is not active
    * @package Google_Api_Ads_AdWords_v201309
@@ -2355,7 +2355,7 @@ if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2388,7 +2388,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2421,7 +2421,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2454,7 +2454,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2487,7 +2487,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2521,7 +2521,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2554,7 +2554,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   /**
    * The various signals a negative location target may use.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2587,7 +2587,7 @@ if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   /**
    * The various signals a positive location target may use.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2620,7 +2620,7 @@ if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2653,7 +2653,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2686,7 +2686,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("Level", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Level", false)) {
   /**
    * The level on which the cap is to be applied.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2719,7 +2719,7 @@ if (!class_exists("Level", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2752,7 +2752,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2785,7 +2785,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2818,7 +2818,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2851,7 +2851,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2884,7 +2884,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2917,7 +2917,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2950,9 +2950,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -2983,7 +2983,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3016,7 +3016,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3049,7 +3049,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3083,7 +3083,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3116,7 +3116,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3149,7 +3149,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3182,7 +3182,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3215,7 +3215,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3248,7 +3248,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3281,7 +3281,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3314,7 +3314,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3347,7 +3347,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("ServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ServingStatus", false)) {
   /**
    * Campaign serving status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3380,7 +3380,7 @@ if (!class_exists("ServingStatus", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3413,7 +3413,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3446,7 +3446,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3479,7 +3479,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3512,7 +3512,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3545,7 +3545,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3578,7 +3578,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("TimeUnit", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TimeUnit", false)) {
   /**
    * Unit of time the cap is defined at.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3611,7 +3611,7 @@ if (!class_exists("TimeUnit", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3659,7 +3659,7 @@ if (!class_exists("CampaignServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3699,7 +3699,7 @@ if (!class_exists("CampaignServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -3755,7 +3755,7 @@ if (!class_exists("CampaignServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3795,7 +3795,7 @@ if (!class_exists("CampaignServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3844,7 +3844,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3884,7 +3884,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3929,7 +3929,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3974,7 +3974,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4019,7 +4019,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4064,7 +4064,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4109,7 +4109,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4154,7 +4154,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingTransitionError", false)) {
   /**
    * Bidding transition errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4199,7 +4199,7 @@ if (!class_exists("BiddingTransitionError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4244,7 +4244,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("CampaignError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignError", false)) {
   /**
    * Base error class for Campaign Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4289,7 +4289,7 @@ if (!class_exists("CampaignError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4334,7 +4334,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -4397,7 +4397,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4442,7 +4442,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4487,7 +4487,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4526,7 +4526,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4600,7 +4600,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4646,7 +4646,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -4692,7 +4692,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSetting", false)) {
   /**
    * Represents a collection of settings related to ads geotargeting.
    * 
@@ -4766,7 +4766,7 @@ if (!class_exists("GeoTargetTypeSetting", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4811,7 +4811,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -4858,7 +4858,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchSetting", false)) {
   /**
    * Improved exact and phrase match option includes misspellings, plurals,
    * and other close variants of your keywords.
@@ -4908,7 +4908,7 @@ if (!class_exists("KeywordMatchSetting", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -4951,7 +4951,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4987,7 +4987,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5029,7 +5029,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5074,7 +5074,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5119,7 +5119,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5164,7 +5164,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5209,7 +5209,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5244,7 +5244,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5289,7 +5289,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5334,7 +5334,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5383,7 +5383,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -5424,7 +5424,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5476,7 +5476,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5521,7 +5521,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5573,7 +5573,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5618,7 +5618,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5684,7 +5684,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5729,7 +5729,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RealTimeBiddingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RealTimeBiddingSetting", false)) {
   /**
    * Settings for Real-Time Bidding, a feature only available for campaigns
    * targeting the Ad Exchange network.
@@ -5772,7 +5772,7 @@ if (!class_exists("RealTimeBiddingSetting", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5817,7 +5817,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -5863,7 +5863,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5908,7 +5908,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5953,7 +5953,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5998,7 +5998,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6043,7 +6043,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6088,7 +6088,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -6134,7 +6134,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6179,7 +6179,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("TrackingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrackingSetting", false)) {
   /**
    * Campaign level settings for tracking information.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6221,7 +6221,7 @@ if (!class_exists("TrackingSetting", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6263,7 +6263,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6319,7 +6319,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6368,7 +6368,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6413,7 +6413,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -6492,7 +6492,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -6545,7 +6545,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -6597,7 +6597,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6640,7 +6640,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -6691,7 +6691,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CampaignOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignOperation", false)) {
   /**
    * An operation on an AdWords campaign.
    * <p class="note"><b>Note:</b> The <code>REMOVE</code> operator is not
@@ -6737,7 +6737,7 @@ if (!class_exists("CampaignOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignPage", false)) {
   /**
    * Contains a subset of campaign resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.campaign.CampaignService#get} call.
@@ -6781,7 +6781,7 @@ if (!class_exists("CampaignPage", false)) {
   }
 }
 
-if (!class_exists("CampaignReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignReturnValue", false)) {
   /**
    * A container for return values from the CampaignService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6830,7 +6830,7 @@ if (!class_exists("CampaignReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6871,7 +6871,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6918,7 +6918,7 @@ if (!class_exists("CampaignService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CampaignService extends AdWordsSoapClient {
+  class CampaignService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -6935,158 +6935,158 @@ if (!class_exists("CampaignService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingTransitionError" => "BiddingTransitionError",
-      "BudgetError" => "BudgetError",
-      "CampaignError" => "CampaignError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "ConversionOptimizerEligibility" => "ConversionOptimizerEligibility",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "FrequencyCap" => "FrequencyCap",
-      "GeoTargetTypeSetting" => "GeoTargetTypeSetting",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "KeywordMatchSetting" => "KeywordMatchSetting",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RealTimeBiddingSetting" => "RealTimeBiddingSetting",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SettingError" => "SettingError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetError" => "TargetError",
-      "TrackingSetting" => "TrackingSetting",
-      "ComparableValue" => "ComparableValue",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Setting" => "Setting",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "Selector" => "Selector",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "Budget" => "Budget",
-      "Campaign" => "Campaign",
-      "CampaignOperation" => "CampaignOperation",
-      "CampaignPage" => "CampaignPage",
-      "CampaignReturnValue" => "CampaignReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdServingOptimizationStatus" => "AdServingOptimizationStatus",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "BiddingTransitionError.Reason" => "BiddingTransitionErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "CampaignError.Reason" => "CampaignErrorReason",
-      "CampaignStatus" => "CampaignStatus",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "ConversionOptimizerEligibility.RejectionReason" => "ConversionOptimizerEligibilityRejectionReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "GeoTargetTypeSetting.NegativeGeoTargetType" => "GeoTargetTypeSettingNegativeGeoTargetType",
-      "GeoTargetTypeSetting.PositiveGeoTargetType" => "GeoTargetTypeSettingPositiveGeoTargetType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "Level" => "Level",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "ServingStatus" => "ServingStatus",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "TimeUnit" => "TimeUnit",
-      "get" => "CampaignServiceGet",
-      "getResponse" => "CampaignServiceGetResponse",
-      "mutate" => "CampaignServiceMutate",
-      "mutateResponse" => "CampaignServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201309\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201309\\BiddingErrors",
+      "BiddingTransitionError" => "Google_Api_Ads_AdWords_v201309\\BiddingTransitionError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201309\\BudgetError",
+      "CampaignError" => "Google_Api_Ads_AdWords_v201309\\CampaignError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme",
+      "ConversionOptimizerEligibility" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibility",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError",
+      "FrequencyCap" => "Google_Api_Ads_AdWords_v201309\\FrequencyCap",
+      "GeoTargetTypeSetting" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSetting",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "KeywordMatchSetting" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchSetting",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201309\\NetworkSetting",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201309\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RealTimeBiddingSetting" => "Google_Api_Ads_AdWords_v201309\\RealTimeBiddingSetting",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SettingError" => "Google_Api_Ads_AdWords_v201309\\SettingError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "TargetError" => "Google_Api_Ads_AdWords_v201309\\TargetError",
+      "TrackingSetting" => "Google_Api_Ads_AdWords_v201309\\TrackingSetting",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201309\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201309\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201309\\CpmBid",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme",
+      "Setting" => "Google_Api_Ads_AdWords_v201309\\Setting",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Bids" => "Google_Api_Ads_AdWords_v201309\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration",
+      "Budget" => "Google_Api_Ads_AdWords_v201309\\Budget",
+      "Campaign" => "Google_Api_Ads_AdWords_v201309\\Campaign",
+      "CampaignOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignOperation",
+      "CampaignPage" => "Google_Api_Ads_AdWords_v201309\\CampaignPage",
+      "CampaignReturnValue" => "Google_Api_Ads_AdWords_v201309\\CampaignReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AdServingOptimizationStatus" => "Google_Api_Ads_AdWords_v201309\\AdServingOptimizationStatus",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201309\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyType",
+      "BiddingTransitionError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingTransitionErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetErrorReason",
+      "CampaignError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignErrorReason",
+      "CampaignStatus" => "Google_Api_Ads_AdWords_v201309\\CampaignStatus",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode",
+      "ConversionOptimizerEligibility.RejectionReason" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibilityRejectionReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason",
+      "GeoTargetTypeSetting.NegativeGeoTargetType" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingNegativeGeoTargetType",
+      "GeoTargetTypeSetting.PositiveGeoTargetType" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingPositiveGeoTargetType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "Level" => "Google_Api_Ads_AdWords_v201309\\Level",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "ServingStatus" => "Google_Api_Ads_AdWords_v201309\\ServingStatus",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201309\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201309\\TargetErrorReason",
+      "TimeUnit" => "Google_Api_Ads_AdWords_v201309\\TimeUnit",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CampaignServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\CampaignServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201309\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201309\\QueryResponse",
     );
 
 
@@ -7159,3 +7159,4 @@ if (!class_exists("CampaignService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CampaignSharedSetService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CampaignSharedSetService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("CampaignSharedSet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSet", false)) {
   /**
    * <span class="constraint Selectable">This field can be selected using the value "SharedSetId".</span><span class="constraint Filterable">This field can be filtered on.</span>
    * <span class="constraint Required">This field is required and should not be {@code null} when it is contained within {@link Operator}s : ADD, REMOVE.</span>
@@ -106,7 +106,7 @@ if (!class_exists("CampaignSharedSet", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -153,7 +153,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Indicates that this instance is a subtype of ListReturnValue.
    * Although this field is returned in the response, it is ignored on input
@@ -227,7 +227,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -306,7 +306,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -353,7 +353,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Indicates that this instance is a subtype of Page.
    * Although this field is returned in the response, it is ignored on input
@@ -434,7 +434,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * <span class="constraint InRange">This field must be greater than or equal to 0.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -481,7 +481,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -535,7 +535,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -610,7 +610,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -678,7 +678,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -773,7 +773,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Indicates that this instance is a subtype of ApplicationException.
    * Although this field is returned in the response, it is ignored on input
@@ -854,7 +854,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * <span class="constraint ContentsDistinct">This field must contain distinct elements.</span>
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
@@ -924,7 +924,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -957,7 +957,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -990,7 +990,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1023,7 +1023,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetStatus", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1056,7 +1056,7 @@ if (!class_exists("CampaignSharedSetStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1089,7 +1089,7 @@ if (!class_exists("CampaignSharedSetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1122,7 +1122,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1155,7 +1155,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1188,7 +1188,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1221,7 +1221,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1254,7 +1254,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1287,7 +1287,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1320,7 +1320,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1353,7 +1353,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1386,7 +1386,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1419,7 +1419,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1452,7 +1452,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1485,7 +1485,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1518,7 +1518,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1551,7 +1551,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1584,7 +1584,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1617,7 +1617,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1650,7 +1650,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1683,7 +1683,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1716,7 +1716,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1749,7 +1749,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1782,7 +1782,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1815,7 +1815,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1848,7 +1848,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1881,7 +1881,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1914,7 +1914,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SharedSetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1947,7 +1947,7 @@ if (!class_exists("SharedSetType", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1980,7 +1980,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2013,7 +2013,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2046,7 +2046,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2094,7 +2094,7 @@ if (!class_exists("CampaignSharedSetServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2134,7 +2134,7 @@ if (!class_exists("CampaignSharedSetServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2184,7 +2184,7 @@ if (!class_exists("CampaignSharedSetServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2224,7 +2224,7 @@ if (!class_exists("CampaignSharedSetServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2269,7 +2269,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2314,7 +2314,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2359,7 +2359,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2404,7 +2404,7 @@ if (!class_exists("CampaignSharedSetError", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetOperation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -2447,7 +2447,7 @@ if (!class_exists("CampaignSharedSetOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetReturnValue", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2489,7 +2489,7 @@ if (!class_exists("CampaignSharedSetReturnValue", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2534,7 +2534,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2579,7 +2579,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2624,7 +2624,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2697,7 +2697,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2742,7 +2742,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2787,7 +2787,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2832,7 +2832,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2877,7 +2877,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2922,7 +2922,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2967,7 +2967,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3012,7 +3012,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3048,7 +3048,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3093,7 +3093,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3138,7 +3138,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3183,7 +3183,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3228,7 +3228,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3273,7 +3273,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3339,7 +3339,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3384,7 +3384,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3429,7 +3429,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3474,7 +3474,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3519,7 +3519,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3564,7 +3564,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3609,7 +3609,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3654,7 +3654,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3699,7 +3699,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3742,7 +3742,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CampaignSharedSetPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignSharedSetPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3789,7 +3789,7 @@ if (!class_exists("CampaignSharedSetService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CampaignSharedSetService extends AdWordsSoapClient {
+  class CampaignSharedSetService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignSharedSetService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3806,91 +3806,91 @@ if (!class_exists("CampaignSharedSetService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "CampaignSharedSet" => "CampaignSharedSet",
-      "CampaignSharedSetError" => "CampaignSharedSetError",
-      "CampaignSharedSetOperation" => "CampaignSharedSetOperation",
-      "CampaignSharedSetPage" => "CampaignSharedSetPage",
-      "CampaignSharedSetReturnValue" => "CampaignSharedSetReturnValue",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "CampaignSharedSet.Status" => "CampaignSharedSetStatus",
-      "CampaignSharedSetError.Reason" => "CampaignSharedSetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SharedSetType" => "SharedSetType",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CampaignSharedSetServiceGet",
-      "getResponse" => "CampaignSharedSetServiceGetResponse",
-      "mutate" => "CampaignSharedSetServiceMutate",
-      "mutateResponse" => "CampaignSharedSetServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "CampaignSharedSet" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSet",
+      "CampaignSharedSetError" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetError",
+      "CampaignSharedSetOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetOperation",
+      "CampaignSharedSetPage" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetPage",
+      "CampaignSharedSetReturnValue" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetReturnValue",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "CampaignSharedSet.Status" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetStatus",
+      "CampaignSharedSetError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SharedSetType" => "Google_Api_Ads_AdWords_v201309\\SharedSetType",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\CampaignSharedSetServiceMutateResponse",
     );
 
 
@@ -3940,3 +3940,4 @@ if (!class_exists("CampaignSharedSetService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ConstantDataService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ConstantDataService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201309
@@ -70,7 +70,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -145,7 +145,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -213,7 +213,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -265,7 +265,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201309
@@ -337,7 +337,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -385,7 +385,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -482,7 +482,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -561,7 +561,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -648,7 +648,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -681,7 +681,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -714,7 +714,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -747,7 +747,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -780,7 +780,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -813,7 +813,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -847,7 +847,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -880,7 +880,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -913,7 +913,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -946,7 +946,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -979,7 +979,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1012,7 +1012,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1045,7 +1045,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1078,7 +1078,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -1112,7 +1112,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1145,7 +1145,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1178,7 +1178,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1211,7 +1211,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1244,7 +1244,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1277,7 +1277,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1311,7 +1311,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1344,7 +1344,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1377,7 +1377,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1410,7 +1410,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1443,7 +1443,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1476,7 +1476,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1509,7 +1509,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1542,7 +1542,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1575,7 +1575,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1608,7 +1608,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1641,7 +1641,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1674,7 +1674,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("GetAgeRangeCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetAgeRangeCriterion", false)) {
   /**
    * Returns a list of all age range criteria.
    * 
@@ -1710,7 +1710,7 @@ if (!class_exists("GetAgeRangeCriterion", false)) {
   }
 }
 
-if (!class_exists("GetAgeRangeCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetAgeRangeCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1750,7 +1750,7 @@ if (!class_exists("GetAgeRangeCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetCarrierCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetCarrierCriterion", false)) {
   /**
    * Returns a list of all carrier criteria.
    * 
@@ -1786,7 +1786,7 @@ if (!class_exists("GetCarrierCriterion", false)) {
   }
 }
 
-if (!class_exists("GetCarrierCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetCarrierCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1826,7 +1826,7 @@ if (!class_exists("GetCarrierCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetGenderCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetGenderCriterion", false)) {
   /**
    * Returns a list of all gender criteria.
    * 
@@ -1862,7 +1862,7 @@ if (!class_exists("GetGenderCriterion", false)) {
   }
 }
 
-if (!class_exists("GetGenderCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetGenderCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1902,7 +1902,7 @@ if (!class_exists("GetGenderCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetLanguageCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetLanguageCriterion", false)) {
   /**
    * Returns a list of all language criteria.
    * 
@@ -1938,7 +1938,7 @@ if (!class_exists("GetLanguageCriterion", false)) {
   }
 }
 
-if (!class_exists("GetLanguageCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetLanguageCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1978,7 +1978,7 @@ if (!class_exists("GetLanguageCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetMobileDeviceCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetMobileDeviceCriterion", false)) {
   /**
    * Returns a list of all mobile devices.
    * 
@@ -2014,7 +2014,7 @@ if (!class_exists("GetMobileDeviceCriterion", false)) {
   }
 }
 
-if (!class_exists("GetMobileDeviceCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetMobileDeviceCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2054,7 +2054,7 @@ if (!class_exists("GetMobileDeviceCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetOperatingSystemVersionCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetOperatingSystemVersionCriterion", false)) {
   /**
    * Returns a list of all operating system version criteria.
    * 
@@ -2090,7 +2090,7 @@ if (!class_exists("GetOperatingSystemVersionCriterion", false)) {
   }
 }
 
-if (!class_exists("GetOperatingSystemVersionCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetOperatingSystemVersionCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2130,7 +2130,7 @@ if (!class_exists("GetOperatingSystemVersionCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetUserInterestCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetUserInterestCriterion", false)) {
   /**
    * Returns a list of user interests.
    * 
@@ -2166,7 +2166,7 @@ if (!class_exists("GetUserInterestCriterion", false)) {
   }
 }
 
-if (!class_exists("GetUserInterestCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetUserInterestCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2206,7 +2206,7 @@ if (!class_exists("GetUserInterestCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetVerticalCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetVerticalCriterion", false)) {
   /**
    * Returns a list of content verticals.
    * 
@@ -2242,7 +2242,7 @@ if (!class_exists("GetVerticalCriterion", false)) {
   }
 }
 
-if (!class_exists("GetVerticalCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetVerticalCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2282,7 +2282,7 @@ if (!class_exists("GetVerticalCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2327,10 +2327,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2373,7 +2373,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2418,7 +2418,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2463,7 +2463,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2508,10 +2508,10 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2561,7 +2561,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2606,7 +2606,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2651,7 +2651,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2696,10 +2696,10 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2742,7 +2742,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2787,7 +2787,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2834,7 +2834,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -2886,10 +2886,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -2939,7 +2939,7 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -2993,7 +2993,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3045,10 +3045,10 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -3112,7 +3112,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3157,7 +3157,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3202,7 +3202,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3247,10 +3247,10 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -3314,7 +3314,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -3360,7 +3360,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3405,7 +3405,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3450,7 +3450,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3516,7 +3516,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3561,7 +3561,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3606,7 +3606,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3652,7 +3652,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3697,7 +3697,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3742,7 +3742,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3787,7 +3787,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3833,7 +3833,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3885,7 +3885,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3944,7 +3944,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -4007,7 +4007,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -4057,7 +4057,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4102,7 +4102,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -4162,7 +4162,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4205,7 +4205,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -4266,7 +4266,7 @@ if (!class_exists("ConstantDataService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ConstantDataService extends AdWordsSoapClient {
+  class ConstantDataService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ConstantDataService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -4283,102 +4283,102 @@ if (!class_exists("ConstantDataService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "Gender" => "Gender",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "Placement" => "Placement",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "ProductCondition" => "ProductCondition",
-      "Webpage" => "Webpage",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Product" => "Product",
-      "Criterion" => "Criterion",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "getAgeRangeCriterion" => "GetAgeRangeCriterion",
-      "getAgeRangeCriterionResponse" => "GetAgeRangeCriterionResponse",
-      "getCarrierCriterion" => "GetCarrierCriterion",
-      "getCarrierCriterionResponse" => "GetCarrierCriterionResponse",
-      "getGenderCriterion" => "GetGenderCriterion",
-      "getGenderCriterionResponse" => "GetGenderCriterionResponse",
-      "getLanguageCriterion" => "GetLanguageCriterion",
-      "getLanguageCriterionResponse" => "GetLanguageCriterionResponse",
-      "getMobileDeviceCriterion" => "GetMobileDeviceCriterion",
-      "getMobileDeviceCriterionResponse" => "GetMobileDeviceCriterionResponse",
-      "getOperatingSystemVersionCriterion" => "GetOperatingSystemVersionCriterion",
-      "getOperatingSystemVersionCriterionResponse" => "GetOperatingSystemVersionCriterionResponse",
-      "getUserInterestCriterion" => "GetUserInterestCriterion",
-      "getUserInterestCriterionResponse" => "GetUserInterestCriterionResponse",
-      "getVerticalCriterion" => "GetVerticalCriterion",
-      "getVerticalCriterionResponse" => "GetVerticalCriterionResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201309\\AgeRange",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "Carrier" => "Google_Api_Ads_AdWords_v201309\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "Gender" => "Google_Api_Ads_AdWords_v201309\\Gender",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201309\\MobileDevice",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201309\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "getAgeRangeCriterion" => "Google_Api_Ads_AdWords_v201309\\GetAgeRangeCriterion",
+      "getAgeRangeCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetAgeRangeCriterionResponse",
+      "getCarrierCriterion" => "Google_Api_Ads_AdWords_v201309\\GetCarrierCriterion",
+      "getCarrierCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetCarrierCriterionResponse",
+      "getGenderCriterion" => "Google_Api_Ads_AdWords_v201309\\GetGenderCriterion",
+      "getGenderCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetGenderCriterionResponse",
+      "getLanguageCriterion" => "Google_Api_Ads_AdWords_v201309\\GetLanguageCriterion",
+      "getLanguageCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetLanguageCriterionResponse",
+      "getMobileDeviceCriterion" => "Google_Api_Ads_AdWords_v201309\\GetMobileDeviceCriterion",
+      "getMobileDeviceCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetMobileDeviceCriterionResponse",
+      "getOperatingSystemVersionCriterion" => "Google_Api_Ads_AdWords_v201309\\GetOperatingSystemVersionCriterion",
+      "getOperatingSystemVersionCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetOperatingSystemVersionCriterionResponse",
+      "getUserInterestCriterion" => "Google_Api_Ads_AdWords_v201309\\GetUserInterestCriterion",
+      "getUserInterestCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetUserInterestCriterionResponse",
+      "getVerticalCriterion" => "Google_Api_Ads_AdWords_v201309\\GetVerticalCriterion",
+      "getVerticalCriterionResponse" => "Google_Api_Ads_AdWords_v201309\\GetVerticalCriterionResponse",
     );
 
 
@@ -4482,3 +4482,4 @@ if (!class_exists("ConstantDataService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ConversionTrackerService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ConversionTrackerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -443,7 +443,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerStats", false)) {
   /**
    * Usage stats about a single {@link ConversionTracker}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -504,7 +504,7 @@ if (!class_exists("ConversionTrackerStats", false)) {
   }
 }
 
-if (!class_exists("ConversionTracker", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTracker", false)) {
   /**
    * An abstract Conversion base class.
    * @package Google_Api_Ads_AdWords_v201309
@@ -639,7 +639,7 @@ if (!class_exists("ConversionTracker", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -711,7 +711,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -791,7 +791,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -888,7 +888,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -967,7 +967,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1046,7 +1046,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1114,7 +1114,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerMarkupLanguage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerMarkupLanguage", false)) {
   /**
    * Controls the markup language in which the snippet will be written.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1147,7 +1147,7 @@ if (!class_exists("AdWordsConversionTrackerMarkupLanguage", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerTextFormat", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerTextFormat", false)) {
   /**
    * Text format to display on the conversion page.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1180,7 +1180,7 @@ if (!class_exists("AdWordsConversionTrackerTextFormat", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerTrackingCodeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerTrackingCodeType", false)) {
   /**
    * Type of snippet code to generate.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1213,7 +1213,7 @@ if (!class_exists("AdWordsConversionTrackerTrackingCodeType", false)) {
   }
 }
 
-if (!class_exists("AppConversionAppConversionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AppConversionAppConversionType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1246,7 +1246,7 @@ if (!class_exists("AppConversionAppConversionType", false)) {
   }
 }
 
-if (!class_exists("AppConversionAppPlatform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AppConversionAppPlatform", false)) {
   /**
    * App platform for the AppConversionTracker.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1279,7 +1279,7 @@ if (!class_exists("AppConversionAppPlatform", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1312,7 +1312,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1345,7 +1345,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1379,7 +1379,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerCategory", false)) {
   /**
    * The category of conversion tracker that is being tracked.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1412,7 +1412,7 @@ if (!class_exists("ConversionTrackerCategory", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerStatus", false)) {
   /**
    * Status of the conversion tracker. The user cannot ADD or SET the
    * status to {@code HIDDEN}.
@@ -1446,7 +1446,7 @@ if (!class_exists("ConversionTrackerStatus", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackingErrorReason", false)) {
   /**
    * Enumerates all the possible reasons for a ConversionTypeError.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1479,7 +1479,7 @@ if (!class_exists("ConversionTrackingErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1512,7 +1512,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1545,7 +1545,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1578,7 +1578,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1611,7 +1611,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1644,7 +1644,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1677,7 +1677,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1710,7 +1710,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1743,7 +1743,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1776,7 +1776,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1809,7 +1809,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1842,7 +1842,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1876,7 +1876,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1909,7 +1909,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1942,7 +1942,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1975,7 +1975,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2008,7 +2008,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2041,7 +2041,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2074,7 +2074,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2107,7 +2107,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2140,7 +2140,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2173,7 +2173,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2225,7 +2225,7 @@ if (!class_exists("ConversionTrackerServiceGet", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2265,7 +2265,7 @@ if (!class_exists("ConversionTrackerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2323,7 +2323,7 @@ if (!class_exists("ConversionTrackerServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2363,7 +2363,7 @@ if (!class_exists("ConversionTrackerServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTracker", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdWordsConversionTracker", false)) {
   /**
    * A conversion tracker created through AdWords Conversion Tracking.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2456,7 +2456,7 @@ if (!class_exists("AdWordsConversionTracker", false)) {
   }
 }
 
-if (!class_exists("AppConversion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AppConversion", false)) {
   /**
    * A ConversionTracker for mobile apps.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2535,7 +2535,7 @@ if (!class_exists("AppConversion", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2580,7 +2580,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2625,7 +2625,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2670,7 +2670,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackingError", false)) {
   /**
    * An error that can occur during calls to the ConversionTypeService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2715,7 +2715,7 @@ if (!class_exists("ConversionTrackingError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2760,7 +2760,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2805,7 +2805,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2850,7 +2850,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2897,7 +2897,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2939,7 +2939,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2984,7 +2984,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3029,7 +3029,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3064,7 +3064,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3109,7 +3109,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3154,7 +3154,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3199,7 +3199,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3244,7 +3244,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3310,7 +3310,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3355,7 +3355,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3401,7 +3401,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3446,7 +3446,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3491,7 +3491,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3536,7 +3536,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3582,7 +3582,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("UploadConversion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UploadConversion", false)) {
   /**
    * A conversion type that receives conversions by having them uploaded
    * through the OfflineConversionFeedService.
@@ -3638,7 +3638,7 @@ if (!class_exists("UploadConversion", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerOperation", false)) {
   /**
    * Operations for conversion tracker.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3681,7 +3681,7 @@ if (!class_exists("ConversionTrackerOperation", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerReturnValue", false)) {
   /**
    * A container for return values from the ConversionTrackerService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3723,7 +3723,7 @@ if (!class_exists("ConversionTrackerReturnValue", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3768,7 +3768,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3811,7 +3811,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3847,7 +3847,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3888,7 +3888,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3929,7 +3929,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionTrackerPage", false)) {
   /**
    * Contains a subset of {@link ConversionTracker}s resulting from the filtering
    * and paging of the {@link ConversionTrackerService#get} call.
@@ -3977,7 +3977,7 @@ if (!class_exists("ConversionTrackerService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ConversionTrackerService extends AdWordsSoapClient {
+  class ConversionTrackerService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ConversionTrackerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3994,91 +3994,91 @@ if (!class_exists("ConversionTrackerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdWordsConversionTracker" => "AdWordsConversionTracker",
-      "AppConversion" => "AppConversion",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionTrackingError" => "ConversionTrackingError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "UploadConversion" => "UploadConversion",
-      "ComparableValue" => "ComparableValue",
-      "ConversionTrackerStats" => "ConversionTrackerStats",
-      "ConversionTracker" => "ConversionTracker",
-      "ConversionTrackerOperation" => "ConversionTrackerOperation",
-      "ConversionTrackerReturnValue" => "ConversionTrackerReturnValue",
-      "DatabaseError" => "DatabaseError",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "ConversionTrackerPage" => "ConversionTrackerPage",
-      "NoStatsPage" => "NoStatsPage",
-      "Page" => "Page",
-      "Selector" => "Selector",
-      "AdWordsConversionTracker.MarkupLanguage" => "AdWordsConversionTrackerMarkupLanguage",
-      "AdWordsConversionTracker.TextFormat" => "AdWordsConversionTrackerTextFormat",
-      "AdWordsConversionTracker.TrackingCodeType" => "AdWordsConversionTrackerTrackingCodeType",
-      "AppConversion.AppConversionType" => "AppConversionAppConversionType",
-      "AppConversion.AppPlatform" => "AppConversionAppPlatform",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionTracker.Category" => "ConversionTrackerCategory",
-      "ConversionTracker.Status" => "ConversionTrackerStatus",
-      "ConversionTrackingError.Reason" => "ConversionTrackingErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "ConversionTrackerServiceGet",
-      "getResponse" => "ConversionTrackerServiceGetResponse",
-      "mutate" => "ConversionTrackerServiceMutate",
-      "mutateResponse" => "ConversionTrackerServiceMutateResponse",
+      "AdWordsConversionTracker" => "Google_Api_Ads_AdWords_v201309\\AdWordsConversionTracker",
+      "AppConversion" => "Google_Api_Ads_AdWords_v201309\\AppConversion",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ConversionTrackingError" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackingError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "UploadConversion" => "Google_Api_Ads_AdWords_v201309\\UploadConversion",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "ConversionTrackerStats" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerStats",
+      "ConversionTracker" => "Google_Api_Ads_AdWords_v201309\\ConversionTracker",
+      "ConversionTrackerOperation" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerOperation",
+      "ConversionTrackerReturnValue" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerReturnValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "ConversionTrackerPage" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerPage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AdWordsConversionTracker.MarkupLanguage" => "Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerMarkupLanguage",
+      "AdWordsConversionTracker.TextFormat" => "Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerTextFormat",
+      "AdWordsConversionTracker.TrackingCodeType" => "Google_Api_Ads_AdWords_v201309\\AdWordsConversionTrackerTrackingCodeType",
+      "AppConversion.AppConversionType" => "Google_Api_Ads_AdWords_v201309\\AppConversionAppConversionType",
+      "AppConversion.AppPlatform" => "Google_Api_Ads_AdWords_v201309\\AppConversionAppPlatform",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ConversionTracker.Category" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerCategory",
+      "ConversionTracker.Status" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerStatus",
+      "ConversionTrackingError.Reason" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackingErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\ConversionTrackerServiceMutateResponse",
     );
 
 
@@ -4140,3 +4140,4 @@ if (!class_exists("ConversionTrackerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CustomerService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CustomerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -109,7 +109,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -181,7 +181,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -282,7 +282,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -365,7 +365,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -402,7 +402,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -439,7 +439,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -477,7 +477,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -514,7 +514,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -551,7 +551,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -588,7 +588,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -625,7 +625,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -662,7 +662,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -699,7 +699,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -736,7 +736,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -773,7 +773,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -810,7 +810,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -848,7 +848,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -885,7 +885,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -922,7 +922,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -959,7 +959,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -996,7 +996,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1033,7 +1033,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1070,7 +1070,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1107,7 +1107,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("Customer", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Customer", false)) {
   /**
    * Represents a customer for the CustomerService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1182,7 +1182,7 @@ if (!class_exists("Customer", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerServiceGet", false)) {
   /**
    * Returns details of the authorized customer.
    * 
@@ -1217,7 +1217,7 @@ if (!class_exists("CustomerServiceGet", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1257,7 +1257,7 @@ if (!class_exists("CustomerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -1306,7 +1306,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -1355,7 +1355,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -1404,7 +1404,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -1453,7 +1453,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -1502,7 +1502,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1553,7 +1553,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1602,7 +1602,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1651,7 +1651,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1700,7 +1700,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1749,7 +1749,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1798,7 +1798,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1847,7 +1847,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1896,7 +1896,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1966,7 +1966,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2015,7 +2015,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2065,7 +2065,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2114,7 +2114,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2163,7 +2163,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2213,7 +2213,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -2262,7 +2262,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -2315,7 +2315,7 @@ if (!class_exists("CustomerService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CustomerService extends AdWordsSoapClient {
+  class CustomerService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CustomerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201309";
@@ -2332,54 +2332,54 @@ if (!class_exists("CustomerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "Customer" => "Customer",
-      "get" => "CustomerServiceGet",
-      "getResponse" => "CustomerServiceGetResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "Customer" => "Google_Api_Ads_AdWords_v201309\\Customer",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CustomerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CustomerServiceGetResponse",
     );
 
 
@@ -2405,3 +2405,4 @@ if (!class_exists("CustomerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/CustomerSyncService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/CustomerSyncService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateTimeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateTimeRange", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -79,7 +79,7 @@ if (!class_exists("DateTimeRange", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -156,7 +156,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -226,7 +226,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -327,7 +327,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Indicates that this instance is a subtype of ApplicationException.
    * Although this field is returned in the response, it is ignored on input
@@ -414,7 +414,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -449,7 +449,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -484,7 +484,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -519,7 +519,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -554,7 +554,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -589,7 +589,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -624,7 +624,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -659,7 +659,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -694,7 +694,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -729,7 +729,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -764,7 +764,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -799,7 +799,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -834,7 +834,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -869,7 +869,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -904,7 +904,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -939,7 +939,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -974,7 +974,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * 
@@ -1013,7 +1013,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1048,7 +1048,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupChangeData", false)) {
   /**
    * Holds information about a changed adgroup
    * @package Google_Api_Ads_AdWords_v201309
@@ -1144,7 +1144,7 @@ if (!class_exists("AdGroupChangeData", false)) {
   }
 }
 
-if (!class_exists("CampaignChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignChangeData", false)) {
   /**
    * Holds information about a changed campaign and any ad groups under
    * that have changed.
@@ -1248,7 +1248,7 @@ if (!class_exists("CampaignChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerSyncError", false)) {
   /**
    * Represents CustomerSyncService specific errors
    * @package Google_Api_Ads_AdWords_v201309
@@ -1300,7 +1300,7 @@ if (!class_exists("CustomerSyncError", false)) {
   }
 }
 
-if (!class_exists("FeedChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedChangeData", false)) {
   /**
    * Holds information about a changed feed and any feeds items within the feed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1361,7 +1361,7 @@ if (!class_exists("FeedChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerChangeData", false)) {
   /**
    * Holds information about changes to a customer
    * @package Google_Api_Ads_AdWords_v201309
@@ -1415,7 +1415,7 @@ if (!class_exists("CustomerChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerSyncSelector", false)) {
   /**
    * A filter for selecting change history data for a customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1469,7 +1469,7 @@ if (!class_exists("CustomerSyncSelector", false)) {
   }
 }
 
-if (!class_exists("ChangeStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ChangeStatus", false)) {
   /**
    * An enum used to classify the types of changes that have been made to
    * an adgroup/campaign during a specified date range.  This only refers
@@ -1508,7 +1508,7 @@ if (!class_exists("ChangeStatus", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerSyncErrorReason", false)) {
   /**
    * The request attempted to access a campaign that either does not
    * exist or belongs to a different account.
@@ -1542,7 +1542,7 @@ if (!class_exists("CustomerSyncErrorReason", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerSyncServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1591,7 +1591,7 @@ if (!class_exists("CustomerSyncServiceGet", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CustomerSyncServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1631,7 +1631,7 @@ if (!class_exists("CustomerSyncServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1678,7 +1678,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1725,7 +1725,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1772,7 +1772,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1819,7 +1819,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1866,7 +1866,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1913,7 +1913,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1960,7 +1960,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2007,7 +2007,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2054,7 +2054,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2101,7 +2101,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2148,7 +2148,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2216,7 +2216,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2263,7 +2263,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2310,7 +2310,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2357,7 +2357,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2404,7 +2404,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2451,7 +2451,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2498,7 +2498,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2549,7 +2549,7 @@ if (!class_exists("CustomerSyncService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class CustomerSyncService extends AdWordsSoapClient {
+  class CustomerSyncService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CustomerSyncService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/ch/v201309";
@@ -2566,58 +2566,58 @@ if (!class_exists("CustomerSyncService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateTimeRange" => "DateTimeRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "AdGroupChangeData" => "AdGroupChangeData",
-      "CampaignChangeData" => "CampaignChangeData",
-      "CustomerSyncError" => "CustomerSyncError",
-      "FeedChangeData" => "FeedChangeData",
-      "CustomerChangeData" => "CustomerChangeData",
-      "CustomerSyncSelector" => "CustomerSyncSelector",
-      "ChangeStatus" => "ChangeStatus",
-      "CustomerSyncError.Reason" => "CustomerSyncErrorReason",
-      "get" => "CustomerSyncServiceGet",
-      "getResponse" => "CustomerSyncServiceGetResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateTimeRange" => "Google_Api_Ads_AdWords_v201309\\DateTimeRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "AdGroupChangeData" => "Google_Api_Ads_AdWords_v201309\\AdGroupChangeData",
+      "CampaignChangeData" => "Google_Api_Ads_AdWords_v201309\\CampaignChangeData",
+      "CustomerSyncError" => "Google_Api_Ads_AdWords_v201309\\CustomerSyncError",
+      "FeedChangeData" => "Google_Api_Ads_AdWords_v201309\\FeedChangeData",
+      "CustomerChangeData" => "Google_Api_Ads_AdWords_v201309\\CustomerChangeData",
+      "CustomerSyncSelector" => "Google_Api_Ads_AdWords_v201309\\CustomerSyncSelector",
+      "ChangeStatus" => "Google_Api_Ads_AdWords_v201309\\ChangeStatus",
+      "CustomerSyncError.Reason" => "Google_Api_Ads_AdWords_v201309\\CustomerSyncErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\CustomerSyncServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\CustomerSyncServiceGetResponse",
     );
 
 
@@ -2650,3 +2650,4 @@ if (!class_exists("CustomerSyncService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/DataService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/DataService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -303,7 +303,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -443,7 +443,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -540,7 +540,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -619,7 +619,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeLandscapePoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidLandscapeLandscapePoint", false)) {
   /**
    * A set of estimates for a criterion's performance for a specific bid
    * amount.
@@ -695,7 +695,7 @@ if (!class_exists("BidLandscapeLandscapePoint", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -763,7 +763,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("DataEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DataEntry", false)) {
   /**
    * The base class of all return types of the table service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -835,7 +835,7 @@ if (!class_exists("DataEntry", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -914,7 +914,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapeType", false)) {
   /**
    * Used to specify the type of {@code AdGroupLandscape}
    * @package Google_Api_Ads_AdWords_v201309
@@ -947,7 +947,7 @@ if (!class_exists("AdGroupBidLandscapeType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -980,7 +980,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1013,7 +1013,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1046,7 +1046,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1079,7 +1079,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1113,7 +1113,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1146,7 +1146,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1179,7 +1179,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1212,7 +1212,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1245,7 +1245,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1278,7 +1278,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1311,7 +1311,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1344,7 +1344,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1377,7 +1377,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1410,7 +1410,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1444,7 +1444,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1477,7 +1477,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1510,7 +1510,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1543,7 +1543,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1576,7 +1576,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1609,7 +1609,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1642,7 +1642,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1675,7 +1675,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1708,7 +1708,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1741,7 +1741,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1774,7 +1774,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("DataErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DataErrorReason", false)) {
   /**
    * Reasons for error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1807,13 +1807,16 @@ if (!class_exists("DataErrorReason", false)) {
   }
 }
 
-if (!class_exists("GetAdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetAdGroupBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the ad groups specified in the selector.
+   * Returns a list of {@link AdGroupBidLandscape}s for the ad groups specified in the selector.
+   * In the result, the returned {@link LandscapePoint}s are grouped into
+   * {@link AdGroupBidLandscape}s by their ad groups, and numberResults of paging limits the total
+   * number of {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
    * 
    * @param serviceSelector Selects the entities to return bid landscapes for.
    * @return A list of bid landscapes.
@@ -1855,7 +1858,7 @@ if (!class_exists("GetAdGroupBidLandscape", false)) {
   }
 }
 
-if (!class_exists("GetAdGroupBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetAdGroupBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1895,13 +1898,16 @@ if (!class_exists("GetAdGroupBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("GetCriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetCriterionBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the criteria specified in the selector.
+   * Returns a list of {@link CriterionBidLandscape}s for the criteria specified in the selector.
+   * In the result, the returned {@link LandscapePoint}s are grouped into
+   * {@link CriterionBidLandscape}s by their criteria, and numberResults of paging limits the total
+   * number of {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
    * 
    * @param serviceSelector Selects the entities to return bid landscapes for.
    * @return A list of bid landscapes.
@@ -1943,7 +1949,7 @@ if (!class_exists("GetCriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("GetCriterionBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetCriterionBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1983,7 +1989,7 @@ if (!class_exists("GetCriterionBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2028,7 +2034,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2073,7 +2079,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2118,7 +2124,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2163,7 +2169,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2208,7 +2214,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2253,7 +2259,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2298,7 +2304,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2343,7 +2349,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2390,7 +2396,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2432,7 +2438,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2477,7 +2483,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2522,7 +2528,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2567,7 +2573,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2602,7 +2608,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2647,7 +2653,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2692,7 +2698,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2758,7 +2764,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2803,7 +2809,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2848,7 +2854,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2894,7 +2900,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2939,7 +2945,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2984,7 +2990,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3029,7 +3035,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3075,7 +3081,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DataError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DataError", false)) {
   /**
    * Represents errors thrown by the get operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3120,7 +3126,7 @@ if (!class_exists("DataError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3165,7 +3171,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3208,7 +3214,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidLandscape", false)) {
   /**
    * Represents data about a bid landscape for an ad group or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3278,7 +3284,7 @@ if (!class_exists("BidLandscape", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3314,7 +3320,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscape", false)) {
   /**
    * Represents data about a bidlandscape for an adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3367,7 +3373,7 @@ if (!class_exists("AdGroupBidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionBidLandscape", false)) {
   /**
    * The bid landscape for a criterion.  A bid landscape estimates how a
    * a criterion will perform based on different bid amounts.
@@ -3414,7 +3420,7 @@ if (!class_exists("CriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3455,7 +3461,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3496,7 +3502,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapePage", false)) {
   /**
    * Contains a subset of {@link AdGroupBidLandscape} objects resulting from the
    * filtering and paging of
@@ -3540,7 +3546,7 @@ if (!class_exists("AdGroupBidLandscapePage", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscapePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionBidLandscapePage", false)) {
   /**
    * Contains a subset of {@link CriterionBidLandscapePage} objects resulting from the
    * filtering and paging of
@@ -3590,7 +3596,7 @@ if (!class_exists("DataService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class DataService extends AdWordsSoapClient {
+  class DataService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "DataService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3607,85 +3613,85 @@ if (!class_exists("DataService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupBidLandscape" => "AdGroupBidLandscape",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "CriterionBidLandscape" => "CriterionBidLandscape",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DataError" => "DataError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "BidLandscape.LandscapePoint" => "BidLandscapeLandscapePoint",
-      "Selector" => "Selector",
-      "BidLandscape" => "BidLandscape",
-      "DataEntry" => "DataEntry",
-      "AdGroupBidLandscapePage" => "AdGroupBidLandscapePage",
-      "CriterionBidLandscapePage" => "CriterionBidLandscapePage",
-      "NoStatsPage" => "NoStatsPage",
-      "Page" => "Page",
-      "AdGroupBidLandscape.Type" => "AdGroupBidLandscapeType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "DataError.Reason" => "DataErrorReason",
-      "getAdGroupBidLandscape" => "GetAdGroupBidLandscape",
-      "getAdGroupBidLandscapeResponse" => "GetAdGroupBidLandscapeResponse",
-      "getCriterionBidLandscape" => "GetCriterionBidLandscape",
-      "getCriterionBidLandscapeResponse" => "GetCriterionBidLandscapeResponse",
+      "AdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscape",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CriterionBidLandscape" => "Google_Api_Ads_AdWords_v201309\\CriterionBidLandscape",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DataError" => "Google_Api_Ads_AdWords_v201309\\DataError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "BidLandscape.LandscapePoint" => "Google_Api_Ads_AdWords_v201309\\BidLandscapeLandscapePoint",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "BidLandscape" => "Google_Api_Ads_AdWords_v201309\\BidLandscape",
+      "DataEntry" => "Google_Api_Ads_AdWords_v201309\\DataEntry",
+      "AdGroupBidLandscapePage" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapePage",
+      "CriterionBidLandscapePage" => "Google_Api_Ads_AdWords_v201309\\CriterionBidLandscapePage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AdGroupBidLandscape.Type" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapeType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "DataError.Reason" => "Google_Api_Ads_AdWords_v201309\\DataErrorReason",
+      "getAdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201309\\GetAdGroupBidLandscape",
+      "getAdGroupBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201309\\GetAdGroupBidLandscapeResponse",
+      "getCriterionBidLandscape" => "Google_Api_Ads_AdWords_v201309\\GetCriterionBidLandscape",
+      "getCriterionBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201309\\GetCriterionBidLandscapeResponse",
     );
 
 
@@ -3704,7 +3710,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the ad groups specified in the selector.
+     * Returns a list of {@link AdGroupBidLandscape}s for the ad groups specified in the selector.
+     * In the result, the returned {@link LandscapePoint}s are grouped into
+     * {@link AdGroupBidLandscape}s by their ad groups, and numberResults of paging limits the total
+     * number of {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
      * 
      * @param serviceSelector Selects the entities to return bid landscapes for.
      * @return A list of bid landscapes.
@@ -3720,7 +3729,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the criteria specified in the selector.
+     * Returns a list of {@link CriterionBidLandscape}s for the criteria specified in the selector.
+     * In the result, the returned {@link LandscapePoint}s are grouped into
+     * {@link CriterionBidLandscape}s by their criteria, and numberResults of paging limits the total
+     * number of {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
      * 
      * @param serviceSelector Selects the entities to return bid landscapes for.
      * @return A list of bid landscapes.
@@ -3733,3 +3745,4 @@ if (!class_exists("DataService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ExperimentService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ExperimentService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("ExperimentSummaryStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentSummaryStats", false)) {
   /**
    * Contains how many changes were made associated with an experiment at
    * the adgroup, critieria and creative levels
@@ -133,7 +133,7 @@ if (!class_exists("ExperimentSummaryStats", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -180,7 +180,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -229,7 +229,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -283,7 +283,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -358,7 +358,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -426,7 +426,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("Experiment", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Experiment", false)) {
   /**
    * Class representing a experiment for the ExperimentService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -536,7 +536,7 @@ if (!class_exists("Experiment", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -608,7 +608,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -688,7 +688,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -767,7 +767,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -864,7 +864,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -943,7 +943,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1011,7 +1011,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1044,7 +1044,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1077,7 +1077,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1110,7 +1110,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1143,7 +1143,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1177,7 +1177,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1210,7 +1210,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1243,7 +1243,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1276,7 +1276,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1310,7 +1310,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1343,7 +1343,7 @@ if (!class_exists("ExperimentServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServingStatus", false)) {
   /**
    * Experiment is currently active and receiving traffic
    * @package Google_Api_Ads_AdWords_v201309
@@ -1376,7 +1376,7 @@ if (!class_exists("ExperimentServingStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentStatus", false)) {
   /**
    * Experiment status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1409,7 +1409,7 @@ if (!class_exists("ExperimentStatus", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1442,7 +1442,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1475,7 +1475,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1508,7 +1508,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1541,7 +1541,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1574,7 +1574,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1607,7 +1607,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1640,7 +1640,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1673,7 +1673,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1706,7 +1706,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1739,7 +1739,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1773,7 +1773,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1806,7 +1806,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1839,7 +1839,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1872,7 +1872,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1905,7 +1905,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1938,7 +1938,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1971,7 +1971,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2004,7 +2004,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2037,7 +2037,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2070,7 +2070,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2103,7 +2103,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2136,7 +2136,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2185,7 +2185,7 @@ if (!class_exists("ExperimentServiceGet", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2225,7 +2225,7 @@ if (!class_exists("ExperimentServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2279,7 +2279,7 @@ if (!class_exists("ExperimentServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2319,7 +2319,7 @@ if (!class_exists("ExperimentServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2364,7 +2364,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2409,7 +2409,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2454,7 +2454,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2499,7 +2499,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2544,7 +2544,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2589,7 +2589,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2634,7 +2634,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2680,7 +2680,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentServiceError", false)) {
   /**
    * Base error class for Experiment Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2725,7 +2725,7 @@ if (!class_exists("ExperimentServiceError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2770,7 +2770,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2817,7 +2817,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2862,7 +2862,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2907,7 +2907,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2952,7 +2952,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2997,7 +2997,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3042,7 +3042,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3087,7 +3087,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3132,7 +3132,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3184,7 +3184,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3229,7 +3229,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3295,7 +3295,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3340,7 +3340,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3385,7 +3385,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3431,7 +3431,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3476,7 +3476,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3521,7 +3521,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3566,7 +3566,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3612,7 +3612,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3657,7 +3657,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ExperimentOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentOperation", false)) {
   /**
    * Operation for adding, updating or removing operations. For removing,
    * use SET and mark status as DELETED.
@@ -3701,7 +3701,7 @@ if (!class_exists("ExperimentOperation", false)) {
   }
 }
 
-if (!class_exists("ExperimentPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentPage", false)) {
   /**
    * Contains a subset of experiment resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.campaign.ExperimentService#get} call.
@@ -3745,7 +3745,7 @@ if (!class_exists("ExperimentPage", false)) {
   }
 }
 
-if (!class_exists("ExperimentReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentReturnValue", false)) {
   /**
    * A container for return values from the ExperimentService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3787,7 +3787,7 @@ if (!class_exists("ExperimentReturnValue", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3836,7 +3836,7 @@ if (!class_exists("ExperimentService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ExperimentService extends AdWordsSoapClient {
+  class ExperimentService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ExperimentService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3853,91 +3853,91 @@ if (!class_exists("ExperimentService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "ExperimentServiceError" => "ExperimentServiceError",
-      "ExperimentSummaryStats" => "ExperimentSummaryStats",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "Experiment" => "Experiment",
-      "ExperimentOperation" => "ExperimentOperation",
-      "ExperimentPage" => "ExperimentPage",
-      "ExperimentReturnValue" => "ExperimentReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentServiceError.Reason" => "ExperimentServiceErrorReason",
-      "ExperimentServingStatus" => "ExperimentServingStatus",
-      "ExperimentStatus" => "ExperimentStatus",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "ExperimentServiceGet",
-      "getResponse" => "ExperimentServiceGetResponse",
-      "mutate" => "ExperimentServiceMutate",
-      "mutateResponse" => "ExperimentServiceMutateResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201309\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ExperimentServiceError" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceError",
+      "ExperimentSummaryStats" => "Google_Api_Ads_AdWords_v201309\\ExperimentSummaryStats",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201309\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "Experiment" => "Google_Api_Ads_AdWords_v201309\\Experiment",
+      "ExperimentOperation" => "Google_Api_Ads_AdWords_v201309\\ExperimentOperation",
+      "ExperimentPage" => "Google_Api_Ads_AdWords_v201309\\ExperimentPage",
+      "ExperimentReturnValue" => "Google_Api_Ads_AdWords_v201309\\ExperimentReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ExperimentServiceError.Reason" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceErrorReason",
+      "ExperimentServingStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentServingStatus",
+      "ExperimentStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentStatus",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\ExperimentServiceMutateResponse",
     );
 
 
@@ -3992,3 +3992,4 @@ if (!class_exists("ExperimentService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ExpressBusinessService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ExpressBusinessService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * 
@@ -116,7 +116,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -174,7 +174,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -226,7 +226,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * 
@@ -277,7 +277,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -381,7 +381,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -439,7 +439,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -518,7 +518,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -590,7 +590,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -691,7 +691,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -774,7 +774,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -846,7 +846,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -930,7 +930,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1013,7 +1013,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -1050,7 +1050,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -1087,7 +1087,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1125,7 +1125,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -1162,7 +1162,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1199,7 +1199,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1236,7 +1236,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1273,7 +1273,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1310,7 +1310,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1347,7 +1347,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -1384,7 +1384,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1421,7 +1421,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1458,7 +1458,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1495,7 +1495,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1532,7 +1532,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1570,7 +1570,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1607,7 +1607,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1644,7 +1644,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1681,7 +1681,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1718,7 +1718,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1755,7 +1755,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1792,7 +1792,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1829,7 +1829,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1866,7 +1866,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1903,7 +1903,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1940,7 +1940,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessError", false)) {
   /**
    * Express business related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1985,7 +1985,7 @@ if (!class_exists("ExpressBusinessError", false)) {
   }
 }
 
-if (!class_exists("PhoneNumber", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PhoneNumber", false)) {
   /**
    * Phone number which contains the phone number string plus the region that the number is to be
    * from.
@@ -2033,7 +2033,7 @@ if (!class_exists("PhoneNumber", false)) {
   }
 }
 
-if (!class_exists("ExpressBusiness", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusiness", false)) {
   /**
    * Information about an AdWords Express business.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2115,7 +2115,7 @@ if (!class_exists("ExpressBusiness", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessOperation", false)) {
   /**
    * A typed {@link Operation} class that uses an instance of {@link ExpressBusiness} as its operand.
    * 
@@ -2162,7 +2162,7 @@ if (!class_exists("ExpressBusinessOperation", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2198,7 +2198,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessStatus", false)) {
   /**
    * Possible statusus of this business.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2231,7 +2231,7 @@ if (!class_exists("ExpressBusinessStatus", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessErrorReason", false)) {
   /**
    * Reason behind the {@code BusinessError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2264,7 +2264,7 @@ if (!class_exists("ExpressBusinessErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCode", false)) {
   /**
    * A region (country, territory, continent, etc), as defined by Unicode's
    * "CLDR", itself based on ISO 3166 (UN country codes).
@@ -2363,7 +2363,7 @@ if (!class_exists("RegionCode", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2410,7 +2410,7 @@ if (!class_exists("ExpressBusinessServiceGet", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2450,7 +2450,7 @@ if (!class_exists("ExpressBusinessServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceMutate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: ADD, SET.</span>
@@ -2499,7 +2499,7 @@ if (!class_exists("ExpressBusinessServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2539,7 +2539,7 @@ if (!class_exists("ExpressBusinessServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2588,7 +2588,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2637,7 +2637,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -2686,7 +2686,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -2735,7 +2735,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -2784,7 +2784,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -2833,7 +2833,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2884,7 +2884,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -2933,7 +2933,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -2982,7 +2982,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -3031,7 +3031,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -3080,7 +3080,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3129,7 +3129,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3178,7 +3178,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3248,7 +3248,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3297,7 +3297,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3346,7 +3346,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3396,7 +3396,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3445,7 +3445,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3494,7 +3494,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3543,7 +3543,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3593,7 +3593,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3642,7 +3642,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3689,7 +3689,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressBusinessPage", false)) {
   /**
    * Contains a page of {@link ExpressBusiness}es with no stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3736,7 +3736,7 @@ if (!class_exists("ExpressBusinessService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ExpressBusinessService extends AdWordsSoapClient {
+  class ExpressBusinessService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ExpressBusinessService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201309";
@@ -3753,81 +3753,81 @@ if (!class_exists("ExpressBusinessService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ExpressBusinessError" => "ExpressBusinessError",
-      "PhoneNumber" => "PhoneNumber",
-      "ExpressBusiness" => "ExpressBusiness",
-      "ExpressBusinessOperation" => "ExpressBusinessOperation",
-      "ExpressBusinessPage" => "ExpressBusinessPage",
-      "NoStatsPage" => "NoStatsPage",
-      "ExpressBusiness.Status" => "ExpressBusinessStatus",
-      "ExpressBusinessError.Reason" => "ExpressBusinessErrorReason",
-      "RegionCode" => "RegionCode",
-      "get" => "ExpressBusinessServiceGet",
-      "getResponse" => "ExpressBusinessServiceGetResponse",
-      "mutate" => "ExpressBusinessServiceMutate",
-      "mutateResponse" => "ExpressBusinessServiceMutateResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "Date" => "Google_Api_Ads_AdWords_v201309\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "ExpressBusinessError" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessError",
+      "PhoneNumber" => "Google_Api_Ads_AdWords_v201309\\PhoneNumber",
+      "ExpressBusiness" => "Google_Api_Ads_AdWords_v201309\\ExpressBusiness",
+      "ExpressBusinessOperation" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessOperation",
+      "ExpressBusinessPage" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessPage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "ExpressBusiness.Status" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessStatus",
+      "ExpressBusinessError.Reason" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessErrorReason",
+      "RegionCode" => "Google_Api_Ads_AdWords_v201309\\RegionCode",
+      "get" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\ExpressBusinessServiceMutateResponse",
     );
 
 
@@ -3875,3 +3875,4 @@ if (!class_exists("ExpressBusinessService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/FeedItemService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/FeedItemService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemAttributeError", false)) {
   /**
    * Contains validation error details for a set of feed attributes.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("FeedItemAttributeError", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemAttributeValue", false)) {
   /**
    * Represents a feed item's value for a particular feed attribute. A feed item's value is
    * composed of a collection of these attribute values.
@@ -194,7 +194,7 @@ if (!class_exists("FeedItemAttributeValue", false)) {
   }
 }
 
-if (!class_exists("FeedItemDevicePreference", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemDevicePreference", false)) {
   /**
    * Represents a FeedItem device preference.
    * @package Google_Api_Ads_AdWords_v201309
@@ -234,7 +234,7 @@ if (!class_exists("FeedItemDevicePreference", false)) {
   }
 }
 
-if (!class_exists("FeedItemSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemSchedule", false)) {
   /**
    * Represents a FeedItem schedule, which specifies a time interval on a given day
    * when the feed item may serve. The FeedItemSchedule times are in the account's time zone.
@@ -303,7 +303,7 @@ if (!class_exists("FeedItemSchedule", false)) {
   }
 }
 
-if (!class_exists("FeedItemScheduling", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemScheduling", false)) {
   /**
    * Represents a collection of FeedItem schedules specifying all time intervals for which
    * the feed item may serve. Any time range not covered by the specified FeedItemSchedules will
@@ -345,7 +345,7 @@ if (!class_exists("FeedItemScheduling", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -392,7 +392,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -441,7 +441,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -495,7 +495,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -570,7 +570,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -638,7 +638,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetail", false)) {
   /**
    * Contains offline-validation and approval results for a given FeedItem and FeedMapping. Each
    * validation detail indicates any issues found on the feed item when used in the context
@@ -701,7 +701,7 @@ if (!class_exists("FeedItemValidationDetail", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -798,7 +798,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -877,7 +877,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("FeedItem", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItem", false)) {
   /**
    * Represents an item in a feed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -973,7 +973,7 @@ if (!class_exists("FeedItem", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1045,7 +1045,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1125,7 +1125,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1193,7 +1193,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1272,7 +1272,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1305,7 +1305,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1338,7 +1338,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1371,7 +1371,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1405,7 +1405,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1438,7 +1438,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1471,7 +1471,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1504,7 +1504,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1537,7 +1537,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1570,7 +1570,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1604,7 +1604,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemStatus", false)) {
   /**
    * Feed item is active
    * @package Google_Api_Ads_AdWords_v201309
@@ -1637,7 +1637,7 @@ if (!class_exists("FeedItemStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemErrorReason", false)) {
   /**
    * The reasons for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1670,7 +1670,7 @@ if (!class_exists("FeedItemErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailApprovalStatus", false)) {
   /**
    * Feed item approval status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1703,7 +1703,7 @@ if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailValidationStatus", false)) {
   /**
    * Feed item validation status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1736,7 +1736,7 @@ if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1769,7 +1769,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1802,7 +1802,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201309
@@ -1835,7 +1835,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1868,7 +1868,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1901,7 +1901,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1934,7 +1934,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1967,7 +1967,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2000,7 +2000,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2033,7 +2033,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2067,7 +2067,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2100,7 +2100,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2133,7 +2133,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2166,7 +2166,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2199,7 +2199,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2232,7 +2232,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2265,7 +2265,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2298,7 +2298,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2331,7 +2331,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2364,7 +2364,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2413,7 +2413,7 @@ if (!class_exists("FeedItemServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2453,7 +2453,7 @@ if (!class_exists("FeedItemServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2504,7 +2504,7 @@ if (!class_exists("FeedItemServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2544,7 +2544,7 @@ if (!class_exists("FeedItemServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2589,7 +2589,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2634,7 +2634,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2679,7 +2679,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2724,7 +2724,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2769,7 +2769,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2814,7 +2814,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2888,7 +2888,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2934,7 +2934,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedItemError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemError", false)) {
   /**
    * FeedItemService related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2979,7 +2979,7 @@ if (!class_exists("FeedItemError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3024,7 +3024,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3071,7 +3071,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3116,7 +3116,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3161,7 +3161,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3206,7 +3206,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3251,7 +3251,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3296,7 +3296,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3341,7 +3341,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3407,7 +3407,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3452,7 +3452,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3498,7 +3498,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3543,7 +3543,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3588,7 +3588,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3633,7 +3633,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3679,7 +3679,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3724,7 +3724,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3767,7 +3767,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedItemOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemOperation", false)) {
   /**
    * FeedItem service mutate operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3810,7 +3810,7 @@ if (!class_exists("FeedItemOperation", false)) {
   }
 }
 
-if (!class_exists("FeedItemReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemReturnValue", false)) {
   /**
    * A container for return values from FeedItemService.mutate().
    * @package Google_Api_Ads_AdWords_v201309
@@ -3859,7 +3859,7 @@ if (!class_exists("FeedItemReturnValue", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3895,7 +3895,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("FeedItemPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemPage", false)) {
   /**
    * Contains a subset of feed items resulting from a {@link FeedItemService#get} call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3942,7 +3942,7 @@ if (!class_exists("FeedItemService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class FeedItemService extends AdWordsSoapClient {
+  class FeedItemService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedItemService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3959,92 +3959,92 @@ if (!class_exists("FeedItemService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedItemAttributeError" => "FeedItemAttributeError",
-      "FeedItemAttributeValue" => "FeedItemAttributeValue",
-      "FeedItemDevicePreference" => "FeedItemDevicePreference",
-      "FeedItemError" => "FeedItemError",
-      "FeedItemSchedule" => "FeedItemSchedule",
-      "FeedItemScheduling" => "FeedItemScheduling",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "FeedItemValidationDetail" => "FeedItemValidationDetail",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "FeedItem" => "FeedItem",
-      "FeedItemOperation" => "FeedItemOperation",
-      "FeedItemPage" => "FeedItemPage",
-      "FeedItemReturnValue" => "FeedItemReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "Selector" => "Selector",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "FeedItem.Status" => "FeedItemStatus",
-      "FeedItemError.Reason" => "FeedItemErrorReason",
-      "FeedItemValidationDetail.ApprovalStatus" => "FeedItemValidationDetailApprovalStatus",
-      "FeedItemValidationDetail.ValidationStatus" => "FeedItemValidationDetailValidationStatus",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MinuteOfHour" => "MinuteOfHour",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedItemServiceGet",
-      "getResponse" => "FeedItemServiceGetResponse",
-      "mutate" => "FeedItemServiceMutate",
-      "mutateResponse" => "FeedItemServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "FeedItemAttributeError" => "Google_Api_Ads_AdWords_v201309\\FeedItemAttributeError",
+      "FeedItemAttributeValue" => "Google_Api_Ads_AdWords_v201309\\FeedItemAttributeValue",
+      "FeedItemDevicePreference" => "Google_Api_Ads_AdWords_v201309\\FeedItemDevicePreference",
+      "FeedItemError" => "Google_Api_Ads_AdWords_v201309\\FeedItemError",
+      "FeedItemSchedule" => "Google_Api_Ads_AdWords_v201309\\FeedItemSchedule",
+      "FeedItemScheduling" => "Google_Api_Ads_AdWords_v201309\\FeedItemScheduling",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "FeedItemValidationDetail" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetail",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "FeedItem" => "Google_Api_Ads_AdWords_v201309\\FeedItem",
+      "FeedItemOperation" => "Google_Api_Ads_AdWords_v201309\\FeedItemOperation",
+      "FeedItemPage" => "Google_Api_Ads_AdWords_v201309\\FeedItemPage",
+      "FeedItemReturnValue" => "Google_Api_Ads_AdWords_v201309\\FeedItemReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201309\\DayOfWeek",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "FeedItem.Status" => "Google_Api_Ads_AdWords_v201309\\FeedItemStatus",
+      "FeedItemError.Reason" => "Google_Api_Ads_AdWords_v201309\\FeedItemErrorReason",
+      "FeedItemValidationDetail.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailApprovalStatus",
+      "FeedItemValidationDetail.ValidationStatus" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailValidationStatus",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201309\\MinuteOfHour",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\FeedItemServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\FeedItemServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\FeedItemServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\FeedItemServiceMutateResponse",
     );
 
 
@@ -4096,3 +4096,4 @@ if (!class_exists("FeedItemService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/FeedMappingService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/FeedMappingService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AttributeFieldMapping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AttributeFieldMapping", false)) {
   /**
    * Represents a mapping between a feed attribute and a placeholder field.
    * 
@@ -82,7 +82,7 @@ if (!class_exists("AttributeFieldMapping", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -130,7 +130,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedMapping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMapping", false)) {
   /**
    * A FeedMapping represents a mapping between feed attributes in a specific feed
    * and placeholder fields for a specific placeholder type. This will tell the
@@ -207,7 +207,7 @@ if (!class_exists("FeedMapping", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -279,7 +279,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -359,7 +359,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -406,7 +406,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -485,7 +485,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -534,7 +534,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -588,7 +588,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -663,7 +663,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -731,7 +731,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -828,7 +828,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -907,7 +907,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -975,7 +975,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1008,7 +1008,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1041,7 +1041,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1075,7 +1075,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1108,7 +1108,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1141,7 +1141,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1175,7 +1175,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedMappingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingStatus", false)) {
   /**
    * This mapping is used in feeds.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1208,7 +1208,7 @@ if (!class_exists("FeedMappingStatus", false)) {
   }
 }
 
-if (!class_exists("FeedMappingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingErrorReason", false)) {
   /**
    * The given placeholder field does not exist.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1241,7 +1241,7 @@ if (!class_exists("FeedMappingErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1274,7 +1274,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1307,7 +1307,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1340,7 +1340,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1373,7 +1373,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1406,7 +1406,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1439,7 +1439,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1472,7 +1472,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1505,7 +1505,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1539,7 +1539,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1572,7 +1572,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1605,7 +1605,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1638,7 +1638,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1671,7 +1671,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1704,7 +1704,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1737,7 +1737,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1770,7 +1770,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1803,7 +1803,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1836,7 +1836,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1885,7 +1885,7 @@ if (!class_exists("FeedMappingServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1925,7 +1925,7 @@ if (!class_exists("FeedMappingServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -1976,7 +1976,7 @@ if (!class_exists("FeedMappingServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2016,7 +2016,7 @@ if (!class_exists("FeedMappingServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2061,7 +2061,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2106,7 +2106,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2151,7 +2151,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2196,7 +2196,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2242,7 +2242,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedMappingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingError", false)) {
   /**
    * Errors caused by invalid usage of FeedMappingService
    * @package Google_Api_Ads_AdWords_v201309
@@ -2287,7 +2287,7 @@ if (!class_exists("FeedMappingError", false)) {
   }
 }
 
-if (!class_exists("FeedMappingOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingOperation", false)) {
   /**
    * Operation used to create a FeedMapping.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2330,7 +2330,7 @@ if (!class_exists("FeedMappingOperation", false)) {
   }
 }
 
-if (!class_exists("FeedMappingReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingReturnValue", false)) {
   /**
    * The result of a call to {@link FeedMappingService#mutate}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2372,7 +2372,7 @@ if (!class_exists("FeedMappingReturnValue", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2417,7 +2417,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2464,7 +2464,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2509,7 +2509,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2554,7 +2554,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2590,7 +2590,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2635,7 +2635,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2680,7 +2680,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2725,7 +2725,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2770,7 +2770,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2836,7 +2836,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2881,7 +2881,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2927,7 +2927,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2972,7 +2972,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3017,7 +3017,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3062,7 +3062,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3108,7 +3108,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3153,7 +3153,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3196,7 +3196,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedMappingPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedMappingPage", false)) {
   /**
    * The result of a call to {@link FeedMappingService#get}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3243,7 +3243,7 @@ if (!class_exists("FeedMappingService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class FeedMappingService extends AdWordsSoapClient {
+  class FeedMappingService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedMappingService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3260,77 +3260,77 @@ if (!class_exists("FeedMappingService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AttributeFieldMapping" => "AttributeFieldMapping",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedMapping" => "FeedMapping",
-      "FeedMappingError" => "FeedMappingError",
-      "FeedMappingOperation" => "FeedMappingOperation",
-      "FeedMappingPage" => "FeedMappingPage",
-      "FeedMappingReturnValue" => "FeedMappingReturnValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "FeedMapping.Status" => "FeedMappingStatus",
-      "FeedMappingError.Reason" => "FeedMappingErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedMappingServiceGet",
-      "getResponse" => "FeedMappingServiceGetResponse",
-      "mutate" => "FeedMappingServiceMutate",
-      "mutateResponse" => "FeedMappingServiceMutateResponse",
+      "AttributeFieldMapping" => "Google_Api_Ads_AdWords_v201309\\AttributeFieldMapping",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "FeedMapping" => "Google_Api_Ads_AdWords_v201309\\FeedMapping",
+      "FeedMappingError" => "Google_Api_Ads_AdWords_v201309\\FeedMappingError",
+      "FeedMappingOperation" => "Google_Api_Ads_AdWords_v201309\\FeedMappingOperation",
+      "FeedMappingPage" => "Google_Api_Ads_AdWords_v201309\\FeedMappingPage",
+      "FeedMappingReturnValue" => "Google_Api_Ads_AdWords_v201309\\FeedMappingReturnValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "FeedMapping.Status" => "Google_Api_Ads_AdWords_v201309\\FeedMappingStatus",
+      "FeedMappingError.Reason" => "Google_Api_Ads_AdWords_v201309\\FeedMappingErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\FeedMappingServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\FeedMappingServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\FeedMappingServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\FeedMappingServiceMutateResponse",
     );
 
 
@@ -3382,3 +3382,4 @@ if (!class_exists("FeedMappingService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/FeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/FeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedAttribute", false)) {
   /**
    * FeedAttributes define the types of data expected to be present in a Feed. A single FeedAttribute
    * specifies the expected type of the FeedItemAttributes with the same FeedAttributeId. Optionally,
@@ -141,7 +141,7 @@ if (!class_exists("FeedAttribute", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -188,7 +188,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -237,7 +237,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -291,7 +291,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -366,7 +366,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -434,7 +434,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -531,7 +531,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -610,7 +610,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Feed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Feed", false)) {
   /**
    * A Feed identifies a source of data and its schema. The data for the Feed can either be
    * user-entered via the FeedItemService or system-generated, in which case the data is provided
@@ -680,7 +680,7 @@ if (!class_exists("Feed", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -752,7 +752,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -832,7 +832,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201309
@@ -911,7 +911,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -979,7 +979,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1012,7 +1012,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1045,7 +1045,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1079,7 +1079,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1112,7 +1112,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1145,7 +1145,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1178,7 +1178,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1212,7 +1212,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedOrigin", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedOrigin", false)) {
   /**
    * Used to Specify who manages the {@link FeedAttribute}s for the {@link Feed}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1245,7 +1245,7 @@ if (!class_exists("FeedOrigin", false)) {
   }
 }
 
-if (!class_exists("FeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedStatus", false)) {
   /**
    * Status of the Feed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1278,7 +1278,7 @@ if (!class_exists("FeedStatus", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedAttributeType", false)) {
   /**
    * Possible data types.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1311,7 +1311,7 @@ if (!class_exists("FeedAttributeType", false)) {
   }
 }
 
-if (!class_exists("FeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1344,7 +1344,7 @@ if (!class_exists("FeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1377,7 +1377,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1410,7 +1410,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1443,7 +1443,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1476,7 +1476,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1509,7 +1509,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1542,7 +1542,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1575,7 +1575,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1608,7 +1608,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1641,7 +1641,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1675,7 +1675,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1708,7 +1708,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1741,7 +1741,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1774,7 +1774,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1807,7 +1807,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1840,7 +1840,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1873,7 +1873,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1906,7 +1906,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1939,7 +1939,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1972,7 +1972,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2021,7 +2021,7 @@ if (!class_exists("FeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2061,7 +2061,7 @@ if (!class_exists("FeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2112,7 +2112,7 @@ if (!class_exists("FeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2152,7 +2152,7 @@ if (!class_exists("FeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2197,7 +2197,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2242,7 +2242,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2287,7 +2287,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2332,7 +2332,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2406,7 +2406,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2452,7 +2452,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedError", false)) {
   /**
    * An error caused by an invalid Feed in a FeedService request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2497,7 +2497,7 @@ if (!class_exists("FeedError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2542,7 +2542,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2589,7 +2589,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2634,7 +2634,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2679,7 +2679,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2724,7 +2724,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2769,7 +2769,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2814,7 +2814,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2859,7 +2859,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2904,7 +2904,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2970,7 +2970,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3015,7 +3015,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3061,7 +3061,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3106,7 +3106,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3151,7 +3151,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3196,7 +3196,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3242,7 +3242,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3287,7 +3287,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3330,7 +3330,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedOperation", false)) {
   /**
    * Operation used to create or mutate a Feed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3373,7 +3373,7 @@ if (!class_exists("FeedOperation", false)) {
   }
 }
 
-if (!class_exists("FeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedReturnValue", false)) {
   /**
    * The result of a call to FeedService#mutate.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3415,7 +3415,7 @@ if (!class_exists("FeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3451,7 +3451,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("FeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedPage", false)) {
   /**
    * The result of a call to FeedService#get.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3498,7 +3498,7 @@ if (!class_exists("FeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class FeedService extends AdWordsSoapClient {
+  class FeedService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3515,83 +3515,83 @@ if (!class_exists("FeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttribute" => "FeedAttribute",
-      "FeedError" => "FeedError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Feed" => "Feed",
-      "FeedOperation" => "FeedOperation",
-      "FeedPage" => "FeedPage",
-      "FeedReturnValue" => "FeedReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Feed.Origin" => "FeedOrigin",
-      "Feed.Status" => "FeedStatus",
-      "FeedAttribute.Type" => "FeedAttributeType",
-      "FeedError.Reason" => "FeedErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedServiceGet",
-      "getResponse" => "FeedServiceGetResponse",
-      "mutate" => "FeedServiceMutate",
-      "mutateResponse" => "FeedServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "FeedAttribute" => "Google_Api_Ads_AdWords_v201309\\FeedAttribute",
+      "FeedError" => "Google_Api_Ads_AdWords_v201309\\FeedError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Feed" => "Google_Api_Ads_AdWords_v201309\\Feed",
+      "FeedOperation" => "Google_Api_Ads_AdWords_v201309\\FeedOperation",
+      "FeedPage" => "Google_Api_Ads_AdWords_v201309\\FeedPage",
+      "FeedReturnValue" => "Google_Api_Ads_AdWords_v201309\\FeedReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "Feed.Origin" => "Google_Api_Ads_AdWords_v201309\\FeedOrigin",
+      "Feed.Status" => "Google_Api_Ads_AdWords_v201309\\FeedStatus",
+      "FeedAttribute.Type" => "Google_Api_Ads_AdWords_v201309\\FeedAttributeType",
+      "FeedError.Reason" => "Google_Api_Ads_AdWords_v201309\\FeedErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\FeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\FeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\FeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\FeedServiceMutateResponse",
     );
 
 
@@ -3643,3 +3643,4 @@ if (!class_exists("FeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/GeoLocationService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/GeoLocationService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201309
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("GeoLocationSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocationSelector", false)) {
   /**
    * A selector used to fetch geographic coordinates for given addresses.
    * @package Google_Api_Ads_AdWords_v201309
@@ -152,7 +152,7 @@ if (!class_exists("GeoLocationSelector", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201309
@@ -199,7 +199,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -274,7 +274,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -342,7 +342,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("GeoLocation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocation", false)) {
   /**
    * Class representing a location with its geographic coordinates.
    * @package Google_Api_Ads_AdWords_v201309
@@ -435,7 +435,7 @@ if (!class_exists("GeoLocation", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -532,7 +532,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -611,7 +611,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -644,7 +644,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -677,7 +677,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -711,7 +711,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -744,7 +744,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -777,7 +777,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoLocationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocationErrorReason", false)) {
   /**
    * The reasons for the geolocation errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -810,7 +810,7 @@ if (!class_exists("GeoLocationErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -843,7 +843,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -876,7 +876,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -909,7 +909,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -942,7 +942,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -975,7 +975,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1009,7 +1009,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1042,7 +1042,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1075,7 +1075,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1108,7 +1108,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1141,7 +1141,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1174,7 +1174,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1207,7 +1207,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1240,7 +1240,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1273,7 +1273,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoLocationServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocationServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1322,7 +1322,7 @@ if (!class_exists("GeoLocationServiceGet", false)) {
   }
 }
 
-if (!class_exists("GeoLocationServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocationServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1362,7 +1362,7 @@ if (!class_exists("GeoLocationServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1407,7 +1407,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1452,7 +1452,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1497,7 +1497,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1542,7 +1542,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("GeoLocationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoLocationError", false)) {
   /**
    * Errors for {@link GeoLocationService}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1587,7 +1587,7 @@ if (!class_exists("GeoLocationError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1632,7 +1632,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1679,7 +1679,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("InvalidGeoLocation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InvalidGeoLocation", false)) {
   /**
    * Invalid GeoLocation object.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1717,7 +1717,7 @@ if (!class_exists("InvalidGeoLocation", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1762,7 +1762,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1807,7 +1807,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1852,7 +1852,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1897,7 +1897,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1942,7 +1942,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2008,7 +2008,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2053,7 +2053,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2098,7 +2098,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2144,7 +2144,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2189,7 +2189,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2234,7 +2234,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2280,7 +2280,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2325,7 +2325,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2374,7 +2374,7 @@ if (!class_exists("GeoLocationService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class GeoLocationService extends AdWordsSoapClient {
+  class GeoLocationService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "GeoLocationService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -2391,58 +2391,58 @@ if (!class_exists("GeoLocationService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DistinctError" => "DistinctError",
-      "GeoLocationError" => "GeoLocationError",
-      "GeoLocationSelector" => "GeoLocationSelector",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "InvalidGeoLocation" => "InvalidGeoLocation",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "GeoLocation" => "GeoLocation",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "GeoLocationError.Reason" => "GeoLocationErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "GeoLocationServiceGet",
-      "getResponse" => "GeoLocationServiceGetResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "GeoLocationError" => "Google_Api_Ads_AdWords_v201309\\GeoLocationError",
+      "GeoLocationSelector" => "Google_Api_Ads_AdWords_v201309\\GeoLocationSelector",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "InvalidGeoLocation" => "Google_Api_Ads_AdWords_v201309\\InvalidGeoLocation",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "GeoLocation" => "Google_Api_Ads_AdWords_v201309\\GeoLocation",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "GeoLocationError.Reason" => "Google_Api_Ads_AdWords_v201309\\GeoLocationErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\GeoLocationServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\GeoLocationServiceGetResponse",
     );
 
 
@@ -2475,3 +2475,4 @@ if (!class_exists("GeoLocationService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/LocationCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/LocationCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -127,7 +127,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -206,7 +206,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -251,7 +251,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -296,7 +296,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -341,7 +341,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -428,7 +428,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201309
@@ -500,7 +500,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -545,7 +545,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Date", false)) {
   /**
    * Represents a date.
    * @package Google_Api_Ads_AdWords_v201309
@@ -599,7 +599,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -644,7 +644,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -692,7 +692,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -737,7 +737,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -782,7 +782,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -829,7 +829,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -881,10 +881,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -948,7 +948,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("LocationCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationCriterion", false)) {
   /**
    * Represents data that encapsulates a location criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1023,7 +1023,7 @@ if (!class_exists("LocationCriterion", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceError", false)) {
   /**
    * Represents errors thrown by the {@link LocationCriterionService#get} operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1068,7 +1068,7 @@ if (!class_exists("LocationCriterionServiceError", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1122,7 +1122,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1174,7 +1174,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1219,7 +1219,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1264,7 +1264,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1309,7 +1309,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1354,7 +1354,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1401,7 +1401,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1450,7 +1450,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1496,7 +1496,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1550,7 +1550,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1605,7 +1605,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1653,7 +1653,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1693,7 +1693,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1738,7 +1738,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1783,7 +1783,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1849,7 +1849,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1894,7 +1894,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1939,7 +1939,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1985,7 +1985,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2030,7 +2030,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2098,7 +2098,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2143,7 +2143,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2188,7 +2188,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2263,7 +2263,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2331,7 +2331,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2377,7 +2377,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2429,7 +2429,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2488,7 +2488,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2551,7 +2551,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -2611,7 +2611,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -2663,7 +2663,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -2713,7 +2713,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2746,7 +2746,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2779,7 +2779,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2812,7 +2812,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2846,7 +2846,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2879,7 +2879,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2912,7 +2912,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2945,7 +2945,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2978,7 +2978,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3011,7 +3011,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3044,7 +3044,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3078,7 +3078,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceErrorReason", false)) {
   /**
    * Reasons for error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3111,7 +3111,7 @@ if (!class_exists("LocationCriterionServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3144,7 +3144,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3177,7 +3177,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3210,7 +3210,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3243,7 +3243,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3276,7 +3276,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3309,7 +3309,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3343,7 +3343,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3376,7 +3376,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3409,7 +3409,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3442,7 +3442,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3475,7 +3475,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3508,7 +3508,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3541,7 +3541,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3574,7 +3574,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3607,7 +3607,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3640,7 +3640,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3673,7 +3673,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3706,7 +3706,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3739,7 +3739,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3787,7 +3787,7 @@ if (!class_exists("LocationCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3827,7 +3827,7 @@ if (!class_exists("LocationCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3872,7 +3872,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3921,7 +3921,7 @@ if (!class_exists("LocationCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class LocationCriterionService extends AdWordsSoapClient {
+  class LocationCriterionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "LocationCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3938,91 +3938,91 @@ if (!class_exists("LocationCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Criterion" => "Criterion",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Location" => "Location",
-      "LocationCriterion" => "LocationCriterion",
-      "LocationCriterionServiceError" => "LocationCriterionServiceError",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationCriterionServiceError.Reason" => "LocationCriterionServiceErrorReason",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "LocationCriterionServiceGet",
-      "getResponse" => "LocationCriterionServiceGetResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201309\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "LocationCriterion" => "Google_Api_Ads_AdWords_v201309\\LocationCriterion",
+      "LocationCriterionServiceError" => "Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceError",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "LocationCriterionServiceError.Reason" => "Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceErrorReason",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\LocationCriterionServiceGetResponse",
     );
 
 
@@ -4054,3 +4054,4 @@ if (!class_exists("LocationCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ManagedCustomerService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ManagedCustomerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -82,7 +82,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -133,7 +133,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -186,7 +186,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -244,7 +244,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -323,7 +323,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -395,7 +395,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -496,7 +496,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -579,7 +579,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -651,7 +651,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -735,7 +735,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -818,7 +818,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -855,7 +855,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -892,7 +892,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -930,7 +930,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -967,7 +967,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1004,7 +1004,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1041,7 +1041,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1078,7 +1078,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1115,7 +1115,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1152,7 +1152,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -1189,7 +1189,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1226,7 +1226,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1263,7 +1263,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1300,7 +1300,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1337,7 +1337,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1375,7 +1375,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1412,7 +1412,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1449,7 +1449,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1486,7 +1486,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1523,7 +1523,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1560,7 +1560,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1597,7 +1597,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1634,7 +1634,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1671,7 +1671,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1708,7 +1708,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1745,7 +1745,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceError", false)) {
   /**
    * Error for {@link ManagedCustomerService}
    * @package Google_Api_Ads_AdWords_v201309
@@ -1797,7 +1797,7 @@ if (!class_exists("ManagedCustomerServiceError", false)) {
   }
 }
 
-if (!class_exists("PendingInvitationSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PendingInvitationSelector", false)) {
   /**
    * Selector for getPendingInvitations method.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1844,7 +1844,7 @@ if (!class_exists("PendingInvitationSelector", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerLink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerLink", false)) {
   /**
    * Represents an AdWords manager-client link.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1905,7 +1905,7 @@ if (!class_exists("ManagedCustomerLink", false)) {
   }
 }
 
-if (!class_exists("LinkOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LinkOperation", false)) {
   /**
    * Operation for modifying ManagedCustomer links. See {@link ManagedCustomerService#mutateLink}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1948,7 +1948,7 @@ if (!class_exists("LinkOperation", false)) {
   }
 }
 
-if (!class_exists("MoveOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MoveOperation", false)) {
   /**
    * Operation for moving ManagedCustomer links. See {@link ManagedCustomerService#mutateManager}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1998,7 +1998,7 @@ if (!class_exists("MoveOperation", false)) {
   }
 }
 
-if (!class_exists("MutateLinkResults", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateLinkResults", false)) {
   /**
    * Results of a {@link ManagedCustomerService#mutateLink} call which changes
    * manager/client links.
@@ -2039,7 +2039,7 @@ if (!class_exists("MutateLinkResults", false)) {
   }
 }
 
-if (!class_exists("MutateManagerResults", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateManagerResults", false)) {
   /**
    * Results of a {@link ManagedCustomerService#mutateManager} call, which moves client customers to
    * new managers.
@@ -2080,7 +2080,7 @@ if (!class_exists("MutateManagerResults", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomer", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomer", false)) {
   /**
    * Data object that represents a managed customer.  Member of {@link ManagedCustomerPage}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2169,7 +2169,7 @@ if (!class_exists("ManagedCustomer", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerOperation", false)) {
   /**
    * An operation on a managed customer.
    * <p class="note"><b>Note:</b> only <code>ADD</code> operator is supported.</p>
@@ -2213,7 +2213,7 @@ if (!class_exists("ManagedCustomerOperation", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerPage", false)) {
   /**
    * Return result of {@link ManagedCustomerService}
    * @package Google_Api_Ads_AdWords_v201309
@@ -2263,7 +2263,7 @@ if (!class_exists("ManagedCustomerPage", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerReturnValue", false)) {
   /**
    * A container for return values from the ManagedCustomerService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2303,7 +2303,7 @@ if (!class_exists("ManagedCustomerReturnValue", false)) {
   }
 }
 
-if (!class_exists("PendingInvitation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PendingInvitation", false)) {
   /**
    * Pending invitation result for the getPendingInvitations method.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2364,7 +2364,7 @@ if (!class_exists("PendingInvitation", false)) {
   }
 }
 
-if (!class_exists("LinkStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LinkStatus", false)) {
   /**
    * These status values match the values in the ServicedAccounts.Status column.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2397,7 +2397,7 @@ if (!class_exists("LinkStatus", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceErrorReason", false)) {
   /**
    * Unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2430,7 +2430,7 @@ if (!class_exists("ManagedCustomerServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2478,7 +2478,7 @@ if (!class_exists("ManagedCustomerServiceGet", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2518,7 +2518,7 @@ if (!class_exists("ManagedCustomerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetPendingInvitations", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetPendingInvitations", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2564,7 +2564,7 @@ if (!class_exists("GetPendingInvitations", false)) {
   }
 }
 
-if (!class_exists("GetPendingInvitationsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetPendingInvitationsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2604,7 +2604,7 @@ if (!class_exists("GetPendingInvitationsResponse", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2658,7 +2658,7 @@ if (!class_exists("ManagedCustomerServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2698,7 +2698,7 @@ if (!class_exists("ManagedCustomerServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("MutateLink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateLink", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: SET, ADD.</span>
@@ -2756,7 +2756,7 @@ if (!class_exists("MutateLink", false)) {
   }
 }
 
-if (!class_exists("MutateLinkResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateLinkResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2796,7 +2796,7 @@ if (!class_exists("MutateLinkResponse", false)) {
   }
 }
 
-if (!class_exists("MutateManager", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateManager", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2852,7 +2852,7 @@ if (!class_exists("MutateManager", false)) {
   }
 }
 
-if (!class_exists("MutateManagerResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateManagerResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2892,7 +2892,7 @@ if (!class_exists("MutateManagerResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2941,7 +2941,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2990,7 +2990,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -3039,7 +3039,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -3088,7 +3088,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -3137,7 +3137,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -3186,7 +3186,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3237,7 +3237,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -3286,7 +3286,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -3335,7 +3335,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -3384,7 +3384,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -3433,7 +3433,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3482,7 +3482,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3531,7 +3531,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3601,7 +3601,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3650,7 +3650,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3699,7 +3699,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3749,7 +3749,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3798,7 +3798,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3847,7 +3847,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3896,7 +3896,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3946,7 +3946,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3995,7 +3995,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4048,7 +4048,7 @@ if (!class_exists("ManagedCustomerService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ManagedCustomerService extends AdWordsSoapClient {
+  class ManagedCustomerService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ManagedCustomerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201309";
@@ -4065,89 +4065,89 @@ if (!class_exists("ManagedCustomerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ManagedCustomerServiceError" => "ManagedCustomerServiceError",
-      "PendingInvitationSelector" => "PendingInvitationSelector",
-      "ManagedCustomerLink" => "ManagedCustomerLink",
-      "LinkOperation" => "LinkOperation",
-      "MoveOperation" => "MoveOperation",
-      "MutateLinkResults" => "MutateLinkResults",
-      "MutateManagerResults" => "MutateManagerResults",
-      "ManagedCustomer" => "ManagedCustomer",
-      "ManagedCustomerOperation" => "ManagedCustomerOperation",
-      "ManagedCustomerPage" => "ManagedCustomerPage",
-      "ManagedCustomerReturnValue" => "ManagedCustomerReturnValue",
-      "PendingInvitation" => "PendingInvitation",
-      "LinkStatus" => "LinkStatus",
-      "ManagedCustomerServiceError.Reason" => "ManagedCustomerServiceErrorReason",
-      "get" => "ManagedCustomerServiceGet",
-      "getResponse" => "ManagedCustomerServiceGetResponse",
-      "getPendingInvitations" => "GetPendingInvitations",
-      "getPendingInvitationsResponse" => "GetPendingInvitationsResponse",
-      "mutate" => "ManagedCustomerServiceMutate",
-      "mutateResponse" => "ManagedCustomerServiceMutateResponse",
-      "mutateLink" => "MutateLink",
-      "mutateLinkResponse" => "MutateLinkResponse",
-      "mutateManager" => "MutateManager",
-      "mutateManagerResponse" => "MutateManagerResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "ManagedCustomerServiceError" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceError",
+      "PendingInvitationSelector" => "Google_Api_Ads_AdWords_v201309\\PendingInvitationSelector",
+      "ManagedCustomerLink" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerLink",
+      "LinkOperation" => "Google_Api_Ads_AdWords_v201309\\LinkOperation",
+      "MoveOperation" => "Google_Api_Ads_AdWords_v201309\\MoveOperation",
+      "MutateLinkResults" => "Google_Api_Ads_AdWords_v201309\\MutateLinkResults",
+      "MutateManagerResults" => "Google_Api_Ads_AdWords_v201309\\MutateManagerResults",
+      "ManagedCustomer" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomer",
+      "ManagedCustomerOperation" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerOperation",
+      "ManagedCustomerPage" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerPage",
+      "ManagedCustomerReturnValue" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerReturnValue",
+      "PendingInvitation" => "Google_Api_Ads_AdWords_v201309\\PendingInvitation",
+      "LinkStatus" => "Google_Api_Ads_AdWords_v201309\\LinkStatus",
+      "ManagedCustomerServiceError.Reason" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceGetResponse",
+      "getPendingInvitations" => "Google_Api_Ads_AdWords_v201309\\GetPendingInvitations",
+      "getPendingInvitationsResponse" => "Google_Api_Ads_AdWords_v201309\\GetPendingInvitationsResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\ManagedCustomerServiceMutateResponse",
+      "mutateLink" => "Google_Api_Ads_AdWords_v201309\\MutateLink",
+      "mutateLinkResponse" => "Google_Api_Ads_AdWords_v201309\\MutateLinkResponse",
+      "mutateManager" => "Google_Api_Ads_AdWords_v201309\\MutateManager",
+      "mutateManagerResponse" => "Google_Api_Ads_AdWords_v201309\\MutateManagerResponse",
     );
 
 
@@ -4265,3 +4265,4 @@ if (!class_exists("ManagedCustomerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/MediaService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/MediaService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -125,7 +125,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -173,7 +173,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -221,7 +221,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201309
@@ -268,7 +268,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -317,7 +317,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201309
@@ -371,7 +371,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -446,7 +446,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -514,7 +514,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -611,7 +611,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -690,7 +690,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201309
@@ -832,7 +832,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaPage", false)) {
   /**
    * Page of media returned by the {@link MediaService} which includes
    * the media.
@@ -880,7 +880,7 @@ if (!class_exists("MediaPage", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201309
@@ -948,7 +948,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AudioErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AudioErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -981,7 +981,7 @@ if (!class_exists("AudioErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1014,7 +1014,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1047,7 +1047,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1081,7 +1081,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1114,7 +1114,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1147,7 +1147,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1181,7 +1181,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1214,7 +1214,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1247,7 +1247,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1280,7 +1280,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201309
@@ -1313,7 +1313,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201309
@@ -1346,7 +1346,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201309
@@ -1379,7 +1379,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1412,7 +1412,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1445,7 +1445,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1478,7 +1478,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1511,7 +1511,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1544,7 +1544,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1577,7 +1577,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1611,7 +1611,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1644,7 +1644,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1677,7 +1677,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1710,7 +1710,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1743,7 +1743,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1776,7 +1776,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1809,7 +1809,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1842,7 +1842,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1875,7 +1875,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1908,7 +1908,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("VideoErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\VideoErrorReason", false)) {
   /**
    * Invalid video.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1941,7 +1941,7 @@ if (!class_exists("VideoErrorReason", false)) {
   }
 }
 
-if (!class_exists("MediaServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1990,7 +1990,7 @@ if (!class_exists("MediaServiceGet", false)) {
   }
 }
 
-if (!class_exists("MediaServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2030,7 +2030,7 @@ if (!class_exists("MediaServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("Upload", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Upload", false)) {
   /**
    * Uploads new media. Currently, you can only upload {@link Image} files.
    * 
@@ -2074,7 +2074,7 @@ if (!class_exists("Upload", false)) {
   }
 }
 
-if (!class_exists("UploadResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UploadResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2114,7 +2114,7 @@ if (!class_exists("UploadResponse", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2180,7 +2180,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("AudioError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AudioError", false)) {
   /**
    * Error class for errors associated with parsing audio data.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2225,7 +2225,7 @@ if (!class_exists("AudioError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2270,7 +2270,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2315,7 +2315,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2360,7 +2360,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2405,7 +2405,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2451,7 +2451,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2496,7 +2496,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -2549,7 +2549,7 @@ if (!class_exists("Image", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2594,7 +2594,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2641,7 +2641,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2686,7 +2686,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2731,7 +2731,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2776,7 +2776,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2821,7 +2821,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2866,7 +2866,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2911,7 +2911,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2956,7 +2956,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3022,7 +3022,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3067,7 +3067,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3113,7 +3113,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3158,7 +3158,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3203,7 +3203,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3248,7 +3248,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3294,7 +3294,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3381,7 +3381,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("VideoError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\VideoError", false)) {
   /**
    * Error class for errors associated with parsing video data.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3426,7 +3426,7 @@ if (!class_exists("VideoError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3471,7 +3471,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3520,7 +3520,7 @@ if (!class_exists("MediaService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class MediaService extends AdWordsSoapClient {
+  class MediaService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "MediaService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3537,83 +3537,83 @@ if (!class_exists("MediaService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Audio" => "Audio",
-      "AudioError" => "AudioError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageError" => "ImageError",
-      "InternalApiError" => "InternalApiError",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "Video" => "Video",
-      "VideoError" => "VideoError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Media" => "Media",
-      "MediaPage" => "MediaPage",
-      "Selector" => "Selector",
-      "AudioError.Reason" => "AudioErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "VideoError.Reason" => "VideoErrorReason",
-      "get" => "MediaServiceGet",
-      "getResponse" => "MediaServiceGetResponse",
-      "upload" => "Upload",
-      "uploadResponse" => "UploadResponse",
+      "Audio" => "Google_Api_Ads_AdWords_v201309\\Audio",
+      "AudioError" => "Google_Api_Ads_AdWords_v201309\\AudioError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201309\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201309\\Image",
+      "ImageError" => "Google_Api_Ads_AdWords_v201309\\ImageError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "MediaError" => "Google_Api_Ads_AdWords_v201309\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "Video" => "Google_Api_Ads_AdWords_v201309\\Video",
+      "VideoError" => "Google_Api_Ads_AdWords_v201309\\VideoError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Media" => "Google_Api_Ads_AdWords_v201309\\Media",
+      "MediaPage" => "Google_Api_Ads_AdWords_v201309\\MediaPage",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AudioError.Reason" => "Google_Api_Ads_AdWords_v201309\\AudioErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201309\\ImageErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201309\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201309\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201309\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201309\\MediaErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "VideoError.Reason" => "Google_Api_Ads_AdWords_v201309\\VideoErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\MediaServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\MediaServiceGetResponse",
+      "upload" => "Google_Api_Ads_AdWords_v201309\\Upload",
+      "uploadResponse" => "Google_Api_Ads_AdWords_v201309\\UploadResponse",
     );
 
 
@@ -3658,3 +3658,4 @@ if (!class_exists("MediaService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/MutateJobService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/MutateJobService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Ad", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Ad", false)) {
   /**
    * The base class of all ad types. To update basic ad fields,
    * you can construct an {@code Ad} object (instead of
@@ -133,7 +133,7 @@ if (!class_exists("Ad", false)) {
   }
 }
 
-if (!class_exists("AdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtension", false)) {
   /**
    * Base class for AdExtension objects. An AdExtension is an extension to
    * an existing ad or metadata that will process into an extension.
@@ -213,7 +213,7 @@ if (!class_exists("AdExtension", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverride", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverride", false)) {
   /**
    * Represents an ad level ad extension override. An ad extension override
    * specifies the ad extension that must be used if the ad is served with
@@ -283,7 +283,7 @@ if (!class_exists("AdExtensionOverride", false)) {
   }
 }
 
-if (!class_exists("AdGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroup", false)) {
   /**
    * Represents an ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -386,7 +386,7 @@ if (!class_exists("AdGroup", false)) {
   }
 }
 
-if (!class_exists("AdGroupAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAd", false)) {
   /**
    * Represents an ad in an ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -475,7 +475,7 @@ if (!class_exists("AdGroupAd", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for an AdGroupAd
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -530,7 +530,7 @@ if (!class_exists("AdGroupAdExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifier", false)) {
   /**
    * Represents an adgroup level bid modifier override for campaign level criterion
    * bid modifier values.
@@ -599,7 +599,7 @@ if (!class_exists("AdGroupBidModifier", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterion", false)) {
   /**
    * Represents a criterion in an ad group, used with AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -699,7 +699,7 @@ if (!class_exists("AdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * Bid multiplier used to modify the bid of a criterion while running
    * an experiment.
@@ -773,7 +773,7 @@ if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupExperimentBidMultipliers", false)) {
   /**
    * Bid multiplier used to modify the bid of an adgroup while running
    * an experiment.
@@ -847,7 +847,7 @@ if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this adgroup.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -909,7 +909,7 @@ if (!class_exists("AdGroupExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdUnionId", false)) {
   /**
    * Represents an id indicating a grouping of Ads under some heuristic.
    * @package Google_Api_Ads_AdWords_v201309
@@ -988,7 +988,7 @@ if (!class_exists("AdUnionId", false)) {
   }
 }
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1070,7 +1070,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -1167,7 +1167,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiErrorReason", false)) {
   /**
    * Interface that has a reason return an associated service error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1599,7 +1599,7 @@ if (!class_exists("ApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1678,7 +1678,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1723,7 +1723,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1768,7 +1768,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1813,7 +1813,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1853,7 +1853,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -1901,7 +1901,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterion", false)) {
   /**
    * A biddable (positive) criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2017,7 +2017,7 @@ if (!class_exists("BiddableAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterionExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this {@link BiddableAdGroupCriterion}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2078,7 +2078,7 @@ if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2123,7 +2123,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2168,7 +2168,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2241,7 +2241,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -2333,7 +2333,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingTransitionError", false)) {
   /**
    * Bidding transition errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2378,7 +2378,7 @@ if (!class_exists("BiddingTransitionError", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2450,7 +2450,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("BillingSummary", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BillingSummary", false)) {
   /**
    * Represents the billing summary of the job that provides the overall cost of
    * the job's operations, i.e., for the work done <i>by</i> the job. This
@@ -2500,7 +2500,7 @@ if (!class_exists("BillingSummary", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2589,7 +2589,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2634,7 +2634,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -2685,7 +2685,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobError", false)) {
   /**
    * Bulk mutate job handling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2730,7 +2730,7 @@ if (!class_exists("BulkMutateJobError", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobPolicy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobPolicy", false)) {
   /**
    * A basic job policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2770,7 +2770,7 @@ if (!class_exists("BulkMutateJobPolicy", false)) {
   }
 }
 
-if (!class_exists("BulkMutateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateRequest", false)) {
   /**
    * A request part of a {@link BulkMutateJob}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2817,7 +2817,7 @@ if (!class_exists("BulkMutateRequest", false)) {
   }
 }
 
-if (!class_exists("BulkMutateResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateResult", false)) {
   /**
    * Represents a result part of a {@link BulkMutateJob}.
    * 
@@ -2913,7 +2913,7 @@ if (!class_exists("BulkMutateResult", false)) {
   }
 }
 
-if (!class_exists("Campaign", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Campaign", false)) {
   /**
    * Data representing an AdWords campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3044,7 +3044,7 @@ if (!class_exists("Campaign", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtension", false)) {
   /**
    * Represents a campaign level ad extension. A campaign ad extension specifies
    * a campaign and an ad extension which can extend any ad under that campaign.
@@ -3106,7 +3106,7 @@ if (!class_exists("CampaignAdExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionError", false)) {
   /**
    * CampaignAdExtension errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3151,7 +3151,7 @@ if (!class_exists("CampaignAdExtensionError", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterion", false)) {
   /**
    * Represents a campaign level criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3258,7 +3258,7 @@ if (!class_exists("CampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionError", false)) {
   /**
    * Base error class for Campaign Criterion Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3303,7 +3303,7 @@ if (!class_exists("CampaignCriterionError", false)) {
   }
 }
 
-if (!class_exists("CampaignError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignError", false)) {
   /**
    * Base error class for Campaign Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3348,7 +3348,7 @@ if (!class_exists("CampaignError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3393,7 +3393,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3465,7 +3465,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -3528,7 +3528,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibility", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibility", false)) {
   /**
    * Eligibility data for Campaign to transition to Conversion Optimizer
    * @package Google_Api_Ads_AdWords_v201309
@@ -3575,7 +3575,7 @@ if (!class_exists("ConversionOptimizerEligibility", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3617,7 +3617,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3673,7 +3673,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3722,7 +3722,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3809,7 +3809,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3854,7 +3854,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3926,7 +3926,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3971,7 +3971,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4016,7 +4016,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DeprecatedAd", false)) {
   /**
    * Represents a deprecated ad.
    * 
@@ -4072,7 +4072,7 @@ if (!class_exists("DeprecatedAd", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4119,7 +4119,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4164,10 +4164,9 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("DomainInfoExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DomainInfoExtension", false)) {
   /**
    * Domain extension, which adds domain info to ads.
-   * <span class="constraint Beta">This is a beta feature.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -4215,7 +4214,7 @@ if (!class_exists("DomainInfoExtension", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4254,7 +4253,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4299,7 +4298,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4373,7 +4372,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityId", false)) {
   /**
    * A qualified long-valued identity that can identify different types of
    * AdWords entities such as campaigns and ad-groups.
@@ -4421,7 +4420,7 @@ if (!class_exists("EntityId", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4467,7 +4466,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4507,7 +4506,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("FeedItem", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItem", false)) {
   /**
    * Represents an item in a feed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4603,7 +4602,7 @@ if (!class_exists("FeedItem", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemAttributeError", false)) {
   /**
    * Contains validation error details for a set of feed attributes.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4650,7 +4649,7 @@ if (!class_exists("FeedItemAttributeError", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemAttributeValue", false)) {
   /**
    * Represents a feed item's value for a particular feed attribute. A feed item's value is
    * composed of a collection of these attribute values.
@@ -4719,7 +4718,7 @@ if (!class_exists("FeedItemAttributeValue", false)) {
   }
 }
 
-if (!class_exists("FeedItemDevicePreference", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemDevicePreference", false)) {
   /**
    * Represents a FeedItem device preference.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4759,7 +4758,7 @@ if (!class_exists("FeedItemDevicePreference", false)) {
   }
 }
 
-if (!class_exists("FeedItemError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemError", false)) {
   /**
    * FeedItemService related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4804,7 +4803,7 @@ if (!class_exists("FeedItemError", false)) {
   }
 }
 
-if (!class_exists("FeedItemSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemSchedule", false)) {
   /**
    * Represents a FeedItem schedule, which specifies a time interval on a given day
    * when the feed item may serve. The FeedItemSchedule times are in the account's time zone.
@@ -4873,7 +4872,7 @@ if (!class_exists("FeedItemSchedule", false)) {
   }
 }
 
-if (!class_exists("FeedItemScheduling", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemScheduling", false)) {
   /**
    * Represents a collection of FeedItem schedules specifying all time intervals for which
    * the feed item may serve. Any time range not covered by the specified FeedItemSchedules will
@@ -4915,7 +4914,7 @@ if (!class_exists("FeedItemScheduling", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetail", false)) {
   /**
    * Contains offline-validation and approval results for a given FeedItem and FeedMapping. Each
    * validation detail indicates any issues found on the feed item when used in the context
@@ -4978,7 +4977,7 @@ if (!class_exists("FeedItemValidationDetail", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -5024,7 +5023,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("FrequencyCap", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FrequencyCap", false)) {
   /**
    * A frequency cap is the maximum number of times an ad (or some set of ads) can
    * be shown to a user over a particular time period.
@@ -5079,10 +5078,10 @@ if (!class_exists("FrequencyCap", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -5125,7 +5124,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5172,7 +5171,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5217,7 +5216,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("ImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageAd", false)) {
   /**
    * Represents an ImageAd.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -5278,7 +5277,7 @@ if (!class_exists("ImageAd", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5323,7 +5322,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InAppLinkExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InAppLinkExtension", false)) {
   /**
    * <p>This extension is useful for advertisers who wish to provide users with a
    * link that points to the advertiser's mobile application in addition to their
@@ -5335,7 +5334,6 @@ if (!class_exists("InAppLinkExtension", false)) {
    * Only the extension for a given {@code AppStore} will render on the device
    * relevant to that {@code AppStore} (e.g. iPhones for {@code AppStore.ITUNES}
    * and Android phones for {@code AppStore.GOOGLE_PLAY}).
-   * <span class="constraint Beta">This is a beta feature.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -5397,7 +5395,7 @@ if (!class_exists("InAppLinkExtension", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -5444,7 +5442,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Job", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Job", false)) {
   /**
    * Represents an asynchronous macro unit of work.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5537,7 +5535,7 @@ if (!class_exists("Job", false)) {
   }
 }
 
-if (!class_exists("JobError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobError", false)) {
   /**
    * Job handling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5582,7 +5580,7 @@ if (!class_exists("JobError", false)) {
   }
 }
 
-if (!class_exists("JobEvent", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobEvent", false)) {
   /**
    * An event defined by a status change of a job.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5661,7 +5659,7 @@ if (!class_exists("JobEvent", false)) {
   }
 }
 
-if (!class_exists("JobResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobResult", false)) {
   /**
    * Represents the result data of a job. This contains both the results of
    * successfully processed operations as well as errors returned by failed
@@ -5710,7 +5708,7 @@ if (!class_exists("JobResult", false)) {
   }
 }
 
-if (!class_exists("JobSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobSelector", false)) {
   /**
    * For selecting jobs whose information will be returned from a get method call
    * of a job service.
@@ -5797,7 +5795,7 @@ if (!class_exists("JobSelector", false)) {
   }
 }
 
-if (!class_exists("JobStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobStats", false)) {
   /**
    * Job-handling statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5890,7 +5888,7 @@ if (!class_exists("JobStats", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -5942,10 +5940,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -5995,10 +5993,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -6062,7 +6060,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("LocationExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationExtension", false)) {
   /**
    * Location based ad extension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6154,7 +6152,7 @@ if (!class_exists("LocationExtension", false)) {
   }
 }
 
-if (!class_exists("LocationOverrideInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationOverrideInfo", false)) {
   /**
    * Represents override info for ad level LocationExtension overrides.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6201,7 +6199,7 @@ if (!class_exists("LocationOverrideInfo", false)) {
   }
 }
 
-if (!class_exists("LocationSyncExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationSyncExtension", false)) {
   /**
    * Local business center(LBC) sync extension that ties a LBC account with a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6272,7 +6270,7 @@ if (!class_exists("LocationSyncExtension", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * AdGroupCriterion level bid multiplier used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6322,7 +6320,7 @@ if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6372,7 +6370,7 @@ if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCPMAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPM bidding strategy.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6415,7 +6413,7 @@ if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6458,7 +6456,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -6494,7 +6492,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6636,7 +6634,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6681,7 +6679,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -6729,7 +6727,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -6777,7 +6775,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("MobileAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAd", false)) {
   /**
    * Represents a mobile ad.
    * 
@@ -6915,7 +6913,7 @@ if (!class_exists("MobileAd", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -6969,7 +6967,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -7021,10 +7019,10 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -7088,7 +7086,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("MobileExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileExtension", false)) {
   /**
    * Represents a phone extension.
    * 
@@ -7163,7 +7161,7 @@ if (!class_exists("MobileExtension", false)) {
   }
 }
 
-if (!class_exists("MobileImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileImageAd", false)) {
   /**
    * Represents a mobile image ad.
    * 
@@ -7228,7 +7226,7 @@ if (!class_exists("MobileImageAd", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7270,7 +7268,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NegativeAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeAdGroupCriterion", false)) {
   /**
    * A negative criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7309,7 +7307,7 @@ if (!class_exists("NegativeAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("NegativeCampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeCampaignCriterion", false)) {
   /**
    * A negative campaign criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7349,7 +7347,7 @@ if (!class_exists("NegativeCampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7410,7 +7408,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7455,7 +7453,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7500,7 +7498,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7545,7 +7543,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7590,7 +7588,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7625,7 +7623,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OAuthInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OAuthInfo", false)) {
   /**
    * Data used for authorization using OAuth.
    * For more information about OAuth, see:
@@ -7681,7 +7679,7 @@ if (!class_exists("OAuthInfo", false)) {
   }
 }
 
-if (!class_exists("Operand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operand", false)) {
   /**
    * A marker interface for entities that can be operated upon in mutate
    * operations.
@@ -7827,10 +7825,10 @@ if (!class_exists("Operand", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -7894,7 +7892,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -7974,7 +7972,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8019,7 +8017,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperationResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationResult", false)) {
   /**
    * Represents the result of an individual mutate operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8091,7 +8089,7 @@ if (!class_exists("OperationResult", false)) {
   }
 }
 
-if (!class_exists("OperationStream", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationStream", false)) {
   /**
    * A stream of AdWords API mutate operations that must be performed serially.
    * Further, this operation stream must be processed serially with all other
@@ -8141,7 +8139,7 @@ if (!class_exists("OperationStream", false)) {
   }
 }
 
-if (!class_exists("OperationStreamResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationStreamResult", false)) {
   /**
    * The result of processing an {@link OperationStream}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8181,7 +8179,7 @@ if (!class_exists("OperationStreamResult", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8226,7 +8224,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OverrideInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OverrideInfo", false)) {
   /**
    * Represents additional override info with which to augment the override
    * extension.
@@ -8267,7 +8265,7 @@ if (!class_exists("OverrideInfo", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -8346,7 +8344,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -8392,7 +8390,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8441,7 +8439,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -8482,7 +8480,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("PlaceHolder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PlaceHolder", false)) {
   /**
    * A place holder for a result which is not available.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8515,7 +8513,7 @@ if (!class_exists("PlaceHolder", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -8561,10 +8559,10 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -8607,7 +8605,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -8698,7 +8696,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8745,7 +8743,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -8793,7 +8791,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -8848,7 +8846,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductAd", false)) {
   /**
    * Represents a product ad (known as a <a href=
    * "//support.google.com/adwords/bin/answer.py?answer=2456103">product
@@ -8907,7 +8905,7 @@ if (!class_exists("ProductAd", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -8955,7 +8953,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8995,7 +8993,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -9003,7 +9001,7 @@ if (!class_exists("Proximity", false)) {
    * by a lat/long pair. The caller may also alternatively provide address fields which will be
    * geocoded into a lat/long pair. Note: If a geoPoint value is provided, the address is not
    * used for calculating the lat/long to target.
-   * <p> A criterion of this type is only targetable.
+   * <p>
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -9067,7 +9065,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QualityInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QualityInfo", false)) {
   /**
    * Container for criterion quality information.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9128,7 +9126,7 @@ if (!class_exists("QualityInfo", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9180,7 +9178,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9225,7 +9223,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9277,7 +9275,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9322,7 +9320,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9388,7 +9386,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9433,7 +9431,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9478,7 +9476,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9523,7 +9521,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -9569,7 +9567,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9614,7 +9612,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("ReturnValueResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReturnValueResult", false)) {
   /**
    * Represents a success result of processing a mutate operation that returned
    * a value.
@@ -9657,7 +9655,7 @@ if (!class_exists("ReturnValueResult", false)) {
   }
 }
 
-if (!class_exists("RichMediaAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAd", false)) {
   /**
    * Data associated with a rich media ad.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -9760,7 +9758,7 @@ if (!class_exists("RichMediaAd", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9805,7 +9803,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9877,7 +9875,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201309
@@ -9922,7 +9920,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("SimpleMutateJob", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SimpleMutateJob", false)) {
   /**
    * A mutation job, which was submitted using
    * {@link MutateJobService#mutate}, and will execute asynchronously
@@ -9983,7 +9981,7 @@ if (!class_exists("SimpleMutateJob", false)) {
   }
 }
 
-if (!class_exists("SimpleMutateResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SimpleMutateResult", false)) {
   /**
    * The results of a simple mutation job.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10030,7 +10028,7 @@ if (!class_exists("SimpleMutateResult", false)) {
   }
 }
 
-if (!class_exists("Sitelink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Sitelink", false)) {
   /**
    * Class to represent a single sitelink
    * @package Google_Api_Ads_AdWords_v201309
@@ -10077,7 +10075,7 @@ if (!class_exists("Sitelink", false)) {
   }
 }
 
-if (!class_exists("SitelinksExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SitelinksExtension", false)) {
   /**
    * Class to represent a set of sitelinks and their order of preference.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10120,7 +10118,7 @@ if (!class_exists("SitelinksExtension", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10165,7 +10163,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10240,7 +10238,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10308,7 +10306,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10353,7 +10351,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -10399,7 +10397,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -10447,7 +10445,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("Target", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Target", false)) {
   /**
    * Target abstract class.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10519,7 +10517,7 @@ if (!class_exists("Target", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -10572,7 +10570,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * @package Google_Api_Ads_AdWords_v201309
@@ -10617,7 +10615,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("TargetList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetList", false)) {
   /**
    * Targets list abstract class (a list of a given type of targets along with their campaign ID).
    * @package Google_Api_Ads_AdWords_v201309
@@ -10696,7 +10694,7 @@ if (!class_exists("TargetList", false)) {
   }
 }
 
-if (!class_exists("TargetingSettingDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingSettingDetail", false)) {
   /**
    * Specifies if criteria of this type group should be used to restrict
    * targeting, or if ads can serve anywhere and criteria are only used in
@@ -10745,7 +10743,7 @@ if (!class_exists("TargetingSettingDetail", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -10797,7 +10795,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingSetting", false)) {
   /**
    * Setting for targeting related features.
    * This is applicable at Campaign and AdGroup level.
@@ -10840,7 +10838,7 @@ if (!class_exists("TargetingSetting", false)) {
   }
 }
 
-if (!class_exists("TempAdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TempAdUnionId", false)) {
   /**
    * Represents the temporary id for an ad union id, which the user can specify.
    * The temporary id can be used to group ads together during ad creation.
@@ -10877,7 +10875,7 @@ if (!class_exists("TempAdUnionId", false)) {
   }
 }
 
-if (!class_exists("TemplateAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateAd", false)) {
   /**
    * Represents a <a href=
    * "//www.google.com/adwords/displaynetwork/plan-creative-campaigns/display-ad-builder.html"
@@ -10971,7 +10969,7 @@ if (!class_exists("TemplateAd", false)) {
   }
 }
 
-if (!class_exists("TemplateElement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElement", false)) {
   /**
    * Represents an element in a template. Each template element is composed
    * of a list of fields (actual value data).
@@ -11019,7 +11017,7 @@ if (!class_exists("TemplateElement", false)) {
   }
 }
 
-if (!class_exists("TemplateElementField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElementField", false)) {
   /**
    * Represents a field in a template element.
    * @package Google_Api_Ads_AdWords_v201309
@@ -11080,7 +11078,7 @@ if (!class_exists("TemplateElementField", false)) {
   }
 }
 
-if (!class_exists("TextAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TextAd", false)) {
   /**
    * Represents a TextAd.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -11141,7 +11139,7 @@ if (!class_exists("TextAd", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAd", false)) {
   /**
    * Data associated with rich media extension attributes.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11220,7 +11218,7 @@ if (!class_exists("ThirdPartyRedirectAd", false)) {
   }
 }
 
-if (!class_exists("TrackingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrackingSetting", false)) {
   /**
    * Campaign level settings for tracking information.
    * @package Google_Api_Ads_AdWords_v201309
@@ -11262,7 +11260,7 @@ if (!class_exists("TrackingSetting", false)) {
   }
 }
 
-if (!class_exists("UnprocessedResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UnprocessedResult", false)) {
   /**
    * Indicates that the mutate operation was not processed. This could result
    * if the job was aborted by the back-end workflow because the developer's API
@@ -11300,7 +11298,7 @@ if (!class_exists("UnprocessedResult", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11352,7 +11350,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11411,7 +11409,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -11474,7 +11472,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -11561,7 +11559,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -11621,7 +11619,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -11673,7 +11671,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -11723,7 +11721,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DynamicSearchAd", false)) {
   /**
    * Represents a dynamic search ad. This ad will have its headline and
    * destination URL auto-generated at serving time according to domain name
@@ -11807,7 +11805,7 @@ if (!class_exists("DynamicSearchAd", false)) {
   }
 }
 
-if (!class_exists("AdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -11840,7 +11838,7 @@ if (!class_exists("AdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionErrorReason", false)) {
   /**
    * Account has been deleted
    * @package Google_Api_Ads_AdWords_v201309
@@ -11873,7 +11871,7 @@ if (!class_exists("AdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideApprovalStatus", false)) {
   /**
    * Approval status for the AdExtensionOverride
    * @package Google_Api_Ads_AdWords_v201309
@@ -11906,7 +11904,7 @@ if (!class_exists("AdExtensionOverrideApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideStatus", false)) {
   /**
    * Status of the AdExtensionOverride
    * @package Google_Api_Ads_AdWords_v201309
@@ -11939,7 +11937,7 @@ if (!class_exists("AdExtensionOverrideStatus", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideErrorReason", false)) {
   /**
    * Cannot override an ad that is already overriden with an adextension
    * @package Google_Api_Ads_AdWords_v201309
@@ -11972,7 +11970,7 @@ if (!class_exists("AdExtensionOverrideErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdApprovalStatus", false)) {
   /**
    * Represents the possible approval statuses.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12005,7 +12003,7 @@ if (!class_exists("AdGroupAdApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdStatus", false)) {
   /**
    * The current status of an Ad.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12038,7 +12036,7 @@ if (!class_exists("AdGroupAdStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12071,7 +12069,7 @@ if (!class_exists("AdGroupAdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12104,7 +12102,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12137,7 +12135,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceErrorReason", false)) {
   /**
    * The reasons for the adgroup service error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12170,7 +12168,7 @@ if (!class_exists("AdGroupServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupStatus", false)) {
   /**
    * Status of this ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12203,7 +12201,7 @@ if (!class_exists("AdGroupStatus", false)) {
   }
 }
 
-if (!class_exists("AdServingOptimizationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdServingOptimizationStatus", false)) {
   /**
    * Ad serving status of campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12236,7 +12234,7 @@ if (!class_exists("AdServingOptimizationStatus", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12269,7 +12267,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -12302,7 +12300,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("ApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApprovalStatus", false)) {
   /**
    * Approval status for the criterion.
    * Note: there are more states involved but we only expose two to users.
@@ -12336,7 +12334,7 @@ if (!class_exists("ApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12369,7 +12367,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12402,7 +12400,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BasicJobStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BasicJobStatus", false)) {
   /**
    * A basic set of job statuses.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12435,7 +12433,7 @@ if (!class_exists("BasicJobStatus", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12468,7 +12466,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidModifierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidModifierSource", false)) {
   /**
    * Enumerates possible sources for bid modifier.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12501,7 +12499,7 @@ if (!class_exists("BidModifierSource", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -12535,7 +12533,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12568,7 +12566,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12601,7 +12599,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12634,7 +12632,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12667,7 +12665,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingTransitionErrorReason", false)) {
   /**
    * Reason for bidding transition error.
    * It is used by capability service as denial reasons, for bidding transition
@@ -12702,7 +12700,7 @@ if (!class_exists("BiddingTransitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12735,7 +12733,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12768,7 +12766,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -12801,7 +12799,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12834,7 +12832,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobErrorReason", false)) {
   /**
    * The reasons for the bulk mutate job handling error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12867,7 +12865,7 @@ if (!class_exists("BulkMutateJobErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionApprovalStatus", false)) {
   /**
    * Approval status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12900,7 +12898,7 @@ if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionStatus", false)) {
   /**
    * Status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12933,7 +12931,7 @@ if (!class_exists("CampaignAdExtensionStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionErrorReason", false)) {
   /**
    * Cannot operate on an adextensions under the wrong campaign
    * @package Google_Api_Ads_AdWords_v201309
@@ -12966,7 +12964,7 @@ if (!class_exists("CampaignAdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -12999,7 +12997,7 @@ if (!class_exists("CampaignCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -13032,7 +13030,7 @@ if (!class_exists("CampaignCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("CampaignErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13065,7 +13063,7 @@ if (!class_exists("CampaignErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignStatus", false)) {
   /**
    * Campaign status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13098,7 +13096,7 @@ if (!class_exists("CampaignStatus", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -13132,7 +13130,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ContentLabelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ContentLabelType", false)) {
   /**
    * Content label type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13165,7 +13163,7 @@ if (!class_exists("ContentLabelType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13198,7 +13196,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -13231,7 +13229,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibilityRejectionReason", false)) {
   /**
    * Campaign is not active
    * @package Google_Api_Ads_AdWords_v201309
@@ -13264,7 +13262,7 @@ if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13297,7 +13295,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13330,7 +13328,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionTypeGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionTypeGroup", false)) {
   /**
    * The list of groupings of criteria types.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13363,7 +13361,7 @@ if (!class_exists("CriterionTypeGroup", false)) {
   }
 }
 
-if (!class_exists("CriterionUse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUse", false)) {
   /**
    * The way a criterion is used - biddable or negative.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13396,7 +13394,7 @@ if (!class_exists("CriterionUse", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13429,7 +13427,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13462,7 +13460,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13495,7 +13493,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DeprecatedAdType", false)) {
   /**
    * Video ad.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13528,7 +13526,7 @@ if (!class_exists("DeprecatedAdType", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13561,7 +13559,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13594,7 +13592,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13627,7 +13625,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityIdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityIdType", false)) {
   /**
    * Type of entity identity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13660,7 +13658,7 @@ if (!class_exists("EntityIdType", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -13694,7 +13692,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13727,7 +13725,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13760,7 +13758,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemStatus", false)) {
   /**
    * Feed item is active
    * @package Google_Api_Ads_AdWords_v201309
@@ -13793,7 +13791,7 @@ if (!class_exists("FeedItemStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemErrorReason", false)) {
   /**
    * The reasons for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13826,7 +13824,7 @@ if (!class_exists("FeedItemErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailApprovalStatus", false)) {
   /**
    * Feed item approval status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13859,7 +13857,7 @@ if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailValidationStatus", false)) {
   /**
    * Feed item validation status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13892,7 +13890,7 @@ if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13925,7 +13923,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -13958,7 +13956,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   /**
    * The various signals a negative location target may use.
    * @package Google_Api_Ads_AdWords_v201309
@@ -13991,7 +13989,7 @@ if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   /**
    * The various signals a positive location target may use.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14024,7 +14022,7 @@ if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14057,7 +14055,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14090,7 +14088,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("InAppLinkExtensionAppStore", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InAppLinkExtensionAppStore", false)) {
   /**
    * The AppStore this extension will render for.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14123,7 +14121,7 @@ if (!class_exists("InAppLinkExtensionAppStore", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14156,7 +14154,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("JobErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\JobErrorReason", false)) {
   /**
    * The reasons for the job handling error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14189,7 +14187,7 @@ if (!class_exists("JobErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -14223,7 +14221,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("Level", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Level", false)) {
   /**
    * The level on which the cap is to be applied.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14256,7 +14254,7 @@ if (!class_exists("Level", false)) {
   }
 }
 
-if (!class_exists("LocationExtensionSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationExtensionSource", false)) {
   /**
    * From manual entry in adwords frontend
    * @package Google_Api_Ads_AdWords_v201309
@@ -14289,7 +14287,7 @@ if (!class_exists("LocationExtensionSource", false)) {
   }
 }
 
-if (!class_exists("LocationOverrideInfoRadiusUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationOverrideInfoRadiusUnits", false)) {
   /**
    * Radius units
    * @package Google_Api_Ads_AdWords_v201309
@@ -14322,7 +14320,7 @@ if (!class_exists("LocationOverrideInfoRadiusUnits", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14355,7 +14353,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("MarkupLanguageType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MarkupLanguageType", false)) {
   /**
    * Markup languages to use for mobile ads.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14388,7 +14386,7 @@ if (!class_exists("MarkupLanguageType", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201309
@@ -14421,7 +14419,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201309
@@ -14454,7 +14452,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201309
@@ -14487,7 +14485,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14520,7 +14518,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201309
@@ -14553,7 +14551,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -14586,7 +14584,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("MultiplierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MultiplierSource", false)) {
   /**
    * Denotes whether the bid multiplier is derived from the adgroup
    * or the criterion
@@ -14620,7 +14618,7 @@ if (!class_exists("MultiplierSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14653,7 +14651,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14686,7 +14684,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14719,7 +14717,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14752,7 +14750,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14785,7 +14783,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14818,7 +14816,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14851,7 +14849,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14884,9 +14882,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -14917,7 +14915,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -14950,7 +14948,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -14983,7 +14981,7 @@ if (!class_exists("PolicyViolationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15016,7 +15014,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15049,7 +15047,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -15083,7 +15081,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15116,7 +15114,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15149,7 +15147,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15182,7 +15180,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15215,7 +15213,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15248,7 +15246,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15281,7 +15279,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15314,7 +15312,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15347,7 +15345,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdAdAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAdAdAttribute", false)) {
   /**
    * A set of attributes that describe the rich media ad capabilities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15380,7 +15378,7 @@ if (!class_exists("RichMediaAdAdAttribute", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdRichMediaAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RichMediaAdRichMediaAdType", false)) {
   /**
    * Different types of rich media ad that are available to customers.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15413,7 +15411,7 @@ if (!class_exists("RichMediaAdRichMediaAdType", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15446,7 +15444,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("ServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ServingStatus", false)) {
   /**
    * Campaign serving status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15479,7 +15477,7 @@ if (!class_exists("ServingStatus", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15512,7 +15510,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15545,7 +15543,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15578,7 +15576,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15611,7 +15609,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("SystemServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SystemServingStatus", false)) {
   /**
    * Reported by system to reflect the criterion's serving status.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15644,7 +15642,7 @@ if (!class_exists("SystemServingStatus", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15677,7 +15675,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("TemplateElementFieldType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TemplateElementFieldType", false)) {
   /**
    * Possible field types of template element fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15710,7 +15708,7 @@ if (!class_exists("TemplateElementFieldType", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAdExpandingDirection", false)) {
   /**
    * Allowed expanding directions for ads that are expandable.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15743,7 +15741,7 @@ if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
   }
 }
 
-if (!class_exists("TimeUnit", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TimeUnit", false)) {
   /**
    * Unit of time the cap is defined at.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15776,7 +15774,7 @@ if (!class_exists("TimeUnit", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15809,7 +15807,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("UserStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\UserStatus", false)) {
   /**
    * Specified by user to pause or unpause a criterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15842,7 +15840,7 @@ if (!class_exists("UserStatus", false)) {
   }
 }
 
-if (!class_exists("VideoType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\VideoType", false)) {
   /**
    * VideoType enum values that are permitted for video filterable
    * creative attribute IDs.
@@ -15876,7 +15874,7 @@ if (!class_exists("VideoType", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -15909,7 +15907,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateJobServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -15955,7 +15953,7 @@ if (!class_exists("MutateJobServiceGet", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateJobServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -15995,7 +15993,7 @@ if (!class_exists("MutateJobServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetResult", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -16042,7 +16040,7 @@ if (!class_exists("GetResult", false)) {
   }
 }
 
-if (!class_exists("GetResultResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetResultResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -16082,7 +16080,7 @@ if (!class_exists("GetResultResponse", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateJobServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -16142,7 +16140,7 @@ if (!class_exists("MutateJobServiceMutate", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MutateJobServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -16182,7 +16180,7 @@ if (!class_exists("MutateJobServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdError", false)) {
   /**
    * Base error class for Ad Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16227,7 +16225,7 @@ if (!class_exists("AdError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionError", false)) {
   /**
    * AdExtension errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16272,7 +16270,7 @@ if (!class_exists("AdExtensionError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideError", false)) {
   /**
    * AdExtensionOverride errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16317,7 +16315,7 @@ if (!class_exists("AdExtensionOverrideError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideOperation", false)) {
   /**
    * AdExtensionOverride service operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16360,7 +16358,7 @@ if (!class_exists("AdExtensionOverrideOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdCountLimitExceeded", false)) {
   /**
    * Indicates too many ads were added/enabled under the specified adgroup.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16399,7 +16397,7 @@ if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdError", false)) {
   /**
    * Error information for AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16444,7 +16442,7 @@ if (!class_exists("AdGroupAdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupAdOperation", false)) {
   /**
    * AdGroupAd service operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16494,7 +16492,7 @@ if (!class_exists("AdGroupAdOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierOperation", false)) {
   /**
    * Operation used to create or mutate a AdGroupBidModifier.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16537,7 +16535,7 @@ if (!class_exists("AdGroupBidModifierOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16582,7 +16580,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16628,7 +16626,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionOperation", false)) {
   /**
    * Operation (add, remove and set) on adgroup criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16678,7 +16676,7 @@ if (!class_exists("AdGroupCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupOperation", false)) {
   /**
    * AdGroup operations for adding/updating/removing adgroups.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16721,7 +16719,7 @@ if (!class_exists("AdGroupOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupServiceError", false)) {
   /**
    * Represents possible error codes in AdGroupService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16773,7 +16771,7 @@ if (!class_exists("AdGroupServiceError", false)) {
   }
 }
 
-if (!class_exists("AdSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdSchedule", false)) {
   /**
    * Represents an AdSchedule Criterion.
    * AdSchedule is specified as day and time of the week criteria to target
@@ -16850,7 +16848,7 @@ if (!class_exists("AdSchedule", false)) {
   }
 }
 
-if (!class_exists("AdScheduleTarget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdScheduleTarget", false)) {
   /**
    * Immutable structure to hold an ad schedule target.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16927,7 +16925,7 @@ if (!class_exists("AdScheduleTarget", false)) {
   }
 }
 
-if (!class_exists("AdScheduleTargetList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdScheduleTargetList", false)) {
   /**
    * List of ad schedule targets.
    * @package Google_Api_Ads_AdWords_v201309
@@ -16970,7 +16968,7 @@ if (!class_exists("AdScheduleTargetList", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17015,10 +17013,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -17061,7 +17059,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17104,7 +17102,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17170,7 +17168,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("BatchFailureResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BatchFailureResult", false)) {
   /**
    * Represents a failure result for a mutate operation that was applied in a
    * transactional batch. It does not imply that the corresponding operation
@@ -17215,7 +17213,7 @@ if (!class_exists("BatchFailureResult", false)) {
   }
 }
 
-if (!class_exists("BudgetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetOperation", false)) {
   /**
    * Operations for adding/updating Budget entities.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17258,7 +17256,7 @@ if (!class_exists("BudgetOperation", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJob", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJob", false)) {
   /**
    * A {@code BulkMutateJob} is essentially a mixed collection of mutate
    * operations from the following AdWords API campaign management services:
@@ -17386,7 +17384,7 @@ if (!class_exists("BulkMutateJob", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobEvent", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobEvent", false)) {
   /**
    * An event defined by a status change of a bulk mutate job.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17429,7 +17427,7 @@ if (!class_exists("BulkMutateJobEvent", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobSelector", false)) {
   /**
    * Specifies additional criteria for selecting bulk mutate jobs.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17480,7 +17478,7 @@ if (!class_exists("BulkMutateJobSelector", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BulkMutateJobStats", false)) {
   /**
    * Bulk mutate job-handling statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17539,7 +17537,7 @@ if (!class_exists("BulkMutateJobStats", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionOperation", false)) {
   /**
    * CampaignAdExtension service operation. <b>Note:</b> The {@code SET} operator
    * is not supported.
@@ -17583,7 +17581,7 @@ if (!class_exists("CampaignAdExtensionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceeded", false)) {
   /**
    * Error to indicate that too many negative criteria added to some campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17629,7 +17627,7 @@ if (!class_exists("CampaignCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignCriterionOperation", false)) {
   /**
    * Generic operation (add, remove and set) for campaign criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17672,7 +17670,7 @@ if (!class_exists("CampaignCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignOperation", false)) {
   /**
    * An operation on an AdWords campaign.
    * <p class="note"><b>Note:</b> The <code>REMOVE</code> operator is not
@@ -17718,7 +17716,7 @@ if (!class_exists("CampaignOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignTargetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignTargetOperation", false)) {
   /**
    * Sets a list of targets on a specified campaign.
    * <p class="note"><b>Note:</b> Only the <code>SET</code> operator is supported.</p>
@@ -17762,10 +17760,10 @@ if (!class_exists("CampaignTargetOperation", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
@@ -17815,7 +17813,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ContentLabel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ContentLabel", false)) {
   /**
    * Content Label for category exclusion.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -17860,7 +17858,7 @@ if (!class_exists("ContentLabel", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17900,7 +17898,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -17941,7 +17939,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExplorerAutoOptimizerSetting", false)) {
   /**
    * Settings for Explorer (GDN Auto Optimizer).
    * @package Google_Api_Ads_AdWords_v201309
@@ -17983,7 +17981,7 @@ if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
   }
 }
 
-if (!class_exists("FailureResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FailureResult", false)) {
   /**
    * Represents a failure result for an individual mutate operation.
    * 
@@ -18033,7 +18031,7 @@ if (!class_exists("FailureResult", false)) {
   }
 }
 
-if (!class_exists("FeedItemOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FeedItemOperation", false)) {
   /**
    * FeedItem service mutate operation.
    * @package Google_Api_Ads_AdWords_v201309
@@ -18076,7 +18074,7 @@ if (!class_exists("FeedItemOperation", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSetting", false)) {
   /**
    * Represents a collection of settings related to ads geotargeting.
    * 
@@ -18150,7 +18148,7 @@ if (!class_exists("GeoTargetTypeSetting", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -18203,7 +18201,7 @@ if (!class_exists("Image", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchSetting", false)) {
   /**
    * Improved exact and phrase match option includes misspellings, plurals,
    * and other close variants of your keywords.
@@ -18253,7 +18251,7 @@ if (!class_exists("KeywordMatchSetting", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -18294,7 +18292,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("LostResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LostResult", false)) {
   /**
    * Represents the result of processing an individual mutate operation that
    * however failed to get durably saved despite the service's best efforts.
@@ -18334,7 +18332,7 @@ if (!class_exists("LostResult", false)) {
   }
 }
 
-if (!class_exists("RealTimeBiddingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RealTimeBiddingSetting", false)) {
   /**
    * Settings for Real-Time Bidding, a feature only available for campaigns
    * targeting the Ad Exchange network.
@@ -18383,7 +18381,7 @@ if (!class_exists("MutateJobService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class MutateJobService extends AdWordsSoapClient {
+  class MutateJobService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "MutateJobService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -18400,372 +18398,372 @@ if (!class_exists("MutateJobService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Ad" => "Ad",
-      "AdError" => "AdError",
-      "AdExtension" => "AdExtension",
-      "AdExtensionError" => "AdExtensionError",
-      "AdExtensionOverride" => "AdExtensionOverride",
-      "AdExtensionOverrideError" => "AdExtensionOverrideError",
-      "AdExtensionOverrideOperation" => "AdExtensionOverrideOperation",
-      "AdGroup" => "AdGroup",
-      "AdGroupAd" => "AdGroupAd",
-      "AdGroupAdCountLimitExceeded" => "AdGroupAdCountLimitExceeded",
-      "AdGroupAdError" => "AdGroupAdError",
-      "AdGroupAdExperimentData" => "AdGroupAdExperimentData",
-      "AdGroupAdOperation" => "AdGroupAdOperation",
-      "AdGroupBidModifier" => "AdGroupBidModifier",
-      "AdGroupBidModifierOperation" => "AdGroupBidModifierOperation",
-      "AdGroupCriterion" => "AdGroupCriterion",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionExperimentBidMultiplier" => "AdGroupCriterionExperimentBidMultiplier",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdGroupCriterionOperation" => "AdGroupCriterionOperation",
-      "AdGroupExperimentBidMultipliers" => "AdGroupExperimentBidMultipliers",
-      "AdGroupExperimentData" => "AdGroupExperimentData",
-      "AdGroupOperation" => "AdGroupOperation",
-      "AdGroupServiceError" => "AdGroupServiceError",
-      "AdSchedule" => "AdSchedule",
-      "AdScheduleTarget" => "AdScheduleTarget",
-      "AdScheduleTargetList" => "AdScheduleTargetList",
-      "AdUnionId" => "AdUnionId",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiErrorReason" => "ApiErrorReason",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Audio" => "Audio",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BatchFailureResult" => "BatchFailureResult",
-      "BetaError" => "BetaError",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "BiddableAdGroupCriterion" => "BiddableAdGroupCriterion",
-      "BiddableAdGroupCriterionExperimentData" => "BiddableAdGroupCriterionExperimentData",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "BiddingTransitionError" => "BiddingTransitionError",
-      "Bids" => "Bids",
-      "BillingSummary" => "BillingSummary",
-      "Budget" => "Budget",
-      "BudgetError" => "BudgetError",
-      "BudgetOperation" => "BudgetOperation",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "BulkMutateJob" => "BulkMutateJob",
-      "BulkMutateJobError" => "BulkMutateJobError",
-      "BulkMutateJobEvent" => "BulkMutateJobEvent",
-      "BulkMutateJobPolicy" => "BulkMutateJobPolicy",
-      "BulkMutateJobSelector" => "BulkMutateJobSelector",
-      "BulkMutateJobStats" => "BulkMutateJobStats",
-      "BulkMutateRequest" => "BulkMutateRequest",
-      "BulkMutateResult" => "BulkMutateResult",
-      "Campaign" => "Campaign",
-      "CampaignAdExtension" => "CampaignAdExtension",
-      "CampaignAdExtensionError" => "CampaignAdExtensionError",
-      "CampaignAdExtensionOperation" => "CampaignAdExtensionOperation",
-      "CampaignCriterion" => "CampaignCriterion",
-      "CampaignCriterionError" => "CampaignCriterionError",
-      "CampaignCriterionLimitExceeded" => "CampaignCriterionLimitExceeded",
-      "CampaignCriterionOperation" => "CampaignCriterionOperation",
-      "CampaignError" => "CampaignError",
-      "CampaignOperation" => "CampaignOperation",
-      "CampaignTargetOperation" => "CampaignTargetOperation",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "ContentLabel" => "ContentLabel",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "ConversionOptimizerEligibility" => "ConversionOptimizerEligibility",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DeprecatedAd" => "DeprecatedAd",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "DomainInfoExtension" => "DomainInfoExtension",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityId" => "EntityId",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ExplorerAutoOptimizerSetting" => "ExplorerAutoOptimizerSetting",
-      "FailureResult" => "FailureResult",
-      "FeedItem" => "FeedItem",
-      "FeedItemAttributeError" => "FeedItemAttributeError",
-      "FeedItemAttributeValue" => "FeedItemAttributeValue",
-      "FeedItemDevicePreference" => "FeedItemDevicePreference",
-      "FeedItemError" => "FeedItemError",
-      "FeedItemOperation" => "FeedItemOperation",
-      "FeedItemSchedule" => "FeedItemSchedule",
-      "FeedItemScheduling" => "FeedItemScheduling",
-      "FeedItemValidationDetail" => "FeedItemValidationDetail",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "FrequencyCap" => "FrequencyCap",
-      "Gender" => "Gender",
-      "GeoPoint" => "GeoPoint",
-      "GeoTargetTypeSetting" => "GeoTargetTypeSetting",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageAd" => "ImageAd",
-      "ImageError" => "ImageError",
-      "InAppLinkExtension" => "InAppLinkExtension",
-      "InternalApiError" => "InternalApiError",
-      "Job" => "Job",
-      "JobError" => "JobError",
-      "JobEvent" => "JobEvent",
-      "JobResult" => "JobResult",
-      "JobSelector" => "JobSelector",
-      "JobStats" => "JobStats",
-      "Keyword" => "Keyword",
-      "KeywordMatchSetting" => "KeywordMatchSetting",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LocationExtension" => "LocationExtension",
-      "LocationOverrideInfo" => "LocationOverrideInfo",
-      "LocationSyncExtension" => "LocationSyncExtension",
-      "LongValue" => "LongValue",
-      "LostResult" => "LostResult",
-      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "ManualCPCAdGroupCriterionExperimentBidMultiplier",
-      "ManualCPCAdGroupExperimentBidMultipliers" => "ManualCPCAdGroupExperimentBidMultipliers",
-      "ManualCPMAdGroupExperimentBidMultipliers" => "ManualCPMAdGroupExperimentBidMultipliers",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Media" => "Media",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "MobileAd" => "MobileAd",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "MobileExtension" => "MobileExtension",
-      "MobileImageAd" => "MobileImageAd",
-      "Money" => "Money",
-      "NegativeAdGroupCriterion" => "NegativeAdGroupCriterion",
-      "NegativeCampaignCriterion" => "NegativeCampaignCriterion",
-      "NetworkSetting" => "NetworkSetting",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OAuthInfo" => "OAuthInfo",
-      "Operand" => "Operand",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperationResult" => "OperationResult",
-      "OperationStream" => "OperationStream",
-      "OperationStreamResult" => "OperationStreamResult",
-      "OperatorError" => "OperatorError",
-      "OverrideInfo" => "OverrideInfo",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "PagingError" => "PagingError",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "PlaceHolder" => "PlaceHolder",
-      "Placement" => "Placement",
-      "Platform" => "Platform",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Product" => "Product",
-      "ProductAd" => "ProductAd",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "Proximity" => "Proximity",
-      "QualityInfo" => "QualityInfo",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RealTimeBiddingSetting" => "RealTimeBiddingSetting",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "ReturnValueResult" => "ReturnValueResult",
-      "RichMediaAd" => "RichMediaAd",
-      "SelectorError" => "SelectorError",
-      "Setting" => "Setting",
-      "SettingError" => "SettingError",
-      "SimpleMutateJob" => "SimpleMutateJob",
-      "SimpleMutateResult" => "SimpleMutateResult",
-      "Sitelink" => "Sitelink",
-      "SitelinksExtension" => "SitelinksExtension",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "Target" => "Target",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetError" => "TargetError",
-      "TargetList" => "TargetList",
-      "TargetingSettingDetail" => "TargetingSettingDetail",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "TargetingSetting" => "TargetingSetting",
-      "TempAdUnionId" => "TempAdUnionId",
-      "TemplateAd" => "TemplateAd",
-      "TemplateElement" => "TemplateElement",
-      "TemplateElementField" => "TemplateElementField",
-      "TextAd" => "TextAd",
-      "ThirdPartyRedirectAd" => "ThirdPartyRedirectAd",
-      "TrackingSetting" => "TrackingSetting",
-      "UnprocessedResult" => "UnprocessedResult",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Video" => "Video",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "DynamicSearchAd" => "DynamicSearchAd",
-      "AdError.Reason" => "AdErrorReason",
-      "AdExtensionError.Reason" => "AdExtensionErrorReason",
-      "AdExtensionOverride.ApprovalStatus" => "AdExtensionOverrideApprovalStatus",
-      "AdExtensionOverride.Status" => "AdExtensionOverrideStatus",
-      "AdExtensionOverrideError.Reason" => "AdExtensionOverrideErrorReason",
-      "AdGroupAd.ApprovalStatus" => "AdGroupAdApprovalStatus",
-      "AdGroupAd.Status" => "AdGroupAdStatus",
-      "AdGroupAdError.Reason" => "AdGroupAdErrorReason",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdGroupServiceError.Reason" => "AdGroupServiceErrorReason",
-      "AdGroup.Status" => "AdGroupStatus",
-      "AdServingOptimizationStatus" => "AdServingOptimizationStatus",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "ApprovalStatus" => "ApprovalStatus",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BasicJobStatus" => "BasicJobStatus",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BidModifierSource" => "BidModifierSource",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "BiddingTransitionError.Reason" => "BiddingTransitionErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "BulkMutateJobError.Reason" => "BulkMutateJobErrorReason",
-      "CampaignAdExtension.ApprovalStatus" => "CampaignAdExtensionApprovalStatus",
-      "CampaignAdExtension.Status" => "CampaignAdExtensionStatus",
-      "CampaignAdExtensionError.Reason" => "CampaignAdExtensionErrorReason",
-      "CampaignCriterionError.Reason" => "CampaignCriterionErrorReason",
-      "CampaignCriterionLimitExceeded.CriteriaLimitType" => "CampaignCriterionLimitExceededCriteriaLimitType",
-      "CampaignError.Reason" => "CampaignErrorReason",
-      "CampaignStatus" => "CampaignStatus",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ContentLabelType" => "ContentLabelType",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "ConversionOptimizerEligibility.RejectionReason" => "ConversionOptimizerEligibilityRejectionReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "CriterionTypeGroup" => "CriterionTypeGroup",
-      "CriterionUse" => "CriterionUse",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DeprecatedAd.Type" => "DeprecatedAdType",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityId.Type" => "EntityIdType",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "FeedItem.Status" => "FeedItemStatus",
-      "FeedItemError.Reason" => "FeedItemErrorReason",
-      "FeedItemValidationDetail.ApprovalStatus" => "FeedItemValidationDetailApprovalStatus",
-      "FeedItemValidationDetail.ValidationStatus" => "FeedItemValidationDetailValidationStatus",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "GeoTargetTypeSetting.NegativeGeoTargetType" => "GeoTargetTypeSettingNegativeGeoTargetType",
-      "GeoTargetTypeSetting.PositiveGeoTargetType" => "GeoTargetTypeSettingPositiveGeoTargetType",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "InAppLinkExtension.AppStore" => "InAppLinkExtensionAppStore",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "JobError.Reason" => "JobErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "Level" => "Level",
-      "LocationExtension.Source" => "LocationExtensionSource",
-      "LocationOverrideInfo.RadiusUnits" => "LocationOverrideInfoRadiusUnits",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "MarkupLanguageType" => "MarkupLanguageType",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "MinuteOfHour" => "MinuteOfHour",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "MultiplierSource" => "MultiplierSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "PagingError.Reason" => "PagingErrorReason",
-      "PolicyViolationError.Reason" => "PolicyViolationErrorReason",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "RichMediaAd.AdAttribute" => "RichMediaAdAdAttribute",
-      "RichMediaAd.RichMediaAdType" => "RichMediaAdRichMediaAdType",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "ServingStatus" => "ServingStatus",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "SystemServingStatus" => "SystemServingStatus",
-      "TargetError.Reason" => "TargetErrorReason",
-      "TemplateElementField.Type" => "TemplateElementFieldType",
-      "ThirdPartyRedirectAd.ExpandingDirection" => "ThirdPartyRedirectAdExpandingDirection",
-      "TimeUnit" => "TimeUnit",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "UserStatus" => "UserStatus",
-      "VideoType" => "VideoType",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "MutateJobServiceGet",
-      "getResponse" => "MutateJobServiceGetResponse",
-      "getResult" => "GetResult",
-      "getResultResponse" => "GetResultResponse",
-      "mutate" => "MutateJobServiceMutate",
-      "mutateResponse" => "MutateJobServiceMutateResponse",
+      "Ad" => "Google_Api_Ads_AdWords_v201309\\Ad",
+      "AdError" => "Google_Api_Ads_AdWords_v201309\\AdError",
+      "AdExtension" => "Google_Api_Ads_AdWords_v201309\\AdExtension",
+      "AdExtensionError" => "Google_Api_Ads_AdWords_v201309\\AdExtensionError",
+      "AdExtensionOverride" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverride",
+      "AdExtensionOverrideError" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideError",
+      "AdExtensionOverrideOperation" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideOperation",
+      "AdGroup" => "Google_Api_Ads_AdWords_v201309\\AdGroup",
+      "AdGroupAd" => "Google_Api_Ads_AdWords_v201309\\AdGroupAd",
+      "AdGroupAdCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdCountLimitExceeded",
+      "AdGroupAdError" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdError",
+      "AdGroupAdExperimentData" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdExperimentData",
+      "AdGroupAdOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdOperation",
+      "AdGroupBidModifier" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifier",
+      "AdGroupBidModifierOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidModifierOperation",
+      "AdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterion",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError",
+      "AdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionExperimentBidMultiplier",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded",
+      "AdGroupCriterionOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionOperation",
+      "AdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\AdGroupExperimentBidMultipliers",
+      "AdGroupExperimentData" => "Google_Api_Ads_AdWords_v201309\\AdGroupExperimentData",
+      "AdGroupOperation" => "Google_Api_Ads_AdWords_v201309\\AdGroupOperation",
+      "AdGroupServiceError" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceError",
+      "AdSchedule" => "Google_Api_Ads_AdWords_v201309\\AdSchedule",
+      "AdScheduleTarget" => "Google_Api_Ads_AdWords_v201309\\AdScheduleTarget",
+      "AdScheduleTargetList" => "Google_Api_Ads_AdWords_v201309\\AdScheduleTargetList",
+      "AdUnionId" => "Google_Api_Ads_AdWords_v201309\\AdUnionId",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201309\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiErrorReason" => "Google_Api_Ads_AdWords_v201309\\ApiErrorReason",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Audio" => "Google_Api_Ads_AdWords_v201309\\Audio",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BatchFailureResult" => "Google_Api_Ads_AdWords_v201309\\BatchFailureResult",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "Bid" => "Google_Api_Ads_AdWords_v201309\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201309\\BidMultiplier",
+      "BiddableAdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterion",
+      "BiddableAdGroupCriterionExperimentData" => "Google_Api_Ads_AdWords_v201309\\BiddableAdGroupCriterionExperimentData",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201309\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201309\\BiddingErrors",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyConfiguration",
+      "BiddingTransitionError" => "Google_Api_Ads_AdWords_v201309\\BiddingTransitionError",
+      "Bids" => "Google_Api_Ads_AdWords_v201309\\Bids",
+      "BillingSummary" => "Google_Api_Ads_AdWords_v201309\\BillingSummary",
+      "Budget" => "Google_Api_Ads_AdWords_v201309\\Budget",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201309\\BudgetError",
+      "BudgetOperation" => "Google_Api_Ads_AdWords_v201309\\BudgetOperation",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\BudgetOptimizerBiddingScheme",
+      "BulkMutateJob" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJob",
+      "BulkMutateJobError" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobError",
+      "BulkMutateJobEvent" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobEvent",
+      "BulkMutateJobPolicy" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobPolicy",
+      "BulkMutateJobSelector" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobSelector",
+      "BulkMutateJobStats" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobStats",
+      "BulkMutateRequest" => "Google_Api_Ads_AdWords_v201309\\BulkMutateRequest",
+      "BulkMutateResult" => "Google_Api_Ads_AdWords_v201309\\BulkMutateResult",
+      "Campaign" => "Google_Api_Ads_AdWords_v201309\\Campaign",
+      "CampaignAdExtension" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtension",
+      "CampaignAdExtensionError" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionError",
+      "CampaignAdExtensionOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionOperation",
+      "CampaignCriterion" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterion",
+      "CampaignCriterionError" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionError",
+      "CampaignCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceeded",
+      "CampaignCriterionOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionOperation",
+      "CampaignError" => "Google_Api_Ads_AdWords_v201309\\CampaignError",
+      "CampaignOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignOperation",
+      "CampaignTargetOperation" => "Google_Api_Ads_AdWords_v201309\\CampaignTargetOperation",
+      "Carrier" => "Google_Api_Ads_AdWords_v201309\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "ContentLabel" => "Google_Api_Ads_AdWords_v201309\\ContentLabel",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingScheme",
+      "ConversionOptimizerEligibility" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibility",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201309\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201309\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201309\\CpmBid",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201309\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DeprecatedAd" => "Google_Api_Ads_AdWords_v201309\\DeprecatedAd",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201309\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DomainInfoExtension" => "Google_Api_Ads_AdWords_v201309\\DomainInfoExtension",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\EnhancedCpcBiddingScheme",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDenied",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityId" => "Google_Api_Ads_AdWords_v201309\\EntityId",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201309\\ExemptionRequest",
+      "ExplorerAutoOptimizerSetting" => "Google_Api_Ads_AdWords_v201309\\ExplorerAutoOptimizerSetting",
+      "FailureResult" => "Google_Api_Ads_AdWords_v201309\\FailureResult",
+      "FeedItem" => "Google_Api_Ads_AdWords_v201309\\FeedItem",
+      "FeedItemAttributeError" => "Google_Api_Ads_AdWords_v201309\\FeedItemAttributeError",
+      "FeedItemAttributeValue" => "Google_Api_Ads_AdWords_v201309\\FeedItemAttributeValue",
+      "FeedItemDevicePreference" => "Google_Api_Ads_AdWords_v201309\\FeedItemDevicePreference",
+      "FeedItemError" => "Google_Api_Ads_AdWords_v201309\\FeedItemError",
+      "FeedItemOperation" => "Google_Api_Ads_AdWords_v201309\\FeedItemOperation",
+      "FeedItemSchedule" => "Google_Api_Ads_AdWords_v201309\\FeedItemSchedule",
+      "FeedItemScheduling" => "Google_Api_Ads_AdWords_v201309\\FeedItemScheduling",
+      "FeedItemValidationDetail" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetail",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityError",
+      "FrequencyCap" => "Google_Api_Ads_AdWords_v201309\\FrequencyCap",
+      "Gender" => "Google_Api_Ads_AdWords_v201309\\Gender",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "GeoTargetTypeSetting" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSetting",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201309\\Image",
+      "ImageAd" => "Google_Api_Ads_AdWords_v201309\\ImageAd",
+      "ImageError" => "Google_Api_Ads_AdWords_v201309\\ImageError",
+      "InAppLinkExtension" => "Google_Api_Ads_AdWords_v201309\\InAppLinkExtension",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Job" => "Google_Api_Ads_AdWords_v201309\\Job",
+      "JobError" => "Google_Api_Ads_AdWords_v201309\\JobError",
+      "JobEvent" => "Google_Api_Ads_AdWords_v201309\\JobEvent",
+      "JobResult" => "Google_Api_Ads_AdWords_v201309\\JobResult",
+      "JobSelector" => "Google_Api_Ads_AdWords_v201309\\JobSelector",
+      "JobStats" => "Google_Api_Ads_AdWords_v201309\\JobStats",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "KeywordMatchSetting" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchSetting",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "LocationExtension" => "Google_Api_Ads_AdWords_v201309\\LocationExtension",
+      "LocationOverrideInfo" => "Google_Api_Ads_AdWords_v201309\\LocationOverrideInfo",
+      "LocationSyncExtension" => "Google_Api_Ads_AdWords_v201309\\LocationSyncExtension",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "LostResult" => "Google_Api_Ads_AdWords_v201309\\LostResult",
+      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupCriterionExperimentBidMultiplier",
+      "ManualCPCAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\ManualCPCAdGroupExperimentBidMultipliers",
+      "ManualCPMAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201309\\ManualCPMAdGroupExperimentBidMultipliers",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\ManualCpmBiddingScheme",
+      "Media" => "Google_Api_Ads_AdWords_v201309\\Media",
+      "MediaError" => "Google_Api_Ads_AdWords_v201309\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\Media_Size_StringMapEntry",
+      "MobileAd" => "Google_Api_Ads_AdWords_v201309\\MobileAd",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201309\\MobileDevice",
+      "MobileExtension" => "Google_Api_Ads_AdWords_v201309\\MobileExtension",
+      "MobileImageAd" => "Google_Api_Ads_AdWords_v201309\\MobileImageAd",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NegativeAdGroupCriterion" => "Google_Api_Ads_AdWords_v201309\\NegativeAdGroupCriterion",
+      "NegativeCampaignCriterion" => "Google_Api_Ads_AdWords_v201309\\NegativeCampaignCriterion",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201309\\NetworkSetting",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OAuthInfo" => "Google_Api_Ads_AdWords_v201309\\OAuthInfo",
+      "Operand" => "Google_Api_Ads_AdWords_v201309\\Operand",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersion",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperationResult" => "Google_Api_Ads_AdWords_v201309\\OperationResult",
+      "OperationStream" => "Google_Api_Ads_AdWords_v201309\\OperationStream",
+      "OperationStreamResult" => "Google_Api_Ads_AdWords_v201309\\OperationStreamResult",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OverrideInfo" => "Google_Api_Ads_AdWords_v201309\\OverrideInfo",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingScheme",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\PercentCpaBiddingScheme",
+      "PlaceHolder" => "Google_Api_Ads_AdWords_v201309\\PlaceHolder",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Platform" => "Google_Api_Ads_AdWords_v201309\\Platform",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationKey",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductAd" => "Google_Api_Ads_AdWords_v201309\\ProductAd",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "Proximity" => "Google_Api_Ads_AdWords_v201309\\Proximity",
+      "QualityInfo" => "Google_Api_Ads_AdWords_v201309\\QualityInfo",
+      "QueryError" => "Google_Api_Ads_AdWords_v201309\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201309\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RealTimeBiddingSetting" => "Google_Api_Ads_AdWords_v201309\\RealTimeBiddingSetting",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "ReturnValueResult" => "Google_Api_Ads_AdWords_v201309\\ReturnValueResult",
+      "RichMediaAd" => "Google_Api_Ads_AdWords_v201309\\RichMediaAd",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "Setting" => "Google_Api_Ads_AdWords_v201309\\Setting",
+      "SettingError" => "Google_Api_Ads_AdWords_v201309\\SettingError",
+      "SimpleMutateJob" => "Google_Api_Ads_AdWords_v201309\\SimpleMutateJob",
+      "SimpleMutateResult" => "Google_Api_Ads_AdWords_v201309\\SimpleMutateResult",
+      "Sitelink" => "Google_Api_Ads_AdWords_v201309\\Sitelink",
+      "SitelinksExtension" => "Google_Api_Ads_AdWords_v201309\\SitelinksExtension",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201309\\String_StringMapEntry",
+      "Target" => "Google_Api_Ads_AdWords_v201309\\Target",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetCpaBiddingScheme",
+      "TargetError" => "Google_Api_Ads_AdWords_v201309\\TargetError",
+      "TargetList" => "Google_Api_Ads_AdWords_v201309\\TargetList",
+      "TargetingSettingDetail" => "Google_Api_Ads_AdWords_v201309\\TargetingSettingDetail",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201309\\TargetSpendBiddingScheme",
+      "TargetingSetting" => "Google_Api_Ads_AdWords_v201309\\TargetingSetting",
+      "TempAdUnionId" => "Google_Api_Ads_AdWords_v201309\\TempAdUnionId",
+      "TemplateAd" => "Google_Api_Ads_AdWords_v201309\\TemplateAd",
+      "TemplateElement" => "Google_Api_Ads_AdWords_v201309\\TemplateElement",
+      "TemplateElementField" => "Google_Api_Ads_AdWords_v201309\\TemplateElementField",
+      "TextAd" => "Google_Api_Ads_AdWords_v201309\\TextAd",
+      "ThirdPartyRedirectAd" => "Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAd",
+      "TrackingSetting" => "Google_Api_Ads_AdWords_v201309\\TrackingSetting",
+      "UnprocessedResult" => "Google_Api_Ads_AdWords_v201309\\UnprocessedResult",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Video" => "Google_Api_Ads_AdWords_v201309\\Video",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "DynamicSearchAd" => "Google_Api_Ads_AdWords_v201309\\DynamicSearchAd",
+      "AdError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdErrorReason",
+      "AdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdExtensionErrorReason",
+      "AdExtensionOverride.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideApprovalStatus",
+      "AdExtensionOverride.Status" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideStatus",
+      "AdExtensionOverrideError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdExtensionOverrideErrorReason",
+      "AdGroupAd.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdApprovalStatus",
+      "AdGroupAd.Status" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdStatus",
+      "AdGroupAdError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupAdErrorReason",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdGroupServiceError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupServiceErrorReason",
+      "AdGroup.Status" => "Google_Api_Ads_AdWords_v201309\\AdGroupStatus",
+      "AdServingOptimizationStatus" => "Google_Api_Ads_AdWords_v201309\\AdServingOptimizationStatus",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201309\\AgeRangeAgeRangeType",
+      "ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\ApprovalStatus",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BasicJobStatus" => "Google_Api_Ads_AdWords_v201309\\BasicJobStatus",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "BidModifierSource" => "Google_Api_Ads_AdWords_v201309\\BidModifierSource",
+      "BidSource" => "Google_Api_Ads_AdWords_v201309\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201309\\BiddingStrategyType",
+      "BiddingTransitionError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingTransitionErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201309\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetErrorReason",
+      "BulkMutateJobError.Reason" => "Google_Api_Ads_AdWords_v201309\\BulkMutateJobErrorReason",
+      "CampaignAdExtension.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionApprovalStatus",
+      "CampaignAdExtension.Status" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionStatus",
+      "CampaignAdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignAdExtensionErrorReason",
+      "CampaignCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionErrorReason",
+      "CampaignCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201309\\CampaignCriterionLimitExceededCriteriaLimitType",
+      "CampaignError.Reason" => "Google_Api_Ads_AdWords_v201309\\CampaignErrorReason",
+      "CampaignStatus" => "Google_Api_Ads_AdWords_v201309\\CampaignStatus",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "ContentLabelType" => "Google_Api_Ads_AdWords_v201309\\ContentLabelType",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerBiddingSchemePricingMode",
+      "ConversionOptimizerEligibility.RejectionReason" => "Google_Api_Ads_AdWords_v201309\\ConversionOptimizerEligibilityRejectionReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "CriterionTypeGroup" => "Google_Api_Ads_AdWords_v201309\\CriterionTypeGroup",
+      "CriterionUse" => "Google_Api_Ads_AdWords_v201309\\CriterionUse",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201309\\DayOfWeek",
+      "DeprecatedAd.Type" => "Google_Api_Ads_AdWords_v201309\\DeprecatedAdType",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityId.Type" => "Google_Api_Ads_AdWords_v201309\\EntityIdType",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201309\\ExperimentDeltaStatus",
+      "FeedItem.Status" => "Google_Api_Ads_AdWords_v201309\\FeedItemStatus",
+      "FeedItemError.Reason" => "Google_Api_Ads_AdWords_v201309\\FeedItemErrorReason",
+      "FeedItemValidationDetail.ApprovalStatus" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailApprovalStatus",
+      "FeedItemValidationDetail.ValidationStatus" => "Google_Api_Ads_AdWords_v201309\\FeedItemValidationDetailValidationStatus",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201309\\ForwardCompatibilityErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201309\\GenderGenderType",
+      "GeoTargetTypeSetting.NegativeGeoTargetType" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingNegativeGeoTargetType",
+      "GeoTargetTypeSetting.PositiveGeoTargetType" => "Google_Api_Ads_AdWords_v201309\\GeoTargetTypeSettingPositiveGeoTargetType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201309\\ImageErrorReason",
+      "InAppLinkExtension.AppStore" => "Google_Api_Ads_AdWords_v201309\\InAppLinkExtensionAppStore",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "JobError.Reason" => "Google_Api_Ads_AdWords_v201309\\JobErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "Level" => "Google_Api_Ads_AdWords_v201309\\Level",
+      "LocationExtension.Source" => "Google_Api_Ads_AdWords_v201309\\LocationExtensionSource",
+      "LocationOverrideInfo.RadiusUnits" => "Google_Api_Ads_AdWords_v201309\\LocationOverrideInfoRadiusUnits",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "MarkupLanguageType" => "Google_Api_Ads_AdWords_v201309\\MarkupLanguageType",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201309\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201309\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201309\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201309\\MediaErrorReason",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201309\\MinuteOfHour",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201309\\MobileDeviceDeviceType",
+      "MultiplierSource" => "Google_Api_Ads_AdWords_v201309\\MultiplierSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201309\\OperatingSystemVersionOperatorType",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201309\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "PolicyViolationError.Reason" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorReason",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "RichMediaAd.AdAttribute" => "Google_Api_Ads_AdWords_v201309\\RichMediaAdAdAttribute",
+      "RichMediaAd.RichMediaAdType" => "Google_Api_Ads_AdWords_v201309\\RichMediaAdRichMediaAdType",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "ServingStatus" => "Google_Api_Ads_AdWords_v201309\\ServingStatus",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201309\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "SystemServingStatus" => "Google_Api_Ads_AdWords_v201309\\SystemServingStatus",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201309\\TargetErrorReason",
+      "TemplateElementField.Type" => "Google_Api_Ads_AdWords_v201309\\TemplateElementFieldType",
+      "ThirdPartyRedirectAd.ExpandingDirection" => "Google_Api_Ads_AdWords_v201309\\ThirdPartyRedirectAdExpandingDirection",
+      "TimeUnit" => "Google_Api_Ads_AdWords_v201309\\TimeUnit",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "UserStatus" => "Google_Api_Ads_AdWords_v201309\\UserStatus",
+      "VideoType" => "Google_Api_Ads_AdWords_v201309\\VideoType",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201309\\MutateJobServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\MutateJobServiceGetResponse",
+      "getResult" => "Google_Api_Ads_AdWords_v201309\\GetResult",
+      "getResultResponse" => "Google_Api_Ads_AdWords_v201309\\GetResultResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\MutateJobServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\MutateJobServiceMutateResponse",
     );
 
 
@@ -18831,3 +18829,4 @@ if (!class_exists("MutateJobService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/OfflineConversionFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/OfflineConversionFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("OfflineConversionFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionFeed", false)) {
   /**
    * Represents an entire record in the offline conversions feed that the advertiser uploads.
    * @package Google_Api_Ads_AdWords_v201309
@@ -91,7 +91,7 @@ if (!class_exists("OfflineConversionFeed", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -171,7 +171,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -246,7 +246,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -314,7 +314,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -411,7 +411,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -490,7 +490,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201309
@@ -562,7 +562,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -595,7 +595,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -628,7 +628,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -662,7 +662,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -695,7 +695,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -728,7 +728,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -761,7 +761,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -794,7 +794,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -827,7 +827,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201309
@@ -860,7 +860,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -894,7 +894,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -927,7 +927,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -960,7 +960,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -993,7 +993,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1026,7 +1026,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1059,7 +1059,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1092,7 +1092,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionErrorReason", false)) {
   /**
    * The reasons for an OfflineConversionError.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1125,7 +1125,7 @@ if (!class_exists("OfflineConversionErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1158,7 +1158,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1191,7 +1191,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1224,7 +1224,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1257,7 +1257,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1291,7 +1291,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1324,7 +1324,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1357,7 +1357,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1390,7 +1390,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1423,7 +1423,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1456,7 +1456,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1489,7 +1489,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1522,7 +1522,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1555,7 +1555,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1588,7 +1588,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -1642,7 +1642,7 @@ if (!class_exists("OfflineConversionFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1682,7 +1682,7 @@ if (!class_exists("OfflineConversionFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1727,7 +1727,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1772,7 +1772,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1817,7 +1817,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1863,7 +1863,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1908,7 +1908,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1953,7 +1953,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1998,7 +1998,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2072,7 +2072,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2118,7 +2118,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2163,7 +2163,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2210,7 +2210,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -2256,7 +2256,7 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2301,7 +2301,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2346,7 +2346,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2391,7 +2391,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionError", false)) {
   /**
    * Errors that the {@link OfflineConversionFeedService} can throw.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2436,7 +2436,7 @@ if (!class_exists("OfflineConversionError", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedOperation", false)) {
   /**
    * Operation for uploading {@link OfflineConversionFeed}.
    * See {@link OfflineConversionFeedService#mutate}
@@ -2480,7 +2480,7 @@ if (!class_exists("OfflineConversionFeedOperation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2525,7 +2525,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2570,7 +2570,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2616,7 +2616,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2661,7 +2661,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2706,7 +2706,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2772,7 +2772,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2817,7 +2817,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2862,7 +2862,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2907,7 +2907,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2953,7 +2953,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2998,7 +2998,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3043,7 +3043,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3089,7 +3089,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3134,7 +3134,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3177,7 +3177,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedReturnValue", false)) {
   /**
    * A container for return values from the OfflineConversionFeedService.
    * @package Google_Api_Ads_AdWords_v201309
@@ -3232,7 +3232,7 @@ if (!class_exists("OfflineConversionFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class OfflineConversionFeedService extends AdWordsSoapClient {
+  class OfflineConversionFeedService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "OfflineConversionFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3249,79 +3249,79 @@ if (!class_exists("OfflineConversionFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "MatchesRegexError" => "MatchesRegexError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OfflineConversionError" => "OfflineConversionError",
-      "OfflineConversionFeed" => "OfflineConversionFeed",
-      "OfflineConversionFeedOperation" => "OfflineConversionFeedOperation",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "PagingError" => "PagingError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "OfflineConversionFeedReturnValue" => "OfflineConversionFeedReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OfflineConversionError.Reason" => "OfflineConversionErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "mutate" => "OfflineConversionFeedServiceMutate",
-      "mutateResponse" => "OfflineConversionFeedServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OfflineConversionError" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionError",
+      "OfflineConversionFeed" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionFeed",
+      "OfflineConversionFeedOperation" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedOperation",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "OfflineConversionFeedReturnValue" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OfflineConversionError.Reason" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\OfflineConversionFeedServiceMutateResponse",
     );
 
 
@@ -3359,3 +3359,4 @@ if (!class_exists("OfflineConversionFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ProductServiceService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ProductServiceService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -135,7 +135,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -222,7 +222,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -275,7 +275,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -381,7 +381,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -476,7 +476,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * 
@@ -556,7 +556,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -609,7 +609,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -671,7 +671,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -724,7 +724,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -780,7 +780,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -833,7 +833,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -886,7 +886,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -941,7 +941,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1001,7 +1001,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1063,7 +1063,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1123,7 +1123,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1176,7 +1176,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1229,7 +1229,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1282,7 +1282,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1337,7 +1337,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1424,7 +1424,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1481,7 +1481,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1535,7 +1535,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -1597,7 +1597,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1660,7 +1660,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1716,7 +1716,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -1764,7 +1764,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1817,7 +1817,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1870,7 +1870,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1944,7 +1944,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -1997,7 +1997,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2050,7 +2050,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2104,7 +2104,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2157,7 +2157,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2233,7 +2233,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2286,7 +2286,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2339,7 +2339,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2422,7 +2422,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2498,7 +2498,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2552,7 +2552,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2612,7 +2612,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2679,7 +2679,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2750,7 +2750,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -2818,7 +2818,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -2878,7 +2878,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -2936,7 +2936,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -2977,7 +2977,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3018,7 +3018,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3060,7 +3060,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3101,7 +3101,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3142,7 +3142,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3183,7 +3183,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3224,7 +3224,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3265,7 +3265,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3306,7 +3306,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3348,7 +3348,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3389,7 +3389,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -3430,7 +3430,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3471,7 +3471,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -3512,7 +3512,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3554,7 +3554,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3595,7 +3595,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3636,7 +3636,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3677,7 +3677,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3718,7 +3718,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3759,7 +3759,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3800,7 +3800,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3841,7 +3841,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -3882,7 +3882,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -3923,7 +3923,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3964,7 +3964,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4005,7 +4005,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * 
@@ -4046,7 +4046,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("ProductService", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductService", false)) {
   /**
    * A {@link Criterion} which describes the product or service an Ad is targeting. A product and
    * service criterion can be used to derive a group of {@link KeywordSet} by AdWords Express.
@@ -4099,7 +4099,7 @@ if (!class_exists("ProductService", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4135,7 +4135,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ProductServiceServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductServiceServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4183,7 +4183,7 @@ if (!class_exists("ProductServiceServiceGet", false)) {
   }
 }
 
-if (!class_exists("ProductServiceServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductServiceServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4223,7 +4223,7 @@ if (!class_exists("ProductServiceServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4274,7 +4274,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ProductServicePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductServicePage", false)) {
   /**
    * Contains a page of {@link ProductService}s with no stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4321,7 +4321,7 @@ if (!class_exists("ProductServiceService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ProductServiceService extends AdWordsSoapClient {
+  class ProductServiceService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ProductServiceService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201309";
@@ -4338,86 +4338,86 @@ if (!class_exists("ProductServiceService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Criterion" => "Criterion",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "ProductService" => "ProductService",
-      "ProductServicePage" => "ProductServicePage",
-      "NoStatsPage" => "NoStatsPage",
-      "get" => "ProductServiceServiceGet",
-      "getResponse" => "ProductServiceServiceGetResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201309\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "ProductService" => "Google_Api_Ads_AdWords_v201309\\ProductService",
+      "ProductServicePage" => "Google_Api_Ads_AdWords_v201309\\ProductServicePage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "get" => "Google_Api_Ads_AdWords_v201309\\ProductServiceServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\ProductServiceServiceGetResponse",
     );
 
 
@@ -4449,3 +4449,4 @@ if (!class_exists("ProductServiceService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/PromotionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/PromotionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Address", false)) {
   /**
    * Structure to specify an address location.
    * 
@@ -116,7 +116,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -217,7 +217,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -300,7 +300,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -349,7 +349,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -398,7 +398,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -447,7 +447,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -523,7 +523,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -614,7 +614,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * 
@@ -690,7 +690,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -739,7 +739,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -797,7 +797,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -846,7 +846,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -898,7 +898,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -947,7 +947,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * 
@@ -998,7 +998,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -1047,7 +1047,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1098,7 +1098,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1154,10 +1154,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1211,10 +1211,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1282,7 +1282,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1340,7 +1340,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1396,7 +1396,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1442,7 +1442,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1491,7 +1491,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1540,7 +1540,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1589,7 +1589,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1628,7 +1628,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1712,7 +1712,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1761,7 +1761,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1810,7 +1810,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1861,7 +1861,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1944,7 +1944,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1997,7 +1997,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -2047,7 +2047,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -2105,7 +2105,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2164,7 +2164,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2216,7 +2216,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -2260,7 +2260,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -2268,7 +2268,7 @@ if (!class_exists("Proximity", false)) {
    * by a lat/long pair. The caller may also alternatively provide address fields which will be
    * geocoded into a lat/long pair. Note: If a geoPoint value is provided, the address is not
    * used for calculating the lat/long to target.
-   * <p> A criterion of this type is only targetable.
+   * <p>
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -2336,7 +2336,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2385,7 +2385,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2434,7 +2434,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2504,7 +2504,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2553,7 +2553,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2602,7 +2602,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2652,7 +2652,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2701,7 +2701,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2773,7 +2773,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2822,7 +2822,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2871,7 +2871,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2950,7 +2950,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -3022,7 +3022,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3072,7 +3072,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3128,7 +3128,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3191,7 +3191,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -3258,7 +3258,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -3322,7 +3322,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -3378,7 +3378,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -3432,7 +3432,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -3469,7 +3469,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3506,7 +3506,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3544,7 +3544,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3581,7 +3581,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3618,7 +3618,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3655,7 +3655,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3692,7 +3692,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3729,7 +3729,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3766,7 +3766,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3804,7 +3804,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -3841,7 +3841,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3878,7 +3878,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -3915,7 +3915,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3952,7 +3952,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3989,7 +3989,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -4026,7 +4026,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4063,7 +4063,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -4100,7 +4100,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * 
@@ -4137,7 +4137,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -4175,7 +4175,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4212,7 +4212,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -4249,7 +4249,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4286,7 +4286,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4323,7 +4323,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -4360,7 +4360,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4397,7 +4397,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4434,7 +4434,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -4471,7 +4471,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -4508,7 +4508,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4545,7 +4545,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4582,7 +4582,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * 
@@ -4619,7 +4619,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("Creative", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Creative", false)) {
   /**
    * Creative for a text ad.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4673,7 +4673,7 @@ if (!class_exists("Creative", false)) {
   }
 }
 
-if (!class_exists("ExpressSoapHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExpressSoapHeader", false)) {
   /**
    * {@link SoapHeader} for AdWords Express services.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4720,7 +4720,7 @@ if (!class_exists("ExpressSoapHeader", false)) {
   }
 }
 
-if (!class_exists("KeywordSet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordSet", false)) {
   /**
    * A keyword set based {@link Criterion}.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -4779,7 +4779,7 @@ if (!class_exists("KeywordSet", false)) {
   }
 }
 
-if (!class_exists("NegativeCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeCriterion", false)) {
   /**
    * A negative criterion. It wraps a {@link Criterion} and will be associated with an ad group as a
    * {@link com.google.ads.api.services.campaignmgmt.criterion.adgroupcriterion.NegativeAdGroupCriterion}
@@ -4826,7 +4826,7 @@ if (!class_exists("NegativeCriterion", false)) {
   }
 }
 
-if (!class_exists("NegativeKeyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NegativeKeyword", false)) {
   /**
    * Criterion to mark a keyword is negative keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -4863,7 +4863,7 @@ if (!class_exists("NegativeKeyword", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4899,7 +4899,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ProductService", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductService", false)) {
   /**
    * A {@link Criterion} which describes the product or service an Ad is targeting. A product and
    * service criterion can be used to derive a group of {@link KeywordSet} by AdWords Express.
@@ -4952,7 +4952,7 @@ if (!class_exists("ProductService", false)) {
   }
 }
 
-if (!class_exists("Promotion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Promotion", false)) {
   /**
    * A promotion for a business. It contains all the user specified data as needed by AdWords Express
    * to generate AdWords campaigns.
@@ -5063,7 +5063,7 @@ if (!class_exists("Promotion", false)) {
   }
 }
 
-if (!class_exists("PromotionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionError", false)) {
   /**
    * Promotion related errors for AdWords Express.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5108,7 +5108,7 @@ if (!class_exists("PromotionError", false)) {
   }
 }
 
-if (!class_exists("PromotionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionOperation", false)) {
   /**
    * A typed {@link Operation} class that uses an instance of {@link Promotion} as its operand.
    * 
@@ -5155,7 +5155,7 @@ if (!class_exists("PromotionOperation", false)) {
   }
 }
 
-if (!class_exists("PromotionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionPage", false)) {
   /**
    * Contains a page of {@link Promotion}s with no stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5196,7 +5196,7 @@ if (!class_exists("PromotionPage", false)) {
   }
 }
 
-if (!class_exists("PromotionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionStatus", false)) {
   /**
    * Statuses of a promotion.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5229,7 +5229,7 @@ if (!class_exists("PromotionStatus", false)) {
   }
 }
 
-if (!class_exists("PromotionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionErrorReason", false)) {
   /**
    * Reason behind the {@code PromotionError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5262,7 +5262,7 @@ if (!class_exists("PromotionErrorReason", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5308,7 +5308,7 @@ if (!class_exists("PromotionServiceGet", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5348,7 +5348,7 @@ if (!class_exists("PromotionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionServiceMutate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: ADD, SET.</span>
@@ -5396,7 +5396,7 @@ if (!class_exists("PromotionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PromotionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -5436,7 +5436,7 @@ if (!class_exists("PromotionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -5483,7 +5483,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -5528,7 +5528,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -5579,7 +5579,7 @@ if (!class_exists("PromotionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class PromotionService extends AdWordsSoapClient {
+  class PromotionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "PromotionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201309";
@@ -5596,116 +5596,116 @@ if (!class_exists("PromotionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "Proximity" => "Proximity",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "Creative" => "Creative",
-      "ExpressSoapHeader" => "ExpressSoapHeader",
-      "KeywordSet" => "KeywordSet",
-      "NegativeCriterion" => "NegativeCriterion",
-      "NegativeKeyword" => "NegativeKeyword",
-      "NoStatsPage" => "NoStatsPage",
-      "ProductService" => "ProductService",
-      "Promotion" => "Promotion",
-      "PromotionError" => "PromotionError",
-      "PromotionOperation" => "PromotionOperation",
-      "PromotionPage" => "PromotionPage",
-      "Promotion.Status" => "PromotionStatus",
-      "PromotionError.Reason" => "PromotionErrorReason",
-      "get" => "PromotionServiceGet",
-      "getResponse" => "PromotionServiceGetResponse",
-      "mutate" => "PromotionServiceMutate",
-      "mutateResponse" => "PromotionServiceMutateResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201309\\Address",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201309\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201309\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "Proximity" => "Google_Api_Ads_AdWords_v201309\\Proximity",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201309\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201309\\ProximityDistanceUnits",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201309\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "Creative" => "Google_Api_Ads_AdWords_v201309\\Creative",
+      "ExpressSoapHeader" => "Google_Api_Ads_AdWords_v201309\\ExpressSoapHeader",
+      "KeywordSet" => "Google_Api_Ads_AdWords_v201309\\KeywordSet",
+      "NegativeCriterion" => "Google_Api_Ads_AdWords_v201309\\NegativeCriterion",
+      "NegativeKeyword" => "Google_Api_Ads_AdWords_v201309\\NegativeKeyword",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201309\\NoStatsPage",
+      "ProductService" => "Google_Api_Ads_AdWords_v201309\\ProductService",
+      "Promotion" => "Google_Api_Ads_AdWords_v201309\\Promotion",
+      "PromotionError" => "Google_Api_Ads_AdWords_v201309\\PromotionError",
+      "PromotionOperation" => "Google_Api_Ads_AdWords_v201309\\PromotionOperation",
+      "PromotionPage" => "Google_Api_Ads_AdWords_v201309\\PromotionPage",
+      "Promotion.Status" => "Google_Api_Ads_AdWords_v201309\\PromotionStatus",
+      "PromotionError.Reason" => "Google_Api_Ads_AdWords_v201309\\PromotionErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\PromotionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\PromotionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\PromotionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\PromotionServiceMutateResponse",
     );
 
 
@@ -5751,3 +5751,4 @@ if (!class_exists("PromotionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/ReportDefinitionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/ReportDefinitionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("EnumValuePair", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EnumValuePair", false)) {
   /**
    * Represents information about enum values.
    * @package Google_Api_Ads_AdWords_v201309
@@ -77,7 +77,7 @@ if (!class_exists("EnumValuePair", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReportDefinitionField", false)) {
   /**
    * Represents the fields that can be used to create a ReportDefinition.
    * This class allows the user to query the list of fields applicable to a
@@ -184,7 +184,7 @@ if (!class_exists("ReportDefinitionField", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -259,7 +259,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201309
@@ -327,7 +327,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -424,7 +424,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201309
@@ -503,7 +503,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201309
@@ -536,7 +536,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -569,7 +569,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -602,7 +602,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -636,7 +636,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -669,7 +669,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -702,7 +702,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -735,7 +735,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -768,7 +768,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -801,7 +801,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -834,7 +834,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -867,7 +867,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -900,7 +900,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -933,7 +933,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -966,7 +966,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1000,7 +1000,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1033,7 +1033,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1066,7 +1066,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1099,7 +1099,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1132,7 +1132,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionReportType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReportDefinitionReportType", false)) {
   /**
    * Enums for report types.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1165,7 +1165,7 @@ if (!class_exists("ReportDefinitionReportType", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReportDefinitionErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * a {@link ReportDefinitionService#mutate(java.util.List)} operation.
@@ -1199,7 +1199,7 @@ if (!class_exists("ReportDefinitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1232,7 +1232,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1265,7 +1265,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1298,7 +1298,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1331,7 +1331,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("GetReportFields", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetReportFields", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1383,7 +1383,7 @@ if (!class_exists("GetReportFields", false)) {
   }
 }
 
-if (!class_exists("GetReportFieldsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetReportFieldsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1423,7 +1423,7 @@ if (!class_exists("GetReportFieldsResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1468,7 +1468,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1513,7 +1513,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * Errors that are thrown when a Beta feature is accessed incorrectly.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1558,7 +1558,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1603,7 +1603,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1649,7 +1649,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1694,7 +1694,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1739,7 +1739,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1784,7 +1784,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1831,7 +1831,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1876,7 +1876,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1921,7 +1921,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201309
@@ -1966,7 +1966,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2011,7 +2011,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2056,7 +2056,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2101,7 +2101,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2167,7 +2167,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2212,7 +2212,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2257,7 +2257,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReportDefinitionError", false)) {
   /**
    * Encapsulates the errors that can be thrown during {@link ReportDefinition}
    * mutate operation.
@@ -2303,7 +2303,7 @@ if (!class_exists("ReportDefinitionError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2349,7 +2349,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2394,7 +2394,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2439,7 +2439,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2485,7 +2485,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2530,7 +2530,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201309
@@ -2579,7 +2579,7 @@ if (!class_exists("ReportDefinitionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class ReportDefinitionService extends AdWordsSoapClient {
+  class ReportDefinitionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ReportDefinitionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -2596,64 +2596,64 @@ if (!class_exists("ReportDefinitionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "EnumValuePair" => "EnumValuePair",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "ReportDefinitionError" => "ReportDefinitionError",
-      "ReportDefinitionField" => "ReportDefinitionField",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "ReportDefinition.ReportType" => "ReportDefinitionReportType",
-      "ReportDefinitionError.Reason" => "ReportDefinitionErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "getReportFields" => "GetReportFields",
-      "getReportFieldsResponse" => "GetReportFieldsResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EnumValuePair" => "Google_Api_Ads_AdWords_v201309\\EnumValuePair",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "ReportDefinitionError" => "Google_Api_Ads_AdWords_v201309\\ReportDefinitionError",
+      "ReportDefinitionField" => "Google_Api_Ads_AdWords_v201309\\ReportDefinitionField",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "ReportDefinition.ReportType" => "Google_Api_Ads_AdWords_v201309\\ReportDefinitionReportType",
+      "ReportDefinitionError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReportDefinitionErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "getReportFields" => "Google_Api_Ads_AdWords_v201309\\GetReportFields",
+      "getReportFieldsResponse" => "Google_Api_Ads_AdWords_v201309\\GetReportFieldsResponse",
     );
 
 
@@ -2689,3 +2689,4 @@ if (!class_exists("ReportDefinitionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/SharedCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/SharedCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -77,7 +77,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -124,7 +124,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * <span class="constraint InRange">This field must be greater than or equal to 0.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -171,7 +171,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -225,7 +225,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint StringLength">This string must not be empty.</span>
@@ -266,7 +266,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -341,7 +341,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -409,7 +409,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -456,7 +456,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Indicates that this instance is a subtype of CriterionParameter.
    * Although this field is returned in the response, it is ignored on input
@@ -530,7 +530,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -577,7 +577,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -672,7 +672,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Indicates that this instance is a subtype of ApplicationException.
    * Although this field is returned in the response, it is ignored on input
@@ -753,7 +753,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * <span class="constraint ContentsDistinct">This field must contain distinct elements.</span>
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
@@ -823,7 +823,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -909,7 +909,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("SharedCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterion", false)) {
   /**
    * <span class="constraint Selectable">This field can be selected using the value "SharedSetId".</span><span class="constraint Filterable">This field can be filtered on.</span>
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
@@ -964,7 +964,7 @@ if (!class_exists("SharedCriterion", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Indicates that this instance is a subtype of ListReturnValue.
    * Although this field is returned in the response, it is ignored on input
@@ -1038,7 +1038,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1117,7 +1117,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Indicates that this instance is a subtype of Page.
    * Although this field is returned in the response, it is ignored on input
@@ -1198,7 +1198,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1231,7 +1231,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1264,7 +1264,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1297,7 +1297,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1330,9 +1330,9 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
-   * <span class="constraint Beta">This is a beta feature.</span>
+   * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -1363,7 +1363,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1396,7 +1396,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1429,7 +1429,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1462,7 +1462,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1495,7 +1495,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1528,7 +1528,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1561,7 +1561,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1594,7 +1594,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1627,7 +1627,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1660,7 +1660,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1693,7 +1693,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1726,7 +1726,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1759,7 +1759,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1792,7 +1792,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1825,7 +1825,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1858,7 +1858,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1891,7 +1891,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1924,7 +1924,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1957,7 +1957,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1990,7 +1990,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2023,7 +2023,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2056,7 +2056,7 @@ if (!class_exists("SharedCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -2089,7 +2089,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2122,7 +2122,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2155,7 +2155,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2188,7 +2188,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -2221,7 +2221,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2269,7 +2269,7 @@ if (!class_exists("SharedCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2309,7 +2309,7 @@ if (!class_exists("SharedCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2361,7 +2361,7 @@ if (!class_exists("SharedCriterionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2401,7 +2401,7 @@ if (!class_exists("SharedCriterionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2446,7 +2446,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2491,7 +2491,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2536,7 +2536,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2581,7 +2581,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2626,7 +2626,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2671,7 +2671,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2744,7 +2744,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2789,7 +2789,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2834,7 +2834,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2879,7 +2879,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -2930,7 +2930,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -2981,7 +2981,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3032,7 +3032,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3077,7 +3077,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3122,7 +3122,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3167,7 +3167,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3212,7 +3212,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3256,7 +3256,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3301,7 +3301,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3346,7 +3346,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3412,7 +3412,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3457,7 +3457,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3502,7 +3502,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3547,7 +3547,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3592,7 +3592,7 @@ if (!class_exists("SharedCriterionError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3637,7 +3637,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3682,7 +3682,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3733,7 +3733,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3791,7 +3791,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3849,7 +3849,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint StringLength">The length of this string should be between 1 and 2048, inclusive.</span>
@@ -3899,7 +3899,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3944,7 +3944,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -4002,7 +4002,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4045,7 +4045,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -4096,7 +4096,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionOperation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -4139,7 +4139,7 @@ if (!class_exists("SharedCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4182,7 +4182,7 @@ if (!class_exists("SharedCriterionPage", false)) {
   }
 }
 
-if (!class_exists("SharedCriterionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedCriterionReturnValue", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4230,7 +4230,7 @@ if (!class_exists("SharedCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class SharedCriterionService extends AdWordsSoapClient {
+  class SharedCriterionService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "SharedCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -4247,97 +4247,97 @@ if (!class_exists("SharedCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "CriterionError" => "CriterionError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SharedCriterionError" => "SharedCriterionError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "ProductCondition" => "ProductCondition",
-      "Webpage" => "Webpage",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Product" => "Product",
-      "Selector" => "Selector",
-      "Criterion" => "Criterion",
-      "SharedCriterion" => "SharedCriterion",
-      "SharedCriterionOperation" => "SharedCriterionOperation",
-      "SharedCriterionPage" => "SharedCriterionPage",
-      "SharedCriterionReturnValue" => "SharedCriterionReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SharedCriterionError.Reason" => "SharedCriterionErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "SharedCriterionServiceGet",
-      "getResponse" => "SharedCriterionServiceGetResponse",
-      "mutate" => "SharedCriterionServiceMutate",
-      "mutateResponse" => "SharedCriterionServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SharedCriterionError" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "SharedCriterion" => "Google_Api_Ads_AdWords_v201309\\SharedCriterion",
+      "SharedCriterionOperation" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionOperation",
+      "SharedCriterionPage" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionPage",
+      "SharedCriterionReturnValue" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SharedCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\SharedCriterionServiceMutateResponse",
     );
 
 
@@ -4389,3 +4389,4 @@ if (!class_exists("SharedCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/SharedSetService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/SharedSetService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateRange", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -77,7 +77,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OrderBy", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -124,7 +124,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * <span class="constraint InRange">This field must be greater than or equal to 0.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -171,7 +171,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Predicate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -225,7 +225,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SharedSet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSet", false)) {
   /**
    * <span class="constraint Selectable">This field can be selected using the value "SharedSetId".</span><span class="constraint Filterable">This field can be filtered on.</span>
    * <span class="constraint Required">This field is required and should not be {@code null} when it is contained within {@link Operator}s : SET, REMOVE.</span>
@@ -301,7 +301,7 @@ if (!class_exists("SharedSet", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -376,7 +376,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -444,7 +444,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ListReturnValue", false)) {
   /**
    * Indicates that this instance is a subtype of ListReturnValue.
    * Although this field is returned in the response, it is ignored on input
@@ -518,7 +518,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -597,7 +597,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Page", false)) {
   /**
    * Indicates that this instance is a subtype of Page.
    * Although this field is returned in the response, it is ignored on input
@@ -678,7 +678,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -773,7 +773,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Indicates that this instance is a subtype of ApplicationException.
    * Although this field is returned in the response, it is ignored on input
@@ -854,7 +854,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Selector", false)) {
   /**
    * <span class="constraint ContentsDistinct">This field must contain distinct elements.</span>
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
@@ -924,7 +924,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -957,7 +957,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -990,7 +990,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1023,7 +1023,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1056,7 +1056,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1089,7 +1089,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1122,7 +1122,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1155,7 +1155,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1188,7 +1188,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1221,7 +1221,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1254,7 +1254,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1287,7 +1287,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1320,7 +1320,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1353,7 +1353,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1386,7 +1386,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1419,7 +1419,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Operator", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1452,7 +1452,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1485,7 +1485,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1518,7 +1518,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PredicateOperator", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1551,7 +1551,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1584,7 +1584,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1617,7 +1617,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1650,7 +1650,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1683,7 +1683,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1716,7 +1716,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1749,7 +1749,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1782,7 +1782,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SharedSetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetStatus", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1815,7 +1815,7 @@ if (!class_exists("SharedSetStatus", false)) {
   }
 }
 
-if (!class_exists("SharedSetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1848,7 +1848,7 @@ if (!class_exists("SharedSetErrorReason", false)) {
   }
 }
 
-if (!class_exists("SharedSetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1881,7 +1881,7 @@ if (!class_exists("SharedSetType", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -1914,7 +1914,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SortOrder", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1947,7 +1947,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -1980,7 +1980,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("SharedSetServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2028,7 +2028,7 @@ if (!class_exists("SharedSetServiceGet", false)) {
   }
 }
 
-if (!class_exists("SharedSetServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2068,7 +2068,7 @@ if (!class_exists("SharedSetServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("SharedSetServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2117,7 +2117,7 @@ if (!class_exists("SharedSetServiceMutate", false)) {
   }
 }
 
-if (!class_exists("SharedSetServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2157,7 +2157,7 @@ if (!class_exists("SharedSetServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2202,7 +2202,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2247,7 +2247,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BetaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BetaError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2292,7 +2292,7 @@ if (!class_exists("BetaError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2337,7 +2337,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2382,7 +2382,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2455,7 +2455,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2500,7 +2500,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2545,7 +2545,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2590,7 +2590,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NewEntityCreationError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2635,7 +2635,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2680,7 +2680,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2725,7 +2725,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2770,7 +2770,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2815,7 +2815,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2860,7 +2860,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PagingError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2905,7 +2905,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2950,7 +2950,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -2995,7 +2995,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3061,7 +3061,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3106,7 +3106,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3151,7 +3151,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3196,7 +3196,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3241,7 +3241,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SharedSetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3286,7 +3286,7 @@ if (!class_exists("SharedSetError", false)) {
   }
 }
 
-if (!class_exists("SharedSetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetOperation", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * @package Google_Api_Ads_AdWords_v201309
@@ -3329,7 +3329,7 @@ if (!class_exists("SharedSetOperation", false)) {
   }
 }
 
-if (!class_exists("SharedSetReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetReturnValue", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3371,7 +3371,7 @@ if (!class_exists("SharedSetReturnValue", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3416,7 +3416,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3461,7 +3461,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3506,7 +3506,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3542,7 +3542,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3585,7 +3585,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("SharedSetPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SharedSetPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -3632,7 +3632,7 @@ if (!class_exists("SharedSetService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class SharedSetService extends AdWordsSoapClient {
+  class SharedSetService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "SharedSetService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
@@ -3649,87 +3649,87 @@ if (!class_exists("SharedSetService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BetaError" => "BetaError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SharedSet" => "SharedSet",
-      "SharedSetError" => "SharedSetError",
-      "SharedSetOperation" => "SharedSetOperation",
-      "SharedSetPage" => "SharedSetPage",
-      "SharedSetReturnValue" => "SharedSetReturnValue",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ListReturnValue" => "ListReturnValue",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BetaError.Reason" => "BetaErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SharedSet.Status" => "SharedSetStatus",
-      "SharedSetError.Reason" => "SharedSetErrorReason",
-      "SharedSetType" => "SharedSetType",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "SharedSetServiceGet",
-      "getResponse" => "SharedSetServiceGetResponse",
-      "mutate" => "SharedSetServiceMutate",
-      "mutateResponse" => "SharedSetServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BetaError" => "Google_Api_Ads_AdWords_v201309\\BetaError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201309\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201309\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201309\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201309\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SharedSet" => "Google_Api_Ads_AdWords_v201309\\SharedSet",
+      "SharedSetError" => "Google_Api_Ads_AdWords_v201309\\SharedSetError",
+      "SharedSetOperation" => "Google_Api_Ads_AdWords_v201309\\SharedSetOperation",
+      "SharedSetPage" => "Google_Api_Ads_AdWords_v201309\\SharedSetPage",
+      "SharedSetReturnValue" => "Google_Api_Ads_AdWords_v201309\\SharedSetReturnValue",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201309\\ListReturnValue",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201309\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201309\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201309\\Page",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201309\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201309\\BetaErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201309\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201309\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201309\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201309\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SharedSet.Status" => "Google_Api_Ads_AdWords_v201309\\SharedSetStatus",
+      "SharedSetError.Reason" => "Google_Api_Ads_AdWords_v201309\\SharedSetErrorReason",
+      "SharedSetType" => "Google_Api_Ads_AdWords_v201309\\SharedSetType",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201309\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\SharedSetServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\SharedSetServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201309\\SharedSetServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201309\\SharedSetServiceMutateResponse",
     );
 
 
@@ -3778,3 +3778,4 @@ if (!class_exists("SharedSetService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/TargetingIdeaService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/TargetingIdeaService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -131,7 +131,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -214,7 +214,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -263,7 +263,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -312,7 +312,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeLandscapePoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidLandscapeLandscapePoint", false)) {
   /**
    * A set of estimates for a criterion's performance for a specific bid
    * amount.
@@ -392,7 +392,7 @@ if (!class_exists("BidLandscapeLandscapePoint", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * 
@@ -441,7 +441,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * 
@@ -490,7 +490,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -539,7 +539,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -554,6 +554,12 @@ if (!class_exists("CollectionSizeError", false)) {
 
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
     const XSI_TYPE = "CollectionSizeError";
+
+    /**
+     * @access public
+     * @var tnsCollectionSizeErrorReason
+     */
+    public $reason;
 
     /**
      * Gets the namesapce of this class
@@ -571,8 +577,9 @@ if (!class_exists("CollectionSizeError", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
+    public function __construct($reason = null, $fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
       parent::__construct();
+      $this->reason = $reason;
       $this->fieldPath = $fieldPath;
       $this->trigger = $trigger;
       $this->errorString = $errorString;
@@ -582,7 +589,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -658,7 +665,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -749,7 +756,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * 
@@ -798,7 +805,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * 
@@ -874,7 +881,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -923,7 +930,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -972,7 +979,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -1021,7 +1028,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1099,7 +1106,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -1149,7 +1156,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -1198,7 +1205,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1249,7 +1256,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1305,10 +1312,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1362,10 +1369,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1433,7 +1440,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1491,7 +1498,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1547,7 +1554,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1593,7 +1600,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * 
@@ -1658,7 +1665,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1707,7 +1714,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1756,7 +1763,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1805,7 +1812,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1844,7 +1851,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1893,7 +1900,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1946,7 +1953,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1996,10 +2003,10 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -2046,7 +2053,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -2141,7 +2148,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * 
@@ -2192,7 +2199,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -2244,7 +2251,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2303,7 +2310,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2355,7 +2362,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -2399,7 +2406,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2448,7 +2455,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2497,7 +2504,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2567,7 +2574,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2616,7 +2623,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * 
@@ -2665,7 +2672,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2715,7 +2722,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2764,7 +2771,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2813,7 +2820,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2892,7 +2899,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2964,7 +2971,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * 
@@ -3013,7 +3020,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3063,7 +3070,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DataEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DataEntry", false)) {
   /**
    * The base class of all return types of the table service.
    * 
@@ -3139,7 +3146,7 @@ if (!class_exists("DataEntry", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * 
@@ -3188,7 +3195,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3244,7 +3251,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3307,7 +3314,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -3374,7 +3381,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -3438,7 +3445,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -3494,7 +3501,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -3548,7 +3555,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapeType", false)) {
   /**
    * Used to specify the type of {@code AdGroupLandscape}
    * 
@@ -3585,7 +3592,7 @@ if (!class_exists("AdGroupBidLandscapeType", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3622,7 +3629,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * 
@@ -3659,7 +3666,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * 
@@ -3696,7 +3703,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -3733,7 +3740,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3770,7 +3777,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * 
@@ -3807,7 +3814,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * 
@@ -3844,7 +3851,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3882,7 +3889,44 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
+  /**
+   * The reasons for the target error.
+   * 
+   * 
+   * 
+   * Represents data about a bidlandscape for an adgroup.
+   * @package Google_Api_Ads_AdWords_v201309
+   * @subpackage v201309
+   */
+  class CollectionSizeErrorReason {
+
+    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
+    const XSI_TYPE = "CollectionSizeError.Reason";
+
+    /**
+     * Gets the namesapce of this class
+     * @return the namespace of this class
+     */
+    public function getNamespace() {
+      return self::WSDL_NAMESPACE;
+    }
+
+    /**
+     * Gets the xsi:type name of this class
+     * @return the xsi:type name of this class
+     */
+    public function getXsiTypeName() {
+      return self::XSI_TYPE;
+    }
+
+    public function __construct() {
+    }
+
+  }
+}
+
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3919,7 +3963,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * 
@@ -3956,7 +4000,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3993,7 +4037,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4030,7 +4074,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4067,7 +4111,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * 
@@ -4104,7 +4148,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -4142,7 +4186,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4179,7 +4223,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -4216,7 +4260,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -4254,7 +4298,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -4291,7 +4335,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4328,7 +4372,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -4365,7 +4409,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4402,7 +4446,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -4439,7 +4483,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -4477,7 +4521,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4514,7 +4558,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -4551,7 +4595,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4588,7 +4632,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4625,7 +4669,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -4662,7 +4706,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4699,7 +4743,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -4736,7 +4780,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * 
@@ -4773,7 +4817,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4810,7 +4854,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4847,7 +4891,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4884,7 +4928,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * 
@@ -4921,7 +4965,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("AdFormatSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdFormatSpec", false)) {
   /**
    * A placement response object which provides information about one of the ad formats
    * supported by a placement.
@@ -4962,7 +5006,7 @@ if (!class_exists("AdFormatSpec", false)) {
   }
 }
 
-if (!class_exists("AdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdSpec", false)) {
   /**
    * Interface for ad specifications to implement. See individual spec
    * documentation for more details on how to use each type, and
@@ -5018,7 +5062,7 @@ if (!class_exists("AdSpec", false)) {
   }
 }
 
-if (!class_exists("Attribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Attribute", false)) {
   /**
    * {@link Attribute}s encompass the core information about a particular
    * {@link com.google.ads.api.services.targetingideas.TargetingIdea}. Some
@@ -5097,7 +5141,7 @@ if (!class_exists("Attribute", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidLandscapeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link BidLandscape} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5139,7 +5183,7 @@ if (!class_exists("BidLandscapeAttribute", false)) {
   }
 }
 
-if (!class_exists("BooleanAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BooleanAttribute", false)) {
   /**
    * {@link Attribute} type that contains a boolean value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5181,7 +5225,7 @@ if (!class_exists("BooleanAttribute", false)) {
   }
 }
 
-if (!class_exists("CriterionAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Criterion} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5223,7 +5267,7 @@ if (!class_exists("CriterionAttribute", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5268,7 +5312,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DisplayAdSpec", false)) {
   /**
    * Placement request/response object which provides details about display
    * ad types, options, and other available configuration variables.
@@ -5323,7 +5367,7 @@ if (!class_exists("DisplayAdSpec", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpecAdSizeSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DisplayAdSpecAdSizeSpec", false)) {
   /**
    * Specification for an ad size. This specification allows customization by
    * display options for more fine-grained control over returns, so that
@@ -5386,7 +5430,7 @@ if (!class_exists("DisplayAdSpecAdSizeSpec", false)) {
   }
 }
 
-if (!class_exists("DisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DisplayType", false)) {
   /**
    * Base interface for types of display ads.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5440,7 +5484,7 @@ if (!class_exists("DisplayType", false)) {
   }
 }
 
-if (!class_exists("DoubleAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleAttribute", false)) {
   /**
    * {@link Attribute} type that contains a double value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5482,58 +5526,7 @@ if (!class_exists("DoubleAttribute", false)) {
   }
 }
 
-if (!class_exists("DoubleComparisonOperation", false)) {
-  /**
-   * Object representing double comparison operations. This is usually used within
-   * a particular
-   * {@link com.google.ads.api.services.targetingideas.search.SearchParameter} to
-   * specify the valid values requested for the specific
-   * {@link com.google.ads.api.services.common.optimization.attributes.Attribute}.
-   * @package Google_Api_Ads_AdWords_v201309
-   * @subpackage v201309
-   */
-  class DoubleComparisonOperation {
-
-    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201309";
-    const XSI_TYPE = "DoubleComparisonOperation";
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $minimum;
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $maximum;
-
-    /**
-     * Gets the namesapce of this class
-     * @return the namespace of this class
-     */
-    public function getNamespace() {
-      return self::WSDL_NAMESPACE;
-    }
-
-    /**
-     * Gets the xsi:type name of this class
-     * @return the xsi:type name of this class
-     */
-    public function getXsiTypeName() {
-      return self::XSI_TYPE;
-    }
-
-    public function __construct($minimum = null, $maximum = null) {
-      $this->minimum = $minimum;
-      $this->maximum = $maximum;
-    }
-
-  }
-}
-
-if (!class_exists("FlashDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\FlashDisplayType", false)) {
   /**
    * {@link DisplayType} implementation for Flash display ads.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5566,7 +5559,7 @@ if (!class_exists("FlashDisplayType", false)) {
   }
 }
 
-if (!class_exists("HtmlDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\HtmlDisplayType", false)) {
   /**
    * HTML-specific options for display ads are contained within
    * this class.
@@ -5607,7 +5600,7 @@ if (!class_exists("HtmlDisplayType", false)) {
   }
 }
 
-if (!class_exists("IdeaTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdeaTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link IdeaType} value. For example,
    * if a {@link com.google.ads.api.services.targetingideas.TargetingIdea}
@@ -5652,7 +5645,7 @@ if (!class_exists("IdeaTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("ImageDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ImageDisplayType", false)) {
   /**
    * {@link DisplayType} implementation for images.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5685,7 +5678,7 @@ if (!class_exists("ImageDisplayType", false)) {
   }
 }
 
-if (!class_exists("InStreamAdInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InStreamAdInfo", false)) {
   /**
    * Information specific to the instream ad format. Instream ads are video ads
    * which play as part of the delivery of video content, either before, during,
@@ -5762,7 +5755,7 @@ if (!class_exists("InStreamAdInfo", false)) {
   }
 }
 
-if (!class_exists("InStreamAdInfoAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InStreamAdInfoAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link InStreamAdInfo} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5804,7 +5797,7 @@ if (!class_exists("InStreamAdInfoAttribute", false)) {
   }
 }
 
-if (!class_exists("InStreamAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InStreamAdSpec", false)) {
   /**
    * Placement request/response object which provides details about instream
    * ad types, options, and other available configuration variables.
@@ -5852,7 +5845,7 @@ if (!class_exists("InStreamAdSpec", false)) {
   }
 }
 
-if (!class_exists("IntegerAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IntegerAttribute", false)) {
   /**
    * {@link Attribute} type that contains an integer value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5894,7 +5887,7 @@ if (!class_exists("IntegerAttribute", false)) {
   }
 }
 
-if (!class_exists("IntegerSetAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IntegerSetAttribute", false)) {
   /**
    * {@link Attribute} type that contains a Set of integer values.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5936,7 +5929,7 @@ if (!class_exists("IntegerSetAttribute", false)) {
   }
 }
 
-if (!class_exists("KeywordAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Keyword} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5978,7 +5971,7 @@ if (!class_exists("KeywordAttribute", false)) {
   }
 }
 
-if (!class_exists("LongAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongAttribute", false)) {
   /**
    * {@link Attribute} type that contains a long value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6020,7 +6013,7 @@ if (!class_exists("LongAttribute", false)) {
   }
 }
 
-if (!class_exists("LongComparisonOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongComparisonOperation", false)) {
   /**
    * Object representing integer comparison operations. This is usually used within
    * a particular
@@ -6071,7 +6064,7 @@ if (!class_exists("LongComparisonOperation", false)) {
   }
 }
 
-if (!class_exists("LongRangeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongRangeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Range} of {@link LongValue}
    * values.
@@ -6114,7 +6107,7 @@ if (!class_exists("LongRangeAttribute", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -6160,7 +6153,7 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("MoneyAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MoneyAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Money} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6202,7 +6195,7 @@ if (!class_exists("MoneyAttribute", false)) {
   }
 }
 
-if (!class_exists("MonthlySearchVolume", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MonthlySearchVolume", false)) {
   /**
    * A keyword response value representing search volume for a single month. An
    * instance with a {@code null} count is valid, indicating that the information
@@ -6258,7 +6251,7 @@ if (!class_exists("MonthlySearchVolume", false)) {
   }
 }
 
-if (!class_exists("MonthlySearchVolumeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MonthlySearchVolumeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link MonthlySearchVolume}
    * values. The list contains the past 12 {@link MonthlySearchVolume}s
@@ -6303,7 +6296,7 @@ if (!class_exists("MonthlySearchVolumeAttribute", false)) {
   }
 }
 
-if (!class_exists("OpportunityIdeaTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OpportunityIdeaTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link OpportunityIdeaType} value.
    * For example, if a
@@ -6349,7 +6342,7 @@ if (!class_exists("OpportunityIdeaTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("PlacementAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PlacementAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Placement} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6391,7 +6384,7 @@ if (!class_exists("PlacementAttribute", false)) {
   }
 }
 
-if (!class_exists("PlacementTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PlacementTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link PlacementType} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6433,7 +6426,7 @@ if (!class_exists("PlacementTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("Range", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Range", false)) {
   /**
    * Represents a range of values that has either an upper or a lower bound.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6480,7 +6473,7 @@ if (!class_exists("Range", false)) {
   }
 }
 
-if (!class_exists("SearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SearchParameter", false)) {
   /**
    * A set of {@link SearchParameter}s are supplied to the
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaSelector}
@@ -6500,7 +6493,10 @@ if (!class_exists("SearchParameter", false)) {
    * related information (eg. {@link CompetitionSearchParameter}, etc.).</li>
    * </ul><p>
    * 
-   * A request should only contain one instance of each {@link SearchParameter}
+   * A request should only contain one instance of each {@link SearchParameter}.
+   * 
+   * NOTICE: Starting with version v201406, requests containing multiple
+   * instances of the same search parameter will be rejected.
    * <p>One or more of the following {@link SearchParameter}s are required:<br/>
    * <ul><li>{@link CategoryProductsAndServicesSearchParameter}</li>
    * <li>{@link LocationSearchParameter}</li>
@@ -6520,7 +6516,6 @@ if (!class_exists("SearchParameter", false)) {
    * <li>{@link NetworkSearchParameter}</li>
    * <li>{@link RelatedToQuerySearchParameter}</li>
    * <li>{@link RelatedToUrlSearchParameter}</li>
-   * <li>{@link SearchVolumeDeltaSearchParameter}</li>
    * <li>{@link SearchVolumeSearchParameter}</li>
    * <li>{@link SeedAdGroupIdSearchParameter}</li>
    * </ul><p>
@@ -6602,63 +6597,7 @@ if (!class_exists("SearchParameter", false)) {
   }
 }
 
-if (!class_exists("SearchVolumeDeltaSearchParameter", false)) {
-  /**
-   * A {@link SearchParameter} that specifies the level of search volume delta expected in results,
-   * and it is directly related to
-   * {@link com.google.ads.api.services.targetingideas.external.AttributeType#SEARCH_VOLUME_DELTA}.
-   * Absence of a {@link SearchVolumeDeltaSearchParameter} in a
-   * {@link com.google.ads.api.services.targetingideas.TargetingIdeaSelector} is
-   * equivalent to having no constraint on search volume delta specified.
-   * <p>This element is supported by following {@link IdeaType}s: KEYWORD.
-   * <p>This element is supported by following {@link RequestType}s: STATS, IDEAS.
-   * @package Google_Api_Ads_AdWords_v201309
-   * @subpackage v201309
-   */
-  class SearchVolumeDeltaSearchParameter extends SearchParameter {
-
-    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201309";
-    const XSI_TYPE = "SearchVolumeDeltaSearchParameter";
-
-    /**
-     * @access public
-     * @var DoubleComparisonOperation
-     */
-    public $relative;
-
-    /**
-     * @access public
-     * @var LongComparisonOperation
-     */
-    public $absolute;
-
-    /**
-     * Gets the namesapce of this class
-     * @return the namespace of this class
-     */
-    public function getNamespace() {
-      return self::WSDL_NAMESPACE;
-    }
-
-    /**
-     * Gets the xsi:type name of this class
-     * @return the xsi:type name of this class
-     */
-    public function getXsiTypeName() {
-      return self::XSI_TYPE;
-    }
-
-    public function __construct($relative = null, $absolute = null, $SearchParameterType = null) {
-      parent::__construct();
-      $this->relative = $relative;
-      $this->absolute = $absolute;
-      $this->SearchParameterType = $SearchParameterType;
-    }
-
-  }
-}
-
-if (!class_exists("SearchVolumeSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SearchVolumeSearchParameter", false)) {
   /**
    * A {@link SearchParameter} that specifies the level of search volume expected in results,
    * and it has a direct relationship to
@@ -6707,7 +6646,7 @@ if (!class_exists("SearchVolumeSearchParameter", false)) {
   }
 }
 
-if (!class_exists("SeedAdGroupIdSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SeedAdGroupIdSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s
    * that specifies that the supplied AdGroup should be used as a seed
@@ -6754,7 +6693,7 @@ if (!class_exists("SeedAdGroupIdSearchParameter", false)) {
   }
 }
 
-if (!class_exists("StringAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringAttribute", false)) {
   /**
    * {@link Attribute} type that contains a string value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -6796,7 +6735,7 @@ if (!class_exists("StringAttribute", false)) {
   }
 }
 
-if (!class_exists("TargetingIdea", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdea", false)) {
   /**
    * Represents a {@link TargetingIdea} returned by search criteria specified in
    * the {@link TargetingIdeaSelector}. Targeting ideas are keywords or placements
@@ -6838,7 +6777,7 @@ if (!class_exists("TargetingIdea", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaError", false)) {
   /**
    * Base error class for the
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaService}.
@@ -6884,7 +6823,7 @@ if (!class_exists("TargetingIdeaError", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaPage", false)) {
   /**
    * Contains a subset of {@link TargetingIdea}s from the search criteria
    * specified by a {@link TargetingIdeaSelector}.
@@ -6932,7 +6871,7 @@ if (!class_exists("TargetingIdeaPage", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaSelector", false)) {
   /**
    * A descriptor for finding {@link TargetingIdea}s that match the specified criteria.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7014,10 +6953,9 @@ if (!class_exists("TargetingIdeaSelector", false)) {
   }
 }
 
-if (!class_exists("TextAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TextAdSpec", false)) {
   /**
-   * Specification for a text ad. Currently there are no customizable
-   * options on text ads, but the presence of a {@code TextAdSpec} in a
+   * Specification for a text ad. The presence of a {@code TextAdSpec} in a
    * request indicates that text ads are a desired result, and the presence
    * of a {@code TextAdSpec} in a response indicates that there are text
    * ads available in the requested inventory.
@@ -7051,7 +6989,7 @@ if (!class_exists("TextAdSpec", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorError", false)) {
   /**
    * Base error class for
    * {@link com.google.ads.api.services.trafficestimator.TrafficEstimatorService}.
@@ -7097,7 +7035,7 @@ if (!class_exists("TrafficEstimatorError", false)) {
   }
 }
 
-if (!class_exists("Type_AttributeMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Type_AttributeMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Type
    * and value of type Attribute.
@@ -7145,7 +7083,7 @@ if (!class_exists("Type_AttributeMapEntry", false)) {
   }
 }
 
-if (!class_exists("WebpageDescriptor", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageDescriptor", false)) {
   /**
    * Basic information about a webpage.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7192,7 +7130,7 @@ if (!class_exists("WebpageDescriptor", false)) {
   }
 }
 
-if (!class_exists("WebpageDescriptorAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageDescriptorAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link WebpageDescriptor} value.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7234,7 +7172,7 @@ if (!class_exists("WebpageDescriptorAttribute", false)) {
   }
 }
 
-if (!class_exists("AttributeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AttributeType", false)) {
   /**
    * Represents the type of
    * {@link com.google.ads.api.services.common.optimization.attributes.Attribute}.
@@ -7290,7 +7228,7 @@ if (!class_exists("AttributeType", false)) {
   }
 }
 
-if (!class_exists("CompetitionSearchParameterLevel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CompetitionSearchParameterLevel", false)) {
   /**
    * An enumeration of possible values to be used in conjunction with the
    * {@link CompetitionSearchParameter} to specify the granularity of
@@ -7325,7 +7263,7 @@ if (!class_exists("CompetitionSearchParameterLevel", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7358,7 +7296,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpecActivationOption", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DisplayAdSpecActivationOption", false)) {
   /**
    * Activation options. Describes the ad's activated mode.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7391,7 +7329,7 @@ if (!class_exists("DisplayAdSpecActivationOption", false)) {
   }
 }
 
-if (!class_exists("HtmlDisplayTypeHtmlOption", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\HtmlDisplayTypeHtmlOption", false)) {
   /**
    * Served by a third party.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7424,7 +7362,7 @@ if (!class_exists("HtmlDisplayTypeHtmlOption", false)) {
   }
 }
 
-if (!class_exists("IdeaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdeaType", false)) {
   /**
    * Represents the type of idea.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -7458,7 +7396,7 @@ if (!class_exists("IdeaType", false)) {
   }
 }
 
-if (!class_exists("InStreamAdSpecInStreamType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InStreamAdSpecInStreamType", false)) {
   /**
    * Display subtype.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7491,7 +7429,7 @@ if (!class_exists("InStreamAdSpecInStreamType", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7524,7 +7462,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("OpportunityIdeaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OpportunityIdeaType", false)) {
   /**
    * Represents the type of opportunity.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7557,7 +7495,7 @@ if (!class_exists("OpportunityIdeaType", false)) {
   }
 }
 
-if (!class_exists("RequestType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestType", false)) {
   /**
    * Represents the type of the request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7590,7 +7528,7 @@ if (!class_exists("RequestType", false)) {
   }
 }
 
-if (!class_exists("SiteConstantsAdFormat", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SiteConstantsAdFormat", false)) {
   /**
    * Enumerates the ad formats which can be reported in search results.
    * @package Google_Api_Ads_AdWords_v201309
@@ -7623,7 +7561,7 @@ if (!class_exists("SiteConstantsAdFormat", false)) {
   }
 }
 
-if (!class_exists("SiteConstantsPlacementType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SiteConstantsPlacementType", false)) {
   /**
    * A placement request and response value indicating the type of site or other medium
    * (for example, a web page, in a feed, in a video) where ads will appear.
@@ -7657,7 +7595,7 @@ if (!class_exists("SiteConstantsPlacementType", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaErrorReason", false)) {
   /**
    * An enumeration of
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaService}
@@ -7692,7 +7630,7 @@ if (!class_exists("TargetingIdeaErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorErrorReason", false)) {
   /**
    * When the request with {@code null} campaign ID in
    * {@link com.google.ads.api.services.trafficestimator.CampaignEstimateRequest}
@@ -7729,7 +7667,7 @@ if (!class_exists("TrafficEstimatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7790,7 +7728,7 @@ if (!class_exists("TargetingIdeaServiceGet", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetingIdeaServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -7830,7 +7768,7 @@ if (!class_exists("TargetingIdeaServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetBulkKeywordIdeas", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetBulkKeywordIdeas", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7903,7 +7841,7 @@ if (!class_exists("GetBulkKeywordIdeas", false)) {
   }
 }
 
-if (!class_exists("GetBulkKeywordIdeasResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\GetBulkKeywordIdeasResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -7943,7 +7881,7 @@ if (!class_exists("GetBulkKeywordIdeasResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * 
@@ -7992,7 +7930,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * 
@@ -8042,7 +7980,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * 
@@ -8091,7 +8029,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -8138,7 +8076,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\BidLandscape", false)) {
   /**
    * Represents data about a bid landscape for an ad group or criterion.
    * 
@@ -8212,7 +8150,7 @@ if (!class_exists("BidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionBidLandscape", false)) {
   /**
    * The bid landscape for a criterion.  A bid landscape estimates how a
    * a criterion will perform based on different bid amounts.
@@ -8263,7 +8201,7 @@ if (!class_exists("CriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * 
@@ -8307,7 +8245,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -8352,7 +8290,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -8397,7 +8335,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdFormatSpecListAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdFormatSpecListAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link AdFormatSpec} values.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8439,7 +8377,7 @@ if (!class_exists("AdFormatSpecListAttribute", false)) {
   }
 }
 
-if (!class_exists("AdSpecListAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdSpecListAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link AdSpec} values.
    * @package Google_Api_Ads_AdWords_v201309
@@ -8481,7 +8419,7 @@ if (!class_exists("AdSpecListAttribute", false)) {
   }
 }
 
-if (!class_exists("AdSpecListSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdSpecListSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code PLACEMENT} {@link IdeaType}s used to
    * filter the results by the list of {@link AdSpec}s. See {@link AdSpec}
@@ -8527,7 +8465,7 @@ if (!class_exists("AdSpecListSearchParameter", false)) {
   }
 }
 
-if (!class_exists("CategoryProductsAndServicesSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CategoryProductsAndServicesSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * sets a keyword category that all search results should belong to.
@@ -8574,7 +8512,7 @@ if (!class_exists("CategoryProductsAndServicesSearchParameter", false)) {
   }
 }
 
-if (!class_exists("CompetitionSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CompetitionSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s used to
    * filter the results by the amount of competition (eg: LOW, MEDIUM, HIGH).
@@ -8619,7 +8557,7 @@ if (!class_exists("CompetitionSearchParameter", false)) {
   }
 }
 
-if (!class_exists("ExcludedKeywordSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ExcludedKeywordSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * specifies {@link Keyword}s that should be excluded from the results.<p>
@@ -8702,7 +8640,7 @@ if (!class_exists("ExcludedKeywordSearchParameter", false)) {
   }
 }
 
-if (!class_exists("IdeaTextFilterSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdeaTextFilterSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * specifies a collection of strings by which the results should be
@@ -8761,7 +8699,7 @@ if (!class_exists("IdeaTextFilterSearchParameter", false)) {
   }
 }
 
-if (!class_exists("IncludeAdultContentSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IncludeAdultContentSearchParameter", false)) {
   /**
    * {@link SearchParameter} that specifies whether adult content should be
    * returned.<p>
@@ -8802,7 +8740,7 @@ if (!class_exists("IncludeAdultContentSearchParameter", false)) {
   }
 }
 
-if (!class_exists("LanguageSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LanguageSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for both {@code PLACEMENT} and {@code KEYWORD}
    * {@link IdeaType}s used to indicate multiple language being targeted. This can
@@ -8857,7 +8795,7 @@ if (!class_exists("LanguageSearchParameter", false)) {
   }
 }
 
-if (!class_exists("LocationSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for both {@code PLACEMENT} and {@code KEYWORD}
    * {@link IdeaType}s used to indicate the locations being targeted. This can
@@ -8912,7 +8850,7 @@ if (!class_exists("LocationSearchParameter", false)) {
   }
 }
 
-if (!class_exists("NetworkSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NetworkSearchParameter", false)) {
   /**
    * <p>A {@link SearchParameter} for setting the search network. Currently we
    * support two network setting options:
@@ -8961,7 +8899,7 @@ if (!class_exists("NetworkSearchParameter", false)) {
   }
 }
 
-if (!class_exists("PlacementTypeSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\PlacementTypeSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code PLACEMENT} {@link IdeaType}s
    * used to filter results based on the type of website, known as
@@ -9009,7 +8947,7 @@ if (!class_exists("PlacementTypeSearchParameter", false)) {
   }
 }
 
-if (!class_exists("RelatedToQuerySearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RelatedToQuerySearchParameter", false)) {
   /**
    * A {@link SearchParameter} for a query of {@code String}s.
    * <p>This search parameter can be used in bulk keyword requests through the {@link com.google.ads.api.services.targetingideas.TargetingIdeaService#getBulkKeywordIdeas(TargetingIdeaSelector)} method.
@@ -9054,7 +8992,7 @@ if (!class_exists("RelatedToQuerySearchParameter", false)) {
   }
 }
 
-if (!class_exists("RelatedToUrlSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RelatedToUrlSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} and {@code PLACEMENT}
    * {@link IdeaType}s that specifies a set of URLs that results should
@@ -9109,7 +9047,7 @@ if (!class_exists("RelatedToUrlSearchParameter", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscape", false)) {
   /**
    * Represents data about a bidlandscape for an adgroup.
    * 
@@ -9172,7 +9110,7 @@ if (!class_exists("TargetingIdeaService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class TargetingIdeaService extends AdWordsSoapClient {
+  class TargetingIdeaService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "TargetingIdeaService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201309";
@@ -9189,193 +9127,192 @@ if (!class_exists("TargetingIdeaService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupBidLandscape" => "AdGroupBidLandscape",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BidLandscape" => "BidLandscape",
-      "BidLandscape.LandscapePoint" => "BidLandscapeLandscapePoint",
-      "BiddingError" => "BiddingError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "CriterionBidLandscape" => "CriterionBidLandscape",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Platform" => "Platform",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "DataEntry" => "DataEntry",
-      "TargetError" => "TargetError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdGroupBidLandscape.Type" => "AdGroupBidLandscapeType",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "AdFormatSpec" => "AdFormatSpec",
-      "AdFormatSpecListAttribute" => "AdFormatSpecListAttribute",
-      "AdSpec" => "AdSpec",
-      "AdSpecListAttribute" => "AdSpecListAttribute",
-      "AdSpecListSearchParameter" => "AdSpecListSearchParameter",
-      "Attribute" => "Attribute",
-      "BidLandscapeAttribute" => "BidLandscapeAttribute",
-      "BooleanAttribute" => "BooleanAttribute",
-      "CategoryProductsAndServicesSearchParameter" => "CategoryProductsAndServicesSearchParameter",
-      "CompetitionSearchParameter" => "CompetitionSearchParameter",
-      "CriterionAttribute" => "CriterionAttribute",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "DisplayAdSpec" => "DisplayAdSpec",
-      "DisplayAdSpec.AdSizeSpec" => "DisplayAdSpecAdSizeSpec",
-      "DisplayType" => "DisplayType",
-      "DoubleAttribute" => "DoubleAttribute",
-      "DoubleComparisonOperation" => "DoubleComparisonOperation",
-      "ExcludedKeywordSearchParameter" => "ExcludedKeywordSearchParameter",
-      "FlashDisplayType" => "FlashDisplayType",
-      "HtmlDisplayType" => "HtmlDisplayType",
-      "IdeaTextFilterSearchParameter" => "IdeaTextFilterSearchParameter",
-      "IdeaTypeAttribute" => "IdeaTypeAttribute",
-      "ImageDisplayType" => "ImageDisplayType",
-      "InStreamAdInfo" => "InStreamAdInfo",
-      "InStreamAdInfoAttribute" => "InStreamAdInfoAttribute",
-      "InStreamAdSpec" => "InStreamAdSpec",
-      "IncludeAdultContentSearchParameter" => "IncludeAdultContentSearchParameter",
-      "IntegerAttribute" => "IntegerAttribute",
-      "IntegerSetAttribute" => "IntegerSetAttribute",
-      "KeywordAttribute" => "KeywordAttribute",
-      "LanguageSearchParameter" => "LanguageSearchParameter",
-      "LocationSearchParameter" => "LocationSearchParameter",
-      "LongAttribute" => "LongAttribute",
-      "LongComparisonOperation" => "LongComparisonOperation",
-      "LongRangeAttribute" => "LongRangeAttribute",
-      "MatchesRegexError" => "MatchesRegexError",
-      "MoneyAttribute" => "MoneyAttribute",
-      "MonthlySearchVolume" => "MonthlySearchVolume",
-      "MonthlySearchVolumeAttribute" => "MonthlySearchVolumeAttribute",
-      "NetworkSearchParameter" => "NetworkSearchParameter",
-      "OpportunityIdeaTypeAttribute" => "OpportunityIdeaTypeAttribute",
-      "PlacementAttribute" => "PlacementAttribute",
-      "PlacementTypeAttribute" => "PlacementTypeAttribute",
-      "PlacementTypeSearchParameter" => "PlacementTypeSearchParameter",
-      "Range" => "Range",
-      "RelatedToQuerySearchParameter" => "RelatedToQuerySearchParameter",
-      "RelatedToUrlSearchParameter" => "RelatedToUrlSearchParameter",
-      "SearchParameter" => "SearchParameter",
-      "SearchVolumeDeltaSearchParameter" => "SearchVolumeDeltaSearchParameter",
-      "SearchVolumeSearchParameter" => "SearchVolumeSearchParameter",
-      "SeedAdGroupIdSearchParameter" => "SeedAdGroupIdSearchParameter",
-      "StringAttribute" => "StringAttribute",
-      "TargetingIdea" => "TargetingIdea",
-      "TargetingIdeaError" => "TargetingIdeaError",
-      "TargetingIdeaPage" => "TargetingIdeaPage",
-      "TargetingIdeaSelector" => "TargetingIdeaSelector",
-      "TextAdSpec" => "TextAdSpec",
-      "TrafficEstimatorError" => "TrafficEstimatorError",
-      "Type_AttributeMapEntry" => "Type_AttributeMapEntry",
-      "WebpageDescriptor" => "WebpageDescriptor",
-      "WebpageDescriptorAttribute" => "WebpageDescriptorAttribute",
-      "AttributeType" => "AttributeType",
-      "CompetitionSearchParameter.Level" => "CompetitionSearchParameterLevel",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "DisplayAdSpec.ActivationOption" => "DisplayAdSpecActivationOption",
-      "HtmlDisplayType.HtmlOption" => "HtmlDisplayTypeHtmlOption",
-      "IdeaType" => "IdeaType",
-      "InStreamAdSpec.InStreamType" => "InStreamAdSpecInStreamType",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "OpportunityIdeaType" => "OpportunityIdeaType",
-      "RequestType" => "RequestType",
-      "SiteConstants.AdFormat" => "SiteConstantsAdFormat",
-      "SiteConstants.PlacementType" => "SiteConstantsPlacementType",
-      "TargetingIdeaError.Reason" => "TargetingIdeaErrorReason",
-      "TrafficEstimatorError.Reason" => "TrafficEstimatorErrorReason",
-      "get" => "TargetingIdeaServiceGet",
-      "getResponse" => "TargetingIdeaServiceGetResponse",
-      "getBulkKeywordIdeas" => "GetBulkKeywordIdeas",
-      "getBulkKeywordIdeasResponse" => "GetBulkKeywordIdeasResponse",
+      "AdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscape",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionError",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceeded",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "BidLandscape" => "Google_Api_Ads_AdWords_v201309\\BidLandscape",
+      "BidLandscape.LandscapePoint" => "Google_Api_Ads_AdWords_v201309\\BidLandscapeLandscapePoint",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201309\\BiddingError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201309\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionBidLandscape" => "Google_Api_Ads_AdWords_v201309\\CriterionBidLandscape",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201309\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201309\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201309\\NetworkSetting",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "Paging" => "Google_Api_Ads_AdWords_v201309\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Platform" => "Google_Api_Ads_AdWords_v201309\\Platform",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201309\\PolicyViolationKey",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201309\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "DataEntry" => "Google_Api_Ads_AdWords_v201309\\DataEntry",
+      "TargetError" => "Google_Api_Ads_AdWords_v201309\\TargetError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AdGroupBidLandscape.Type" => "Google_Api_Ads_AdWords_v201309\\AdGroupBidLandscapeType",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201309\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201309\\BiddingErrorReason",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201309\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201309\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201309\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201309\\TargetErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "AdFormatSpec" => "Google_Api_Ads_AdWords_v201309\\AdFormatSpec",
+      "AdFormatSpecListAttribute" => "Google_Api_Ads_AdWords_v201309\\AdFormatSpecListAttribute",
+      "AdSpec" => "Google_Api_Ads_AdWords_v201309\\AdSpec",
+      "AdSpecListAttribute" => "Google_Api_Ads_AdWords_v201309\\AdSpecListAttribute",
+      "AdSpecListSearchParameter" => "Google_Api_Ads_AdWords_v201309\\AdSpecListSearchParameter",
+      "Attribute" => "Google_Api_Ads_AdWords_v201309\\Attribute",
+      "BidLandscapeAttribute" => "Google_Api_Ads_AdWords_v201309\\BidLandscapeAttribute",
+      "BooleanAttribute" => "Google_Api_Ads_AdWords_v201309\\BooleanAttribute",
+      "CategoryProductsAndServicesSearchParameter" => "Google_Api_Ads_AdWords_v201309\\CategoryProductsAndServicesSearchParameter",
+      "CompetitionSearchParameter" => "Google_Api_Ads_AdWords_v201309\\CompetitionSearchParameter",
+      "CriterionAttribute" => "Google_Api_Ads_AdWords_v201309\\CriterionAttribute",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeError",
+      "DisplayAdSpec" => "Google_Api_Ads_AdWords_v201309\\DisplayAdSpec",
+      "DisplayAdSpec.AdSizeSpec" => "Google_Api_Ads_AdWords_v201309\\DisplayAdSpecAdSizeSpec",
+      "DisplayType" => "Google_Api_Ads_AdWords_v201309\\DisplayType",
+      "DoubleAttribute" => "Google_Api_Ads_AdWords_v201309\\DoubleAttribute",
+      "ExcludedKeywordSearchParameter" => "Google_Api_Ads_AdWords_v201309\\ExcludedKeywordSearchParameter",
+      "FlashDisplayType" => "Google_Api_Ads_AdWords_v201309\\FlashDisplayType",
+      "HtmlDisplayType" => "Google_Api_Ads_AdWords_v201309\\HtmlDisplayType",
+      "IdeaTextFilterSearchParameter" => "Google_Api_Ads_AdWords_v201309\\IdeaTextFilterSearchParameter",
+      "IdeaTypeAttribute" => "Google_Api_Ads_AdWords_v201309\\IdeaTypeAttribute",
+      "ImageDisplayType" => "Google_Api_Ads_AdWords_v201309\\ImageDisplayType",
+      "InStreamAdInfo" => "Google_Api_Ads_AdWords_v201309\\InStreamAdInfo",
+      "InStreamAdInfoAttribute" => "Google_Api_Ads_AdWords_v201309\\InStreamAdInfoAttribute",
+      "InStreamAdSpec" => "Google_Api_Ads_AdWords_v201309\\InStreamAdSpec",
+      "IncludeAdultContentSearchParameter" => "Google_Api_Ads_AdWords_v201309\\IncludeAdultContentSearchParameter",
+      "IntegerAttribute" => "Google_Api_Ads_AdWords_v201309\\IntegerAttribute",
+      "IntegerSetAttribute" => "Google_Api_Ads_AdWords_v201309\\IntegerSetAttribute",
+      "KeywordAttribute" => "Google_Api_Ads_AdWords_v201309\\KeywordAttribute",
+      "LanguageSearchParameter" => "Google_Api_Ads_AdWords_v201309\\LanguageSearchParameter",
+      "LocationSearchParameter" => "Google_Api_Ads_AdWords_v201309\\LocationSearchParameter",
+      "LongAttribute" => "Google_Api_Ads_AdWords_v201309\\LongAttribute",
+      "LongComparisonOperation" => "Google_Api_Ads_AdWords_v201309\\LongComparisonOperation",
+      "LongRangeAttribute" => "Google_Api_Ads_AdWords_v201309\\LongRangeAttribute",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexError",
+      "MoneyAttribute" => "Google_Api_Ads_AdWords_v201309\\MoneyAttribute",
+      "MonthlySearchVolume" => "Google_Api_Ads_AdWords_v201309\\MonthlySearchVolume",
+      "MonthlySearchVolumeAttribute" => "Google_Api_Ads_AdWords_v201309\\MonthlySearchVolumeAttribute",
+      "NetworkSearchParameter" => "Google_Api_Ads_AdWords_v201309\\NetworkSearchParameter",
+      "OpportunityIdeaTypeAttribute" => "Google_Api_Ads_AdWords_v201309\\OpportunityIdeaTypeAttribute",
+      "PlacementAttribute" => "Google_Api_Ads_AdWords_v201309\\PlacementAttribute",
+      "PlacementTypeAttribute" => "Google_Api_Ads_AdWords_v201309\\PlacementTypeAttribute",
+      "PlacementTypeSearchParameter" => "Google_Api_Ads_AdWords_v201309\\PlacementTypeSearchParameter",
+      "Range" => "Google_Api_Ads_AdWords_v201309\\Range",
+      "RelatedToQuerySearchParameter" => "Google_Api_Ads_AdWords_v201309\\RelatedToQuerySearchParameter",
+      "RelatedToUrlSearchParameter" => "Google_Api_Ads_AdWords_v201309\\RelatedToUrlSearchParameter",
+      "SearchParameter" => "Google_Api_Ads_AdWords_v201309\\SearchParameter",
+      "SearchVolumeSearchParameter" => "Google_Api_Ads_AdWords_v201309\\SearchVolumeSearchParameter",
+      "SeedAdGroupIdSearchParameter" => "Google_Api_Ads_AdWords_v201309\\SeedAdGroupIdSearchParameter",
+      "StringAttribute" => "Google_Api_Ads_AdWords_v201309\\StringAttribute",
+      "TargetingIdea" => "Google_Api_Ads_AdWords_v201309\\TargetingIdea",
+      "TargetingIdeaError" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaError",
+      "TargetingIdeaPage" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaPage",
+      "TargetingIdeaSelector" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaSelector",
+      "TextAdSpec" => "Google_Api_Ads_AdWords_v201309\\TextAdSpec",
+      "TrafficEstimatorError" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorError",
+      "Type_AttributeMapEntry" => "Google_Api_Ads_AdWords_v201309\\Type_AttributeMapEntry",
+      "WebpageDescriptor" => "Google_Api_Ads_AdWords_v201309\\WebpageDescriptor",
+      "WebpageDescriptorAttribute" => "Google_Api_Ads_AdWords_v201309\\WebpageDescriptorAttribute",
+      "AttributeType" => "Google_Api_Ads_AdWords_v201309\\AttributeType",
+      "CompetitionSearchParameter.Level" => "Google_Api_Ads_AdWords_v201309\\CompetitionSearchParameterLevel",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason",
+      "DisplayAdSpec.ActivationOption" => "Google_Api_Ads_AdWords_v201309\\DisplayAdSpecActivationOption",
+      "HtmlDisplayType.HtmlOption" => "Google_Api_Ads_AdWords_v201309\\HtmlDisplayTypeHtmlOption",
+      "IdeaType" => "Google_Api_Ads_AdWords_v201309\\IdeaType",
+      "InStreamAdSpec.InStreamType" => "Google_Api_Ads_AdWords_v201309\\InStreamAdSpecInStreamType",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason",
+      "OpportunityIdeaType" => "Google_Api_Ads_AdWords_v201309\\OpportunityIdeaType",
+      "RequestType" => "Google_Api_Ads_AdWords_v201309\\RequestType",
+      "SiteConstants.AdFormat" => "Google_Api_Ads_AdWords_v201309\\SiteConstantsAdFormat",
+      "SiteConstants.PlacementType" => "Google_Api_Ads_AdWords_v201309\\SiteConstantsPlacementType",
+      "TargetingIdeaError.Reason" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaErrorReason",
+      "TrafficEstimatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\TargetingIdeaServiceGetResponse",
+      "getBulkKeywordIdeas" => "Google_Api_Ads_AdWords_v201309\\GetBulkKeywordIdeas",
+      "getBulkKeywordIdeasResponse" => "Google_Api_Ads_AdWords_v201309\\GetBulkKeywordIdeasResponse",
     );
 
 
@@ -9461,3 +9398,4 @@ if (!class_exists("TargetingIdeaService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201309/TrafficEstimatorService.php
+++ b/src/Google/Api/Ads/AdWords/v201309/TrafficEstimatorService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201309;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -131,7 +131,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -214,7 +214,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -263,7 +263,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -312,7 +312,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -361,7 +361,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -376,6 +376,12 @@ if (!class_exists("CollectionSizeError", false)) {
 
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
     const XSI_TYPE = "CollectionSizeError";
+
+    /**
+     * @access public
+     * @var tnsCollectionSizeErrorReason
+     */
+    public $reason;
 
     /**
      * Gets the namesapce of this class
@@ -393,8 +399,9 @@ if (!class_exists("CollectionSizeError", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
+    public function __construct($reason = null, $fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
       parent::__construct();
+      $this->reason = $reason;
       $this->fieldPath = $fieldPath;
       $this->trigger = $trigger;
       $this->errorString = $errorString;
@@ -404,7 +411,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -480,7 +487,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -571,7 +578,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * 
@@ -647,7 +654,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -696,7 +703,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -745,7 +752,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -794,7 +801,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * 
@@ -843,7 +850,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -893,7 +900,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -942,7 +949,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -993,7 +1000,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1049,10 +1056,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1106,10 +1113,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1177,7 +1184,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1235,7 +1242,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1291,7 +1298,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1337,7 +1344,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * 
@@ -1402,7 +1409,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1451,7 +1458,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1500,7 +1507,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1549,7 +1556,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1588,7 +1595,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1637,7 +1644,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1686,7 +1693,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1736,7 +1743,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1795,7 +1802,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1847,7 +1854,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -1891,7 +1898,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1940,7 +1947,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1989,7 +1996,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2059,7 +2066,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2108,7 +2115,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * 
@@ -2157,7 +2164,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2206,7 +2213,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2256,7 +2263,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2305,7 +2312,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2354,7 +2361,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2433,7 +2440,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2505,7 +2512,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2555,7 +2562,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * 
@@ -2604,7 +2611,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2660,7 +2667,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2723,7 +2730,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2790,7 +2797,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -2854,7 +2861,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -2910,7 +2917,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -2964,7 +2971,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * 
@@ -3001,7 +3008,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -3038,7 +3045,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3075,7 +3082,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3113,7 +3120,44 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason", false)) {
+  /**
+   * The reasons for the target error.
+   * 
+   * 
+   * 
+   * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
+   * @package Google_Api_Ads_AdWords_v201309
+   * @subpackage v201309
+   */
+  class CollectionSizeErrorReason {
+
+    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201309";
+    const XSI_TYPE = "CollectionSizeError.Reason";
+
+    /**
+     * Gets the namesapce of this class
+     * @return the namespace of this class
+     */
+    public function getNamespace() {
+      return self::WSDL_NAMESPACE;
+    }
+
+    /**
+     * Gets the xsi:type name of this class
+     * @return the xsi:type name of this class
+     */
+    public function getXsiTypeName() {
+      return self::XSI_TYPE;
+    }
+
+    public function __construct() {
+    }
+
+  }
+}
+
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3150,7 +3194,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3187,7 +3231,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3224,7 +3268,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3261,7 +3305,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * 
@@ -3298,7 +3342,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -3336,7 +3380,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3373,7 +3417,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3410,7 +3454,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3448,7 +3492,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -3485,7 +3529,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3522,7 +3566,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * 
@@ -3559,7 +3603,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3596,7 +3640,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3633,7 +3677,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3670,7 +3714,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3708,7 +3752,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3745,7 +3789,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3782,7 +3826,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3819,7 +3863,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3856,7 +3900,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3893,7 +3937,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3930,7 +3974,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3967,7 +4011,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -4004,7 +4048,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4041,7 +4085,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4078,7 +4122,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4115,7 +4159,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * 
@@ -4152,7 +4196,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4197,7 +4241,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("Estimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\Estimate", false)) {
   /**
    * Abstract class representing an reply to an {@link EstimateRequest}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4269,7 +4313,7 @@ if (!class_exists("Estimate", false)) {
   }
 }
 
-if (!class_exists("EstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\EstimateRequest", false)) {
   /**
    * Abstract class representing a request to estimate stats.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4341,7 +4385,7 @@ if (!class_exists("EstimateRequest", false)) {
   }
 }
 
-if (!class_exists("KeywordEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordEstimate", false)) {
   /**
    * Represents the traffic estimate result for a single keyword.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4397,7 +4441,7 @@ if (!class_exists("KeywordEstimate", false)) {
   }
 }
 
-if (!class_exists("KeywordEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\KeywordEstimateRequest", false)) {
   /**
    * Represents a keyword to be estimated.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4453,7 +4497,7 @@ if (!class_exists("KeywordEstimateRequest", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -4499,9 +4543,12 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("StatsEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\StatsEstimate", false)) {
   /**
-   * Represents a set of stats for a traffic estimate.
+   * Represents a set of stats for a daily traffic estimate.
+   * As of v201406 {@code averageCpc}, {@code averagePosition} and {@code clickThroughRate} will be
+   * {@code null} when not defined (respectively, if {@code clicksPerDay} or
+   * {@code impressionsPerDay} are 0).
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
@@ -4526,6 +4573,12 @@ if (!class_exists("StatsEstimate", false)) {
      * @access public
      * @var double
      */
+    public $clickThroughRate;
+
+    /**
+     * @access public
+     * @var double
+     */
     public $clicksPerDay;
 
     /**
@@ -4533,12 +4586,6 @@ if (!class_exists("StatsEstimate", false)) {
      * @var double
      */
     public $impressionsPerDay;
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $clickThroughRate;
 
     /**
      * @access public
@@ -4562,19 +4609,19 @@ if (!class_exists("StatsEstimate", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($averageCpc = null, $averagePosition = null, $clicksPerDay = null, $impressionsPerDay = null, $clickThroughRate = null, $totalCost = null) {
+    public function __construct($averageCpc = null, $averagePosition = null, $clickThroughRate = null, $clicksPerDay = null, $impressionsPerDay = null, $totalCost = null) {
       $this->averageCpc = $averageCpc;
       $this->averagePosition = $averagePosition;
+      $this->clickThroughRate = $clickThroughRate;
       $this->clicksPerDay = $clicksPerDay;
       $this->impressionsPerDay = $impressionsPerDay;
-      $this->clickThroughRate = $clickThroughRate;
       $this->totalCost = $totalCost;
     }
 
   }
 }
 
-if (!class_exists("TrafficEstimatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorError", false)) {
   /**
    * Base error class for
    * {@link com.google.ads.api.services.trafficestimator.TrafficEstimatorService}.
@@ -4620,7 +4667,7 @@ if (!class_exists("TrafficEstimatorError", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorResult", false)) {
   /**
    * Contains results of traffic estimation request.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4660,7 +4707,7 @@ if (!class_exists("TrafficEstimatorResult", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorSelector", false)) {
   /**
    * Contains a list of campaigns to perform a traffic estimate on.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4700,7 +4747,7 @@ if (!class_exists("TrafficEstimatorSelector", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4733,7 +4780,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201309
@@ -4766,7 +4813,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorErrorReason", false)) {
   /**
    * When the request with {@code null} campaign ID in
    * {@link com.google.ads.api.services.trafficestimator.CampaignEstimateRequest}
@@ -4803,7 +4850,7 @@ if (!class_exists("TrafficEstimatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4852,7 +4899,7 @@ if (!class_exists("TrafficEstimatorServiceGet", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\TrafficEstimatorServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201309
@@ -4892,7 +4939,7 @@ if (!class_exists("TrafficEstimatorServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * 
@@ -4941,7 +4988,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4988,7 +5035,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -5033,7 +5080,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -5078,7 +5125,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdGroupEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupEstimate", false)) {
   /**
    * Represents the estimate results for a single ad group.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5127,7 +5174,7 @@ if (!class_exists("AdGroupEstimate", false)) {
   }
 }
 
-if (!class_exists("AdGroupEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\AdGroupEstimateRequest", false)) {
   /**
    * Represents an ad group that will be estimated. Ad groups may be all
    * new or all existing, or a mixture of new and existing. Only existing
@@ -5193,7 +5240,7 @@ if (!class_exists("AdGroupEstimateRequest", false)) {
   }
 }
 
-if (!class_exists("CampaignEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignEstimate", false)) {
   /**
    * Represents the estimate results for a single campaign.
    * @package Google_Api_Ads_AdWords_v201309
@@ -5242,7 +5289,7 @@ if (!class_exists("CampaignEstimate", false)) {
   }
 }
 
-if (!class_exists("CampaignEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201309\\CampaignEstimateRequest", false)) {
   /**
    * Represents a campaign that will be estimated.<p>
    * 
@@ -5333,7 +5380,7 @@ if (!class_exists("TrafficEstimatorService", false)) {
    * @package Google_Api_Ads_AdWords_v201309
    * @subpackage v201309
    */
-  class TrafficEstimatorService extends AdWordsSoapClient {
+  class TrafficEstimatorService extends Google_Api_Ads_AdWords_v201309\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "TrafficEstimatorService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201309";
@@ -5350,113 +5397,114 @@ if (!class_exists("TrafficEstimatorService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "CriterionParameter" => "CriterionParameter",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "Placement" => "Placement",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "TargetError" => "TargetError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "AdGroupEstimate" => "AdGroupEstimate",
-      "AdGroupEstimateRequest" => "AdGroupEstimateRequest",
-      "CampaignEstimate" => "CampaignEstimate",
-      "CampaignEstimateRequest" => "CampaignEstimateRequest",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "Estimate" => "Estimate",
-      "EstimateRequest" => "EstimateRequest",
-      "KeywordEstimate" => "KeywordEstimate",
-      "KeywordEstimateRequest" => "KeywordEstimateRequest",
-      "MatchesRegexError" => "MatchesRegexError",
-      "StatsEstimate" => "StatsEstimate",
-      "TrafficEstimatorError" => "TrafficEstimatorError",
-      "TrafficEstimatorResult" => "TrafficEstimatorResult",
-      "TrafficEstimatorSelector" => "TrafficEstimatorSelector",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "TrafficEstimatorError.Reason" => "TrafficEstimatorErrorReason",
-      "get" => "TrafficEstimatorServiceGet",
-      "getResponse" => "TrafficEstimatorServiceGetResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201309\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201309\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201309\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201309\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201309\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201309\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201309\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201309\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201309\\Criterion",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201309\\CriterionParameter",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201309\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201309\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201309\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201309\\DoubleValue",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDenied",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201309\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201309\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201309\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201309\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201309\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201309\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201309\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201309\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201309\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201309\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201309\\NetworkSetting",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201309\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201309\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201309\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201309\\OperatorError",
+      "Placement" => "Google_Api_Ads_AdWords_v201309\\Placement",
+      "Product" => "Google_Api_Ads_AdWords_v201309\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201309\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201309\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201309\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201309\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201309\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201309\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201309\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201309\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201309\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201309\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201309\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201309\\StringLengthError",
+      "TargetError" => "Google_Api_Ads_AdWords_v201309\\TargetError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201309\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201309\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201309\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201309\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201309\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201309\\WebpageParameter",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201309\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201309\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201309\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CollectionSizeErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201309\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201309\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201309\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201309\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityAccessDeniedReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201309\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201309\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201309\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201309\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201309\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201309\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201309\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201309\\OperationAccessDeniedReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201309\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201309\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201309\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201309\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201309\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201309\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201309\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201309\\TargetErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201309\\CriterionUserListMembershipStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201309\\WebpageConditionOperand",
+      "AdGroupEstimate" => "Google_Api_Ads_AdWords_v201309\\AdGroupEstimate",
+      "AdGroupEstimateRequest" => "Google_Api_Ads_AdWords_v201309\\AdGroupEstimateRequest",
+      "CampaignEstimate" => "Google_Api_Ads_AdWords_v201309\\CampaignEstimate",
+      "CampaignEstimateRequest" => "Google_Api_Ads_AdWords_v201309\\CampaignEstimateRequest",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeError",
+      "Estimate" => "Google_Api_Ads_AdWords_v201309\\Estimate",
+      "EstimateRequest" => "Google_Api_Ads_AdWords_v201309\\EstimateRequest",
+      "KeywordEstimate" => "Google_Api_Ads_AdWords_v201309\\KeywordEstimate",
+      "KeywordEstimateRequest" => "Google_Api_Ads_AdWords_v201309\\KeywordEstimateRequest",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexError",
+      "StatsEstimate" => "Google_Api_Ads_AdWords_v201309\\StatsEstimate",
+      "TrafficEstimatorError" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorError",
+      "TrafficEstimatorResult" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorResult",
+      "TrafficEstimatorSelector" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorSelector",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201309\\CurrencyCodeErrorReason",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201309\\MatchesRegexErrorReason",
+      "TrafficEstimatorError.Reason" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201309\\TrafficEstimatorServiceGetResponse",
     );
 
 
@@ -5489,3 +5537,4 @@ if (!class_exists("TrafficEstimatorService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdGroupAdService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdGroupAdService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Ad", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Ad", false)) {
   /**
    * The base class of all ad types. To update basic ad fields,
    * you can construct an {@code Ad} object (instead of
@@ -133,7 +133,7 @@ if (!class_exists("Ad", false)) {
   }
 }
 
-if (!class_exists("AdGroupAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAd", false)) {
   /**
    * Represents an ad in an ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -222,7 +222,7 @@ if (!class_exists("AdGroupAd", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for an AdGroupAd
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -277,7 +277,7 @@ if (!class_exists("AdGroupAdExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdUnionId", false)) {
   /**
    * Represents an id indicating a grouping of Ads under some heuristic.
    * @package Google_Api_Ads_AdWords_v201402
@@ -356,7 +356,7 @@ if (!class_exists("AdUnionId", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -453,7 +453,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -532,7 +532,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -577,7 +577,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -622,7 +622,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -667,7 +667,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -712,7 +712,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -757,7 +757,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -805,7 +805,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DeprecatedAd", false)) {
   /**
    * Represents a deprecated ad.
    * 
@@ -861,7 +861,7 @@ if (!class_exists("DeprecatedAd", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -908,7 +908,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -953,7 +953,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1027,7 +1027,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -1073,7 +1073,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1113,7 +1113,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("ExperimentError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentError", false)) {
   /**
    * The error reason represented by an enum.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1158,7 +1158,7 @@ if (!class_exists("ExperimentError", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -1204,7 +1204,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1249,7 +1249,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("ImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageAd", false)) {
   /**
    * Represents an ImageAd.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1310,7 +1310,7 @@ if (!class_exists("ImageAd", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1355,7 +1355,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1402,7 +1402,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1474,7 +1474,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1616,7 +1616,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1661,7 +1661,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -1709,7 +1709,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -1757,7 +1757,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("MobileAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAd", false)) {
   /**
    * Represents a mobile ad.
    * 
@@ -1895,7 +1895,7 @@ if (!class_exists("MobileAd", false)) {
   }
 }
 
-if (!class_exists("MobileImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileImageAd", false)) {
   /**
    * Represents a mobile image ad.
    * 
@@ -1960,7 +1960,7 @@ if (!class_exists("MobileImageAd", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2005,7 +2005,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2050,7 +2050,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2095,7 +2095,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -2175,7 +2175,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2220,7 +2220,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2267,7 +2267,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2346,7 +2346,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -2395,7 +2395,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2441,7 +2441,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -2532,7 +2532,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2579,7 +2579,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -2627,7 +2627,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2681,7 +2681,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("ProductAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAd", false)) {
   /**
    * Represents a product ad (known as a <a href=
    * "//support.google.com/adwords/bin/answer.py?answer=2456103">product
@@ -2740,7 +2740,7 @@ if (!class_exists("ProductAd", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2792,7 +2792,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2837,7 +2837,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2882,7 +2882,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2948,7 +2948,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2993,7 +2993,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3038,7 +3038,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3084,7 +3084,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3129,7 +3129,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("RichMediaAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAd", false)) {
   /**
    * Data associated with a rich media ad.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3232,7 +3232,7 @@ if (!class_exists("RichMediaAd", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3300,7 +3300,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3345,7 +3345,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3390,7 +3390,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3458,7 +3458,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3526,7 +3526,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3571,7 +3571,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3617,7 +3617,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -3665,7 +3665,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TempAdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TempAdUnionId", false)) {
   /**
    * Represents the temporary id for an ad union id, which the user can specify.
    * The temporary id can be used to group ads together during ad creation.
@@ -3702,7 +3702,7 @@ if (!class_exists("TempAdUnionId", false)) {
   }
 }
 
-if (!class_exists("TemplateAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateAd", false)) {
   /**
    * Represents a <a href=
    * "//www.google.com/adwords/displaynetwork/plan-creative-campaigns/display-ad-builder.html"
@@ -3803,7 +3803,7 @@ if (!class_exists("TemplateAd", false)) {
   }
 }
 
-if (!class_exists("TemplateElement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElement", false)) {
   /**
    * Represents an element in a template. Each template element is composed
    * of a list of fields (actual value data).
@@ -3851,7 +3851,7 @@ if (!class_exists("TemplateElement", false)) {
   }
 }
 
-if (!class_exists("TemplateElementField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElementField", false)) {
   /**
    * Represents a field in a template element.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3912,7 +3912,7 @@ if (!class_exists("TemplateElementField", false)) {
   }
 }
 
-if (!class_exists("TextAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TextAd", false)) {
   /**
    * Represents a TextAd.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3973,7 +3973,7 @@ if (!class_exists("TextAd", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAd", false)) {
   /**
    * Data associated with rich media extension attributes.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4052,7 +4052,7 @@ if (!class_exists("ThirdPartyRedirectAd", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4139,7 +4139,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DynamicSearchAd", false)) {
   /**
    * Represents a dynamic search ad. This ad will have its headline and
    * destination URL auto-generated at serving time according to domain name
@@ -4223,7 +4223,7 @@ if (!class_exists("DynamicSearchAd", false)) {
   }
 }
 
-if (!class_exists("AdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4256,7 +4256,7 @@ if (!class_exists("AdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdApprovalStatus", false)) {
   /**
    * Represents the possible approval statuses.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4289,7 +4289,7 @@ if (!class_exists("AdGroupAdApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdStatus", false)) {
   /**
    * The current status of an Ad.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4322,7 +4322,7 @@ if (!class_exists("AdGroupAdStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4355,7 +4355,7 @@ if (!class_exists("AdGroupAdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4388,7 +4388,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4421,7 +4421,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4454,7 +4454,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -4488,7 +4488,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4521,7 +4521,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4554,7 +4554,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DeprecatedAdType", false)) {
   /**
    * Video ad.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4587,7 +4587,7 @@ if (!class_exists("DeprecatedAdType", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4620,7 +4620,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4653,7 +4653,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -4687,7 +4687,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4720,7 +4720,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4753,7 +4753,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4786,7 +4786,7 @@ if (!class_exists("ExperimentErrorReason", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4819,7 +4819,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4852,7 +4852,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4885,7 +4885,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4918,7 +4918,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MarkupLanguageType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MarkupLanguageType", false)) {
   /**
    * Markup languages to use for mobile ads.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4951,7 +4951,7 @@ if (!class_exists("MarkupLanguageType", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201402
@@ -4984,7 +4984,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201402
@@ -5017,7 +5017,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201402
@@ -5050,7 +5050,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5083,7 +5083,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5116,7 +5116,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5149,7 +5149,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5182,7 +5182,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5215,7 +5215,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5248,7 +5248,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5281,7 +5281,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5314,7 +5314,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5347,7 +5347,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -5381,7 +5381,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5414,7 +5414,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5447,7 +5447,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5480,7 +5480,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5513,7 +5513,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5546,7 +5546,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5579,7 +5579,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdAdAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAdAdAttribute", false)) {
   /**
    * A set of attributes that describe the rich media ad capabilities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5612,7 +5612,7 @@ if (!class_exists("RichMediaAdAdAttribute", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdRichMediaAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAdRichMediaAdType", false)) {
   /**
    * Different types of rich media ad that are available to customers.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5645,7 +5645,7 @@ if (!class_exists("RichMediaAdRichMediaAdType", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5678,7 +5678,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5711,7 +5711,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5744,7 +5744,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5777,7 +5777,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5810,7 +5810,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TemplateElementFieldType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElementFieldType", false)) {
   /**
    * Possible field types of template element fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5843,7 +5843,7 @@ if (!class_exists("TemplateElementFieldType", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAdExpandingDirection", false)) {
   /**
    * Allowed expanding directions for ads that are expandable.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5876,7 +5876,7 @@ if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
   }
 }
 
-if (!class_exists("VideoType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\VideoType", false)) {
   /**
    * VideoType enum values that are permitted for video filterable
    * creative attribute IDs.
@@ -5910,7 +5910,7 @@ if (!class_exists("VideoType", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5959,7 +5959,7 @@ if (!class_exists("AdGroupAdServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -5999,7 +5999,7 @@ if (!class_exists("AdGroupAdServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -6066,7 +6066,7 @@ if (!class_exists("AdGroupAdServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6106,7 +6106,7 @@ if (!class_exists("AdGroupAdServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -6154,7 +6154,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6194,7 +6194,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdError", false)) {
   /**
    * Base error class for Ad Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6239,7 +6239,7 @@ if (!class_exists("AdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdCountLimitExceeded", false)) {
   /**
    * Indicates too many ads were added/enabled under the specified adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6278,7 +6278,7 @@ if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdError", false)) {
   /**
    * Error information for AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6323,7 +6323,7 @@ if (!class_exists("AdGroupAdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdOperation", false)) {
   /**
    * AdGroupAd service operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6373,7 +6373,7 @@ if (!class_exists("AdGroupAdOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdPage", false)) {
   /**
    * Represents a page of {@link AdGroupAd}s resulting from the query done by
    * {@link AdGroupAdService}.
@@ -6417,7 +6417,7 @@ if (!class_exists("AdGroupAdPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdReturnValue", false)) {
   /**
    * A container for return values from the AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6466,7 +6466,7 @@ if (!class_exists("AdGroupAdReturnValue", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6511,7 +6511,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6554,7 +6554,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6620,7 +6620,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -6679,7 +6679,7 @@ if (!class_exists("AdGroupAdService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdGroupAdService extends AdWordsSoapClient {
+  class AdGroupAdService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupAdService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -6696,143 +6696,143 @@ if (!class_exists("AdGroupAdService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Ad" => "Ad",
-      "AdError" => "AdError",
-      "AdGroupAd" => "AdGroupAd",
-      "AdGroupAdCountLimitExceeded" => "AdGroupAdCountLimitExceeded",
-      "AdGroupAdError" => "AdGroupAdError",
-      "AdGroupAdExperimentData" => "AdGroupAdExperimentData",
-      "AdGroupAdOperation" => "AdGroupAdOperation",
-      "AdGroupAdPage" => "AdGroupAdPage",
-      "AdGroupAdReturnValue" => "AdGroupAdReturnValue",
-      "AdUnionId" => "AdUnionId",
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Audio" => "Audio",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DeprecatedAd" => "DeprecatedAd",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ExperimentError" => "ExperimentError",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageAd" => "ImageAd",
-      "ImageError" => "ImageError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "Media" => "Media",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "MobileAd" => "MobileAd",
-      "MobileImageAd" => "MobileImageAd",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "ProductAd" => "ProductAd",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "RichMediaAd" => "RichMediaAd",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TempAdUnionId" => "TempAdUnionId",
-      "TemplateAd" => "TemplateAd",
-      "TemplateElement" => "TemplateElement",
-      "TemplateElementField" => "TemplateElementField",
-      "TextAd" => "TextAd",
-      "ThirdPartyRedirectAd" => "ThirdPartyRedirectAd",
-      "Video" => "Video",
-      "DynamicSearchAd" => "DynamicSearchAd",
-      "AdError.Reason" => "AdErrorReason",
-      "AdGroupAd.ApprovalStatus" => "AdGroupAdApprovalStatus",
-      "AdGroupAd.Status" => "AdGroupAdStatus",
-      "AdGroupAdError.Reason" => "AdGroupAdErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DeprecatedAd.Type" => "DeprecatedAdType",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ExperimentError.Reason" => "ExperimentErrorReason",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MarkupLanguageType" => "MarkupLanguageType",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "RichMediaAd.AdAttribute" => "RichMediaAdAdAttribute",
-      "RichMediaAd.RichMediaAdType" => "RichMediaAdRichMediaAdType",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TemplateElementField.Type" => "TemplateElementFieldType",
-      "ThirdPartyRedirectAd.ExpandingDirection" => "ThirdPartyRedirectAdExpandingDirection",
-      "VideoType" => "VideoType",
-      "get" => "AdGroupAdServiceGet",
-      "getResponse" => "AdGroupAdServiceGetResponse",
-      "mutate" => "AdGroupAdServiceMutate",
-      "mutateResponse" => "AdGroupAdServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "Ad" => "Google_Api_Ads_AdWords_v201402\\Ad",
+      "AdError" => "Google_Api_Ads_AdWords_v201402\\AdError",
+      "AdGroupAd" => "Google_Api_Ads_AdWords_v201402\\AdGroupAd",
+      "AdGroupAdCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdCountLimitExceeded",
+      "AdGroupAdError" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdError",
+      "AdGroupAdExperimentData" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdExperimentData",
+      "AdGroupAdOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdOperation",
+      "AdGroupAdPage" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdPage",
+      "AdGroupAdReturnValue" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdReturnValue",
+      "AdUnionId" => "Google_Api_Ads_AdWords_v201402\\AdUnionId",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Audio" => "Google_Api_Ads_AdWords_v201402\\Audio",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DeprecatedAd" => "Google_Api_Ads_AdWords_v201402\\DeprecatedAd",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201402\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201402\\ExemptionRequest",
+      "ExperimentError" => "Google_Api_Ads_AdWords_v201402\\ExperimentError",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201402\\Image",
+      "ImageAd" => "Google_Api_Ads_AdWords_v201402\\ImageAd",
+      "ImageError" => "Google_Api_Ads_AdWords_v201402\\ImageError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Media" => "Google_Api_Ads_AdWords_v201402\\Media",
+      "MediaError" => "Google_Api_Ads_AdWords_v201402\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry",
+      "MobileAd" => "Google_Api_Ads_AdWords_v201402\\MobileAd",
+      "MobileImageAd" => "Google_Api_Ads_AdWords_v201402\\MobileImageAd",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "ProductAd" => "Google_Api_Ads_AdWords_v201402\\ProductAd",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "RichMediaAd" => "Google_Api_Ads_AdWords_v201402\\RichMediaAd",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "TempAdUnionId" => "Google_Api_Ads_AdWords_v201402\\TempAdUnionId",
+      "TemplateAd" => "Google_Api_Ads_AdWords_v201402\\TemplateAd",
+      "TemplateElement" => "Google_Api_Ads_AdWords_v201402\\TemplateElement",
+      "TemplateElementField" => "Google_Api_Ads_AdWords_v201402\\TemplateElementField",
+      "TextAd" => "Google_Api_Ads_AdWords_v201402\\TextAd",
+      "ThirdPartyRedirectAd" => "Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAd",
+      "Video" => "Google_Api_Ads_AdWords_v201402\\Video",
+      "DynamicSearchAd" => "Google_Api_Ads_AdWords_v201402\\DynamicSearchAd",
+      "AdError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdErrorReason",
+      "AdGroupAd.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdApprovalStatus",
+      "AdGroupAd.Status" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdStatus",
+      "AdGroupAdError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DeprecatedAd.Type" => "Google_Api_Ads_AdWords_v201402\\DeprecatedAdType",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus",
+      "ExperimentError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201402\\ImageErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "MarkupLanguageType" => "Google_Api_Ads_AdWords_v201402\\MarkupLanguageType",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201402\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201402\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201402\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201402\\MediaErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "RichMediaAd.AdAttribute" => "Google_Api_Ads_AdWords_v201402\\RichMediaAdAdAttribute",
+      "RichMediaAd.RichMediaAdType" => "Google_Api_Ads_AdWords_v201402\\RichMediaAdRichMediaAdType",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "TemplateElementField.Type" => "Google_Api_Ads_AdWords_v201402\\TemplateElementFieldType",
+      "ThirdPartyRedirectAd.ExpandingDirection" => "Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAdExpandingDirection",
+      "VideoType" => "Google_Api_Ads_AdWords_v201402\\VideoType",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -6916,3 +6916,4 @@ if (!class_exists("AdGroupAdService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdGroupBidModifierService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdGroupBidModifierService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -461,7 +461,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -540,7 +540,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -608,7 +608,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -695,7 +695,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifier", false)) {
   /**
    * Represents an adgroup level bid modifier override for campaign level criterion
    * bid modifier values.
@@ -764,7 +764,7 @@ if (!class_exists("AdGroupBidModifier", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -836,7 +836,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -916,7 +916,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -995,7 +995,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1028,7 +1028,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1061,7 +1061,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidModifierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidModifierSource", false)) {
   /**
    * Enumerates possible sources for bid modifier.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1094,7 +1094,7 @@ if (!class_exists("BidModifierSource", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1128,7 +1128,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1161,7 +1161,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1194,7 +1194,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1227,7 +1227,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1260,7 +1260,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1294,7 +1294,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1327,7 +1327,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1360,7 +1360,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1393,7 +1393,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1426,7 +1426,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1459,7 +1459,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1492,7 +1492,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1525,7 +1525,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1558,7 +1558,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1592,7 +1592,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1625,7 +1625,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1658,7 +1658,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1691,7 +1691,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1724,7 +1724,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1757,7 +1757,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1790,7 +1790,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1823,7 +1823,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1856,7 +1856,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1889,7 +1889,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1922,7 +1922,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1970,7 +1970,7 @@ if (!class_exists("AdGroupBidModifierServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2010,7 +2010,7 @@ if (!class_exists("AdGroupBidModifierServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2061,7 +2061,7 @@ if (!class_exists("AdGroupBidModifierServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2101,7 +2101,7 @@ if (!class_exists("AdGroupBidModifierServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2148,7 +2148,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2188,7 +2188,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2233,7 +2233,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2278,7 +2278,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2323,7 +2323,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2368,7 +2368,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2413,7 +2413,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2459,7 +2459,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2504,7 +2504,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2551,7 +2551,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2596,7 +2596,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2641,7 +2641,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2686,10 +2686,10 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -2732,7 +2732,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2784,7 +2784,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2829,7 +2829,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2874,7 +2874,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2940,7 +2940,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2985,7 +2985,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3030,7 +3030,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3076,7 +3076,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3121,7 +3121,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3166,7 +3166,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3211,7 +3211,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3257,7 +3257,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3302,7 +3302,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3345,7 +3345,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierOperation", false)) {
   /**
    * Operation used to create or mutate a AdGroupBidModifier.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3388,7 +3388,7 @@ if (!class_exists("AdGroupBidModifierOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierPage", false)) {
   /**
    * Contains a subset of adgroup bid modifiers resulting from a call to
    * {@link AdGroupBidModifierService#get}.
@@ -3432,7 +3432,7 @@ if (!class_exists("AdGroupBidModifierPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierReturnValue", false)) {
   /**
    * A container for return values from the AdGroupBidModifierService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3487,7 +3487,7 @@ if (!class_exists("AdGroupBidModifierService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdGroupBidModifierService extends AdWordsSoapClient {
+  class AdGroupBidModifierService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupBidModifierService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3504,82 +3504,82 @@ if (!class_exists("AdGroupBidModifierService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CriterionError" => "CriterionError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Platform" => "Platform",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Criterion" => "Criterion",
-      "AdGroupBidModifier" => "AdGroupBidModifier",
-      "AdGroupBidModifierOperation" => "AdGroupBidModifierOperation",
-      "AdGroupBidModifierPage" => "AdGroupBidModifierPage",
-      "AdGroupBidModifierReturnValue" => "AdGroupBidModifierReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BidModifierSource" => "BidModifierSource",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupBidModifierServiceGet",
-      "getResponse" => "AdGroupBidModifierServiceGetResponse",
-      "mutate" => "AdGroupBidModifierServiceMutate",
-      "mutateResponse" => "AdGroupBidModifierServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201402\\CriterionError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Platform" => "Google_Api_Ads_AdWords_v201402\\Platform",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "AdGroupBidModifier" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifier",
+      "AdGroupBidModifierOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierOperation",
+      "AdGroupBidModifierPage" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierPage",
+      "AdGroupBidModifierReturnValue" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BidModifierSource" => "Google_Api_Ads_AdWords_v201402\\BidModifierSource",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -3645,3 +3645,4 @@ if (!class_exists("AdGroupBidModifierService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdGroupCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdGroupCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterion", false)) {
   /**
    * Represents a criterion in an ad group, used with AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -130,7 +130,7 @@ if (!class_exists("AdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * Bid multiplier used to modify the bid of a criterion while running
    * an experiment.
@@ -204,7 +204,7 @@ if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -301,7 +301,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -380,7 +380,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -425,7 +425,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -470,7 +470,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -510,7 +510,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -558,7 +558,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterion", false)) {
   /**
    * A biddable (positive) criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -674,7 +674,7 @@ if (!class_exists("BiddableAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterionExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this {@link BiddableAdGroupCriterion}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -735,7 +735,7 @@ if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -780,7 +780,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -825,7 +825,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -898,7 +898,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -990,7 +990,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1062,7 +1062,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -1113,7 +1113,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1158,7 +1158,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1230,7 +1230,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -1293,7 +1293,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1335,7 +1335,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1391,7 +1391,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1440,7 +1440,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1527,7 +1527,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1572,7 +1572,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1644,7 +1644,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1689,7 +1689,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1734,7 +1734,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -1782,7 +1782,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1827,7 +1827,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -1866,7 +1866,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1911,7 +1911,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1985,7 +1985,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2031,7 +2031,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2071,7 +2071,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("ExperimentError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentError", false)) {
   /**
    * The error reason represented by an enum.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2116,7 +2116,7 @@ if (!class_exists("ExperimentError", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -2162,10 +2162,10 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -2208,7 +2208,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2253,7 +2253,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2300,7 +2300,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -2352,7 +2352,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2424,7 +2424,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * AdGroupCriterion level bid multiplier used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2474,7 +2474,7 @@ if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2517,7 +2517,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2553,7 +2553,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -2607,7 +2607,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2659,7 +2659,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2701,7 +2701,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NegativeAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeAdGroupCriterion", false)) {
   /**
    * A negative criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2740,7 +2740,7 @@ if (!class_exists("NegativeAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2785,7 +2785,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2830,7 +2830,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2875,7 +2875,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2910,7 +2910,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -2990,7 +2990,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3035,7 +3035,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3082,7 +3082,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3161,7 +3161,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -3240,7 +3240,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -3289,7 +3289,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -3335,7 +3335,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3384,7 +3384,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -3425,7 +3425,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -3471,7 +3471,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -3562,7 +3562,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3609,7 +3609,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -3657,7 +3657,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3711,7 +3711,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -3766,7 +3766,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -3814,7 +3814,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3854,7 +3854,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("ProductDimension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimension", false)) {
   /**
    * Dimension by which to subdivide or filter products.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3926,7 +3926,7 @@ if (!class_exists("ProductDimension", false)) {
   }
 }
 
-if (!class_exists("ProductOfferId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductOfferId", false)) {
   /**
    * An offer ID as specified by the merchant.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3968,7 +3968,7 @@ if (!class_exists("ProductOfferId", false)) {
   }
 }
 
-if (!class_exists("ProductPartition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductPartition", false)) {
   /**
    * Product partition (product group) in a shopping campaign. Depending on its type, a product
    * partition subdivides products along some product dimension, specifies a bid for products, or
@@ -4040,7 +4040,7 @@ if (!class_exists("ProductPartition", false)) {
   }
 }
 
-if (!class_exists("ProductType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductType", false)) {
   /**
    * One element of a product type string at a certain level. Top-level product types are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -4092,7 +4092,7 @@ if (!class_exists("ProductType", false)) {
   }
 }
 
-if (!class_exists("ProductTypeFull", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductTypeFull", false)) {
   /**
    * A full product type string. Category of the product according to the merchant's own
    * classification. Example:
@@ -4139,7 +4139,7 @@ if (!class_exists("ProductTypeFull", false)) {
   }
 }
 
-if (!class_exists("QualityInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QualityInfo", false)) {
   /**
    * Container for criterion quality information.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4200,7 +4200,7 @@ if (!class_exists("QualityInfo", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4252,7 +4252,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4297,7 +4297,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4342,7 +4342,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4408,7 +4408,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4453,7 +4453,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4498,7 +4498,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -4544,7 +4544,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4589,7 +4589,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4657,7 +4657,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4702,7 +4702,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4747,7 +4747,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4815,7 +4815,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4883,7 +4883,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4928,7 +4928,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4974,7 +4974,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -5022,7 +5022,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -5089,7 +5089,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetRoasBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme", false)) {
   /**
    * Target Roas bidding strategy helps you maximize revenue while averaging a specific target
    * Return On Average Spend (ROAS).
@@ -5155,7 +5155,7 @@ if (!class_exists("TargetRoasBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -5207,7 +5207,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -5259,7 +5259,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -5318,7 +5318,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -5381,7 +5381,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -5441,7 +5441,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -5493,7 +5493,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -5543,7 +5543,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5576,7 +5576,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5609,7 +5609,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5642,7 +5642,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201402
@@ -5675,7 +5675,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("ApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApprovalStatus", false)) {
   /**
    * Approval status for the criterion.
    * Note: there are more states involved but we only expose two to users.
@@ -5709,7 +5709,7 @@ if (!class_exists("ApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5742,7 +5742,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5775,7 +5775,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -5809,7 +5809,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5842,7 +5842,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5875,7 +5875,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5908,7 +5908,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5941,7 +5941,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -5975,7 +5975,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6008,7 +6008,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6041,7 +6041,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6074,7 +6074,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6107,7 +6107,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUse", false)) {
   /**
    * The way a criterion is used - biddable or negative.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6140,7 +6140,7 @@ if (!class_exists("CriterionUse", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6173,7 +6173,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6206,7 +6206,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6239,7 +6239,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6272,7 +6272,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6305,7 +6305,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -6339,7 +6339,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6372,7 +6372,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6405,7 +6405,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6438,7 +6438,7 @@ if (!class_exists("ExperimentErrorReason", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6471,7 +6471,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6504,7 +6504,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6537,7 +6537,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6570,7 +6570,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -6604,7 +6604,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("MultiplierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MultiplierSource", false)) {
   /**
    * Denotes whether the bid multiplier is derived from the adgroup
    * or the criterion
@@ -6638,7 +6638,7 @@ if (!class_exists("MultiplierSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6671,7 +6671,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6704,7 +6704,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6737,7 +6737,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6770,7 +6770,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6803,9 +6803,9 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -6836,7 +6836,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6869,7 +6869,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6902,7 +6902,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalConditionCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition", false)) {
   /**
    * A canonical product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6935,7 +6935,7 @@ if (!class_exists("ProductCanonicalConditionCondition", false)) {
   }
 }
 
-if (!class_exists("ProductDimensionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimensionType", false)) {
   /**
    * Type of product dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6968,7 +6968,7 @@ if (!class_exists("ProductDimensionType", false)) {
   }
 }
 
-if (!class_exists("ProductPartitionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductPartitionType", false)) {
   /**
    * Type of a product partition in a shopping campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7001,7 +7001,7 @@ if (!class_exists("ProductPartitionType", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7034,7 +7034,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -7068,7 +7068,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7101,7 +7101,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7134,7 +7134,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7167,7 +7167,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7200,7 +7200,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7233,7 +7233,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7266,7 +7266,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7299,7 +7299,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7332,7 +7332,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7365,7 +7365,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7398,7 +7398,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7431,7 +7431,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("SystemServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SystemServingStatus", false)) {
   /**
    * Reported by system to reflect the criterion's serving status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7464,7 +7464,7 @@ if (!class_exists("SystemServingStatus", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7497,7 +7497,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("UserStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserStatus", false)) {
   /**
    * Specified by user to pause or unpause a criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7530,7 +7530,7 @@ if (!class_exists("UserStatus", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7563,7 +7563,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7611,7 +7611,7 @@ if (!class_exists("AdGroupCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -7651,7 +7651,7 @@ if (!class_exists("AdGroupCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -7704,7 +7704,7 @@ if (!class_exists("AdGroupCriterionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -7744,7 +7744,7 @@ if (!class_exists("AdGroupCriterionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7792,7 +7792,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -7832,7 +7832,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7877,7 +7877,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7923,7 +7923,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionOperation", false)) {
   /**
    * Operation (add, remove and set) on adgroup criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7973,7 +7973,7 @@ if (!class_exists("AdGroupCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionPage", false)) {
   /**
    * Contains a subset of adgroup criteria resulting from a
    * {@link AdGroupCriterionService#get} call.
@@ -8017,7 +8017,7 @@ if (!class_exists("AdGroupCriterionPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionReturnValue", false)) {
   /**
    * A container for return values from the AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8066,7 +8066,7 @@ if (!class_exists("AdGroupCriterionReturnValue", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8111,10 +8111,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -8157,7 +8157,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8200,7 +8200,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8240,7 +8240,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8281,7 +8281,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8322,7 +8322,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsGrouping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping", false)) {
   /**
    * An {@code adwords grouping} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -8365,7 +8365,7 @@ if (!class_exists("ProductAdwordsGrouping", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsLabels", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels", false)) {
   /**
    * An {@code adwords labels} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -8408,7 +8408,7 @@ if (!class_exists("ProductAdwordsLabels", false)) {
   }
 }
 
-if (!class_exists("ProductBiddingCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory", false)) {
   /**
    * One element of a bidding category at a certain level. Top-level categories are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -8460,7 +8460,7 @@ if (!class_exists("ProductBiddingCategory", false)) {
   }
 }
 
-if (!class_exists("ProductBrand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBrand", false)) {
   /**
    * A brand string.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8502,7 +8502,7 @@ if (!class_exists("ProductBrand", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition", false)) {
   /**
    * A canonical condition. Only supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -8545,7 +8545,7 @@ if (!class_exists("ProductCanonicalCondition", false)) {
   }
 }
 
-if (!class_exists("ProductLegacyCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition", false)) {
   /**
    * A plain condition string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -8588,7 +8588,7 @@ if (!class_exists("ProductLegacyCondition", false)) {
   }
 }
 
-if (!class_exists("ProductCustomAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute", false)) {
   /**
    * A custom attribute value. As a product can have multiple custom attributes, the user must specify
    * a dimension type that indicates the index of the attribute by which to subdivide. All cases of
@@ -8645,7 +8645,7 @@ if (!class_exists("AdGroupCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdGroupCriterionService extends AdWordsSoapClient {
+  class AdGroupCriterionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -8662,191 +8662,191 @@ if (!class_exists("AdGroupCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupCriterion" => "AdGroupCriterion",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionExperimentBidMultiplier" => "AdGroupCriterionExperimentBidMultiplier",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdGroupCriterionOperation" => "AdGroupCriterionOperation",
-      "AdGroupCriterionPage" => "AdGroupCriterionPage",
-      "AdGroupCriterionReturnValue" => "AdGroupCriterionReturnValue",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "BiddableAdGroupCriterion" => "BiddableAdGroupCriterion",
-      "BiddableAdGroupCriterionExperimentData" => "BiddableAdGroupCriterionExperimentData",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ExperimentError" => "ExperimentError",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "Gender" => "Gender",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "ListReturnValue" => "ListReturnValue",
-      "LongValue" => "LongValue",
-      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "ManualCPCAdGroupCriterionExperimentBidMultiplier",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NegativeAdGroupCriterion" => "NegativeAdGroupCriterion",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Placement" => "Placement",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductAdwordsGrouping" => "ProductAdwordsGrouping",
-      "ProductAdwordsLabels" => "ProductAdwordsLabels",
-      "ProductBiddingCategory" => "ProductBiddingCategory",
-      "ProductBrand" => "ProductBrand",
-      "ProductCanonicalCondition" => "ProductCanonicalCondition",
-      "ProductLegacyCondition" => "ProductLegacyCondition",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "ProductCustomAttribute" => "ProductCustomAttribute",
-      "ProductDimension" => "ProductDimension",
-      "ProductOfferId" => "ProductOfferId",
-      "ProductPartition" => "ProductPartition",
-      "ProductType" => "ProductType",
-      "ProductTypeFull" => "ProductTypeFull",
-      "QualityInfo" => "QualityInfo",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetRoasBiddingScheme" => "TargetRoasBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "ApprovalStatus" => "ApprovalStatus",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "CriterionUse" => "CriterionUse",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ExperimentError.Reason" => "ExperimentErrorReason",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "MultiplierSource" => "MultiplierSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "ProductCanonicalCondition.Condition" => "ProductCanonicalConditionCondition",
-      "ProductDimensionType" => "ProductDimensionType",
-      "ProductPartitionType" => "ProductPartitionType",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "SystemServingStatus" => "SystemServingStatus",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "UserStatus" => "UserStatus",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "AdGroupCriterionServiceGet",
-      "getResponse" => "AdGroupCriterionServiceGetResponse",
-      "mutate" => "AdGroupCriterionServiceMutate",
-      "mutateResponse" => "AdGroupCriterionServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterion",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError",
+      "AdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionExperimentBidMultiplier",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded",
+      "AdGroupCriterionOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionOperation",
+      "AdGroupCriterionPage" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionPage",
+      "AdGroupCriterionReturnValue" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionReturnValue",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201402\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "Bid" => "Google_Api_Ads_AdWords_v201402\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201402\\BidMultiplier",
+      "BiddableAdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterion",
+      "BiddableAdGroupCriterionExperimentData" => "Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterionExperimentData",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201402\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201402\\BiddingErrors",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration",
+      "Bids" => "Google_Api_Ads_AdWords_v201402\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201402\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201402\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201402\\CpmBid",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201402\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201402\\CriterionParameter",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201402\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDenied",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201402\\ExemptionRequest",
+      "ExperimentError" => "Google_Api_Ads_AdWords_v201402\\ExperimentError",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError",
+      "Gender" => "Google_Api_Ads_AdWords_v201402\\Gender",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupCriterionExperimentBidMultiplier",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NegativeAdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\NegativeAdGroupCriterion",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductAdwordsGrouping" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping",
+      "ProductAdwordsLabels" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels",
+      "ProductBiddingCategory" => "Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory",
+      "ProductBrand" => "Google_Api_Ads_AdWords_v201402\\ProductBrand",
+      "ProductCanonicalCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition",
+      "ProductLegacyCondition" => "Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "ProductCustomAttribute" => "Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute",
+      "ProductDimension" => "Google_Api_Ads_AdWords_v201402\\ProductDimension",
+      "ProductOfferId" => "Google_Api_Ads_AdWords_v201402\\ProductOfferId",
+      "ProductPartition" => "Google_Api_Ads_AdWords_v201402\\ProductPartition",
+      "ProductType" => "Google_Api_Ads_AdWords_v201402\\ProductType",
+      "ProductTypeFull" => "Google_Api_Ads_AdWords_v201402\\ProductTypeFull",
+      "QualityInfo" => "Google_Api_Ads_AdWords_v201402\\QualityInfo",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme",
+      "TargetRoasBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "Webpage" => "Google_Api_Ads_AdWords_v201402\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201402\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201402\\WebpageParameter",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType",
+      "ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\ApprovalStatus",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201402\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CriterionErrorReason",
+      "CriterionUse" => "Google_Api_Ads_AdWords_v201402\\CriterionUse",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus",
+      "ExperimentError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201402\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "MultiplierSource" => "Google_Api_Ads_AdWords_v201402\\MultiplierSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "ProductCanonicalCondition.Condition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition",
+      "ProductDimensionType" => "Google_Api_Ads_AdWords_v201402\\ProductDimensionType",
+      "ProductPartitionType" => "Google_Api_Ads_AdWords_v201402\\ProductPartitionType",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "SystemServingStatus" => "Google_Api_Ads_AdWords_v201402\\SystemServingStatus",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "UserStatus" => "Google_Api_Ads_AdWords_v201402\\UserStatus",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201402\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -8915,3 +8915,4 @@ if (!class_exists("AdGroupCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdGroupFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdGroupFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdGroupFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeed", false)) {
   /**
    * AdGroupFeeds are used to link a feed to an adgroup using a matching function,
    * making the feed's feed items available in the adgroup's ads for substitution.
@@ -99,7 +99,7 @@ if (!class_exists("AdGroupFeed", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -196,7 +196,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -275,7 +275,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -320,7 +320,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -365,7 +365,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -410,7 +410,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -456,7 +456,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -501,7 +501,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -549,7 +549,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -594,7 +594,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -668,7 +668,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -714,7 +714,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -798,7 +798,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -843,7 +843,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -888,7 +888,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -935,7 +935,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1007,7 +1007,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1052,7 +1052,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1097,7 +1097,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1169,7 +1169,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1249,7 +1249,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1294,7 +1294,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1341,7 +1341,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1420,7 +1420,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1469,7 +1469,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1523,7 +1523,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1575,7 +1575,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1620,7 +1620,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1665,7 +1665,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1731,7 +1731,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1776,7 +1776,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1821,7 +1821,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperand", false)) {
   /**
    * An operand in a function referring to a value in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1863,7 +1863,7 @@ if (!class_exists("RequestContextOperand", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1909,7 +1909,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1954,7 +1954,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2022,7 +2022,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2067,7 +2067,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2112,7 +2112,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2180,7 +2180,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2248,7 +2248,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2294,7 +2294,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedStatus", false)) {
   /**
    * Status of the AdGroupFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2327,7 +2327,7 @@ if (!class_exists("AdGroupFeedStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2360,7 +2360,7 @@ if (!class_exists("AdGroupFeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2393,7 +2393,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2426,7 +2426,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2460,7 +2460,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2493,7 +2493,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantOperandConstantType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType", false)) {
   /**
    * The types of constant operands.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2526,7 +2526,7 @@ if (!class_exists("ConstantOperandConstantType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2559,7 +2559,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2592,7 +2592,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2625,7 +2625,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2659,7 +2659,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2692,7 +2692,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2725,7 +2725,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2758,7 +2758,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2791,7 +2791,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2824,7 +2824,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2857,7 +2857,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2890,7 +2890,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2923,7 +2923,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2956,7 +2956,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2989,7 +2989,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3023,7 +3023,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3056,7 +3056,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3089,7 +3089,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3122,7 +3122,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3155,7 +3155,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperandContextType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType", false)) {
   /**
    * Campaign Id in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3188,7 +3188,7 @@ if (!class_exists("RequestContextOperandContextType", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3221,7 +3221,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3254,7 +3254,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3287,7 +3287,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3320,7 +3320,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3353,7 +3353,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3386,7 +3386,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3435,7 +3435,7 @@ if (!class_exists("AdGroupFeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3475,7 +3475,7 @@ if (!class_exists("AdGroupFeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -3525,7 +3525,7 @@ if (!class_exists("AdGroupFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3565,7 +3565,7 @@ if (!class_exists("AdGroupFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3613,7 +3613,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3653,7 +3653,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedError", false)) {
   /**
    * Represents an error for the AdGroupFeedService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3698,7 +3698,7 @@ if (!class_exists("AdGroupFeedError", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedOperation", false)) {
   /**
    * Operation used to create or mutate an AdGroupFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3741,7 +3741,7 @@ if (!class_exists("AdGroupFeedOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedReturnValue", false)) {
   /**
    * The result of a call to AdGroupFeedService#mutate.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3783,7 +3783,7 @@ if (!class_exists("AdGroupFeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3826,7 +3826,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ConstantOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperand", false)) {
   /**
    * A constant operand in a matching function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3896,7 +3896,7 @@ if (!class_exists("ConstantOperand", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand", false)) {
   /**
    * Represents a feed attribute reference to use in a function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3945,7 +3945,7 @@ if (!class_exists("FeedAttributeOperand", false)) {
   }
 }
 
-if (!class_exists("FunctionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperand", false)) {
   /**
    * A function operand in a matching function.
    * Used to represent nested functions.
@@ -3988,7 +3988,7 @@ if (!class_exists("FunctionOperand", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4024,7 +4024,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupFeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupFeedPage", false)) {
   /**
    * The result of a call to AdGroupFeedService#get. Contains a list of
    * associations between ad groups and feeds.
@@ -4072,7 +4072,7 @@ if (!class_exists("AdGroupFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdGroupFeedService extends AdWordsSoapClient {
+  class AdGroupFeedService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4089,95 +4089,95 @@ if (!class_exists("AdGroupFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupFeed" => "AdGroupFeed",
-      "AdGroupFeedError" => "AdGroupFeedError",
-      "AdGroupFeedOperation" => "AdGroupFeedOperation",
-      "AdGroupFeedPage" => "AdGroupFeedPage",
-      "AdGroupFeedReturnValue" => "AdGroupFeedReturnValue",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ConstantOperand" => "ConstantOperand",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttributeOperand" => "FeedAttributeOperand",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "FunctionOperand" => "FunctionOperand",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NullStatsPage" => "NullStatsPage",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestContextOperand" => "RequestContextOperand",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "AdGroupFeed.Status" => "AdGroupFeedStatus",
-      "AdGroupFeedError.Reason" => "AdGroupFeedErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "ConstantOperand.ConstantType" => "ConstantOperandConstantType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestContextOperand.ContextType" => "RequestContextOperandContextType",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupFeedServiceGet",
-      "getResponse" => "AdGroupFeedServiceGetResponse",
-      "mutate" => "AdGroupFeedServiceMutate",
-      "mutateResponse" => "AdGroupFeedServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdGroupFeed" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeed",
+      "AdGroupFeedError" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedError",
+      "AdGroupFeedOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedOperation",
+      "AdGroupFeedPage" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedPage",
+      "AdGroupFeedReturnValue" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedReturnValue",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "ConstantOperand" => "Google_Api_Ads_AdWords_v201402\\ConstantOperand",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedAttributeOperand" => "Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand",
+      "Function" => "Google_Api_Ads_AdWords_v201402\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201402\\FunctionError",
+      "FunctionOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestContextOperand" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperand",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "AdGroupFeed.Status" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedStatus",
+      "AdGroupFeedError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "ConstantOperand.ConstantType" => "Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201402\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201402\\FunctionErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestContextOperand.ContextType" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupFeedServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4244,3 +4244,4 @@ if (!class_exists("AdGroupFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdGroupService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdGroupService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -412,7 +412,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("TargetingSettingDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingSettingDetail", false)) {
   /**
    * Specifies if criteria of this type group should be used to restrict
    * targeting, or if ads can serve anywhere and criteria are only used in
@@ -461,7 +461,7 @@ if (!class_exists("TargetingSettingDetail", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -533,7 +533,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -605,7 +605,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -702,7 +702,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -781,7 +781,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -821,7 +821,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -869,7 +869,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -941,7 +941,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1009,7 +1009,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupExperimentBidMultipliers", false)) {
   /**
    * Bid multiplier used to modify the bid of an adgroup while running
    * an experiment.
@@ -1083,7 +1083,7 @@ if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this adgroup.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1145,7 +1145,7 @@ if (!class_exists("AdGroupExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1218,7 +1218,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -1310,7 +1310,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("AdGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroup", false)) {
   /**
    * Represents an ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1413,7 +1413,7 @@ if (!class_exists("AdGroup", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1485,7 +1485,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1565,7 +1565,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1644,7 +1644,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceErrorReason", false)) {
   /**
    * The reasons for the adgroup service error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1677,7 +1677,7 @@ if (!class_exists("AdGroupServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupStatus", false)) {
   /**
    * Status of this ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1710,7 +1710,7 @@ if (!class_exists("AdGroupStatus", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1743,7 +1743,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1776,7 +1776,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1809,7 +1809,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -1843,7 +1843,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1876,7 +1876,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1909,7 +1909,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1942,7 +1942,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1975,7 +1975,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2009,7 +2009,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2042,7 +2042,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2075,7 +2075,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("CriterionTypeGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionTypeGroup", false)) {
   /**
    * The list of groupings of criteria types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2108,7 +2108,7 @@ if (!class_exists("CriterionTypeGroup", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2141,7 +2141,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2174,7 +2174,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2207,7 +2207,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2240,7 +2240,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2274,7 +2274,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2307,7 +2307,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2340,7 +2340,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2373,7 +2373,7 @@ if (!class_exists("ExperimentErrorReason", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2406,7 +2406,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2439,7 +2439,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2472,7 +2472,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2505,7 +2505,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2538,7 +2538,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2571,7 +2571,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2604,7 +2604,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2637,7 +2637,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2670,9 +2670,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -2703,7 +2703,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2736,7 +2736,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2769,7 +2769,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2803,7 +2803,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2836,7 +2836,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2869,7 +2869,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2902,7 +2902,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2935,7 +2935,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2968,7 +2968,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3001,7 +3001,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3034,7 +3034,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3067,7 +3067,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3100,7 +3100,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3133,7 +3133,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3166,7 +3166,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3199,7 +3199,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3232,7 +3232,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3281,7 +3281,7 @@ if (!class_exists("AdGroupServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3321,7 +3321,7 @@ if (!class_exists("AdGroupServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -3376,7 +3376,7 @@ if (!class_exists("AdGroupServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3416,7 +3416,7 @@ if (!class_exists("AdGroupServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3464,7 +3464,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3504,7 +3504,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceError", false)) {
   /**
    * Represents possible error codes in AdGroupService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3556,7 +3556,7 @@ if (!class_exists("AdGroupServiceError", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3601,7 +3601,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3646,7 +3646,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3691,7 +3691,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3736,7 +3736,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3781,7 +3781,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3826,7 +3826,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -3889,7 +3889,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3934,7 +3934,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3979,7 +3979,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4018,7 +4018,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4092,7 +4092,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4138,7 +4138,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExperimentError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentError", false)) {
   /**
    * The error reason represented by an enum.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4183,7 +4183,7 @@ if (!class_exists("ExperimentError", false)) {
   }
 }
 
-if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExplorerAutoOptimizerSetting", false)) {
   /**
    * Settings for Explorer (GDN Auto Optimizer).
    * @package Google_Api_Ads_AdWords_v201402
@@ -4225,7 +4225,7 @@ if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -4271,7 +4271,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4316,7 +4316,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -4363,7 +4363,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -4406,7 +4406,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4442,7 +4442,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4484,7 +4484,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4529,7 +4529,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4574,7 +4574,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4619,7 +4619,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4654,7 +4654,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4699,7 +4699,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4744,7 +4744,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4793,7 +4793,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -4834,7 +4834,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4886,7 +4886,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4931,7 +4931,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4983,7 +4983,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5028,7 +5028,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5094,7 +5094,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5139,7 +5139,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5184,7 +5184,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -5230,7 +5230,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5275,7 +5275,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5320,7 +5320,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5365,7 +5365,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5410,7 +5410,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5455,7 +5455,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -5501,7 +5501,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingSetting", false)) {
   /**
    * Setting for targeting related features.
    * This is applicable at Campaign and AdGroup level.
@@ -5544,7 +5544,7 @@ if (!class_exists("TargetingSetting", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5586,7 +5586,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5642,7 +5642,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5691,7 +5691,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5736,7 +5736,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -5815,7 +5815,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -5882,7 +5882,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetRoasBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme", false)) {
   /**
    * Target Roas bidding strategy helps you maximize revenue while averaging a specific target
    * Return On Average Spend (ROAS).
@@ -5948,7 +5948,7 @@ if (!class_exists("TargetRoasBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -6000,7 +6000,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6043,7 +6043,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -6094,7 +6094,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6144,7 +6144,7 @@ if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPMAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPM bidding strategy.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6187,7 +6187,7 @@ if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupOperation", false)) {
   /**
    * AdGroup operations for adding/updating/removing adgroups.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6230,7 +6230,7 @@ if (!class_exists("AdGroupOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupPage", false)) {
   /**
    * Contains a subset of adgroup resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.adgroup.AdGroupService#get} call
@@ -6274,7 +6274,7 @@ if (!class_exists("AdGroupPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupReturnValue", false)) {
   /**
    * A container for return values from the AdGroupService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6323,7 +6323,7 @@ if (!class_exists("AdGroupReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6364,7 +6364,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6411,7 +6411,7 @@ if (!class_exists("AdGroupService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdGroupService extends AdWordsSoapClient {
+  class AdGroupService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdGroupService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -6428,145 +6428,145 @@ if (!class_exists("AdGroupService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupServiceError" => "AdGroupServiceError",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExperimentError" => "ExperimentError",
-      "ExplorerAutoOptimizerSetting" => "ExplorerAutoOptimizerSetting",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SettingError" => "SettingError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetingSettingDetail" => "TargetingSettingDetail",
-      "TargetingSetting" => "TargetingSetting",
-      "ComparableValue" => "ComparableValue",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Setting" => "Setting",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetRoasBiddingScheme" => "TargetRoasBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "ManualCPCAdGroupExperimentBidMultipliers" => "ManualCPCAdGroupExperimentBidMultipliers",
-      "ManualCPMAdGroupExperimentBidMultipliers" => "ManualCPMAdGroupExperimentBidMultipliers",
-      "Selector" => "Selector",
-      "AdGroupExperimentBidMultipliers" => "AdGroupExperimentBidMultipliers",
-      "AdGroupExperimentData" => "AdGroupExperimentData",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "AdGroup" => "AdGroup",
-      "AdGroupOperation" => "AdGroupOperation",
-      "AdGroupPage" => "AdGroupPage",
-      "AdGroupReturnValue" => "AdGroupReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdGroupServiceError.Reason" => "AdGroupServiceErrorReason",
-      "AdGroup.Status" => "AdGroupStatus",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "CriterionTypeGroup" => "CriterionTypeGroup",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ExperimentError.Reason" => "ExperimentErrorReason",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdGroupServiceGet",
-      "getResponse" => "AdGroupServiceGetResponse",
-      "mutate" => "AdGroupServiceMutate",
-      "mutateResponse" => "AdGroupServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdGroupServiceError" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceError",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201402\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201402\\BiddingErrors",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ExperimentError" => "Google_Api_Ads_AdWords_v201402\\ExperimentError",
+      "ExplorerAutoOptimizerSetting" => "Google_Api_Ads_AdWords_v201402\\ExplorerAutoOptimizerSetting",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201402\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SettingError" => "Google_Api_Ads_AdWords_v201402\\SettingError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "TargetingSettingDetail" => "Google_Api_Ads_AdWords_v201402\\TargetingSettingDetail",
+      "TargetingSetting" => "Google_Api_Ads_AdWords_v201402\\TargetingSetting",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201402\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201402\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201402\\CpmBid",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme",
+      "Setting" => "Google_Api_Ads_AdWords_v201402\\Setting",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme",
+      "TargetRoasBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Bid" => "Google_Api_Ads_AdWords_v201402\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201402\\BidMultiplier",
+      "Bids" => "Google_Api_Ads_AdWords_v201402\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme",
+      "ManualCPCAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupExperimentBidMultipliers",
+      "ManualCPMAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\ManualCPMAdGroupExperimentBidMultipliers",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\AdGroupExperimentBidMultipliers",
+      "AdGroupExperimentData" => "Google_Api_Ads_AdWords_v201402\\AdGroupExperimentData",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration",
+      "AdGroup" => "Google_Api_Ads_AdWords_v201402\\AdGroup",
+      "AdGroupOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupOperation",
+      "AdGroupPage" => "Google_Api_Ads_AdWords_v201402\\AdGroupPage",
+      "AdGroupReturnValue" => "Google_Api_Ads_AdWords_v201402\\AdGroupReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AdGroupServiceError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceErrorReason",
+      "AdGroup.Status" => "Google_Api_Ads_AdWords_v201402\\AdGroupStatus",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201402\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode",
+      "CriterionTypeGroup" => "Google_Api_Ads_AdWords_v201402\\CriterionTypeGroup",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus",
+      "ExperimentError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201402\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -6638,3 +6638,4 @@ if (!class_exists("AdGroupService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdParamService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdParamService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AdParam", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParam", false)) {
   /**
    * Represents an ad parameter.  Use ad parameters to update numeric values
    * (such as prices or inventory levels) in any line of a text ad, including
@@ -103,7 +103,7 @@ if (!class_exists("AdParam", false)) {
   }
 }
 
-if (!class_exists("AdParamPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamPage", false)) {
   /**
    * Represents a page of AdParams returned by the {@link AdParamService}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -150,7 +150,7 @@ if (!class_exists("AdParamPage", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -198,7 +198,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -278,7 +278,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -325,7 +325,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -374,7 +374,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -421,7 +421,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -469,7 +469,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -523,7 +523,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -591,7 +591,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -659,7 +659,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -756,7 +756,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -835,7 +835,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -903,7 +903,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdParamErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamErrorReason", false)) {
   /**
    * The same ad param cannot be specified in multiple operations
    * @package Google_Api_Ads_AdWords_v201402
@@ -936,7 +936,7 @@ if (!class_exists("AdParamErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -969,7 +969,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1002,7 +1002,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1035,7 +1035,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1069,7 +1069,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1102,7 +1102,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1135,7 +1135,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1168,7 +1168,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1201,7 +1201,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1234,7 +1234,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1267,7 +1267,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1300,7 +1300,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1333,7 +1333,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1366,7 +1366,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1399,7 +1399,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1433,7 +1433,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1466,7 +1466,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1499,7 +1499,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1532,7 +1532,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1565,7 +1565,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1598,7 +1598,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1631,7 +1631,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1664,7 +1664,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1697,7 +1697,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1730,7 +1730,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1763,7 +1763,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1811,7 +1811,7 @@ if (!class_exists("AdParamServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1851,7 +1851,7 @@ if (!class_exists("AdParamServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -1914,7 +1914,7 @@ if (!class_exists("AdParamServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdParamServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1954,7 +1954,7 @@ if (!class_exists("AdParamServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdParamError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamError", false)) {
   /**
    * Errors for AdParamService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1999,7 +1999,7 @@ if (!class_exists("AdParamError", false)) {
   }
 }
 
-if (!class_exists("AdParamOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamOperation", false)) {
   /**
    * Represents an operation on an {@link AdParam}. The supported operators
    * are {@code SET} and {@code REMOVE}.
@@ -2043,7 +2043,7 @@ if (!class_exists("AdParamOperation", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2088,7 +2088,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2133,7 +2133,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2178,7 +2178,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2223,7 +2223,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2268,7 +2268,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2313,7 +2313,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2360,7 +2360,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2405,7 +2405,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2450,7 +2450,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2495,7 +2495,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2540,7 +2540,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2585,7 +2585,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2630,7 +2630,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2696,7 +2696,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2741,7 +2741,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2786,7 +2786,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2832,7 +2832,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2877,7 +2877,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2922,7 +2922,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2967,7 +2967,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3013,7 +3013,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3058,7 +3058,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -3149,7 +3149,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3192,7 +3192,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AdParamPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdParamPolicyError", false)) {
   /**
    * Policy violation for an AdParam.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3238,7 +3238,7 @@ if (!class_exists("AdParamService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdParamService extends AdWordsSoapClient {
+  class AdParamService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdParamService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3255,77 +3255,77 @@ if (!class_exists("AdParamService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdParam" => "AdParam",
-      "AdParamError" => "AdParamError",
-      "AdParamOperation" => "AdParamOperation",
-      "AdParamPage" => "AdParamPage",
-      "AdParamPolicyError" => "AdParamPolicyError",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "PolicyViolationError" => "PolicyViolationError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AdParamError.Reason" => "AdParamErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "AdParamServiceGet",
-      "getResponse" => "AdParamServiceGetResponse",
-      "mutate" => "AdParamServiceMutate",
-      "mutateResponse" => "AdParamServiceMutateResponse",
+      "AdParam" => "Google_Api_Ads_AdWords_v201402\\AdParam",
+      "AdParamError" => "Google_Api_Ads_AdWords_v201402\\AdParamError",
+      "AdParamOperation" => "Google_Api_Ads_AdWords_v201402\\AdParamOperation",
+      "AdParamPage" => "Google_Api_Ads_AdWords_v201402\\AdParamPage",
+      "AdParamPolicyError" => "Google_Api_Ads_AdWords_v201402\\AdParamPolicyError",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationKey",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AdParamError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdParamErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdParamServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdParamServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdParamServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdParamServiceMutateResponse",
     );
 
 
@@ -3388,3 +3388,4 @@ if (!class_exists("AdParamService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AdwordsUserListService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AdwordsUserListService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -82,7 +82,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -133,7 +133,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -186,7 +186,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -244,7 +244,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -316,7 +316,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -388,7 +388,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -489,7 +489,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -572,7 +572,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -644,7 +644,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * 
@@ -720,7 +720,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -804,7 +804,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -887,7 +887,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -924,7 +924,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -961,7 +961,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -998,7 +998,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1035,7 +1035,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1072,7 +1072,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1110,7 +1110,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1147,7 +1147,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1184,7 +1184,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1221,7 +1221,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -1258,7 +1258,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1295,7 +1295,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1332,7 +1332,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1369,7 +1369,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1407,7 +1407,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1444,7 +1444,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1481,7 +1481,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1518,7 +1518,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1555,7 +1555,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1592,7 +1592,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1629,7 +1629,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1666,7 +1666,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1703,7 +1703,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1740,7 +1740,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1786,7 +1786,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("UserListConversionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListConversionType", false)) {
   /**
    * Represents a conversion type used for building remarketing user lists.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1840,7 +1840,7 @@ if (!class_exists("UserListConversionType", false)) {
   }
 }
 
-if (!class_exists("LogicalUserListOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LogicalUserListOperand", false)) {
   /**
    * An interface for a logical user list operand. A logical user list is a
    * combination of logical rules. Each rule is defined as a logical operator and
@@ -1882,7 +1882,7 @@ if (!class_exists("LogicalUserListOperand", false)) {
   }
 }
 
-if (!class_exists("UserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserList", false)) {
   /**
    * Represents a UserList object that is sent over the wire.
    * This is a list of users an account may target.
@@ -2046,7 +2046,7 @@ if (!class_exists("UserList", false)) {
   }
 }
 
-if (!class_exists("UserListError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListError", false)) {
   /**
    * Represents possible error codes in UserListService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2091,7 +2091,7 @@ if (!class_exists("UserListError", false)) {
   }
 }
 
-if (!class_exists("UserListLogicalRule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListLogicalRule", false)) {
   /**
    * A user list logical rule. A rule has a logical operator (and/or/not) and a
    * list of operands that can be user lists or user interests.
@@ -2139,7 +2139,7 @@ if (!class_exists("UserListLogicalRule", false)) {
   }
 }
 
-if (!class_exists("UserListOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListOperation", false)) {
   /**
    * UserList operations for adding/updating UserList entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2182,7 +2182,7 @@ if (!class_exists("UserListOperation", false)) {
   }
 }
 
-if (!class_exists("UserListPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListPage", false)) {
   /**
    * Contains a list of user lists resulting from the filtering and paging of the
    * {@link UserListService#get} call.
@@ -2226,7 +2226,7 @@ if (!class_exists("UserListPage", false)) {
   }
 }
 
-if (!class_exists("UserListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListReturnValue", false)) {
   /**
    * A container for return values from the UserListService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2268,7 +2268,7 @@ if (!class_exists("UserListReturnValue", false)) {
   }
 }
 
-if (!class_exists("AccessReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AccessReason", false)) {
   /**
    * This indicates the way the entity such as UserList is related to a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2301,7 +2301,7 @@ if (!class_exists("AccessReason", false)) {
   }
 }
 
-if (!class_exists("AccountUserListStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AccountUserListStatus", false)) {
   /**
    * Status in the AccountUserListStatus table. This indicates if the user list share or
    * the licensing of the userlist is still active.
@@ -2335,7 +2335,7 @@ if (!class_exists("AccountUserListStatus", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2368,7 +2368,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("UserListConversionTypeCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListConversionTypeCategory", false)) {
   /**
    * User can create only BOOMERANG_EVENT conversion types. For all other types
    * UserListService service will return OTHER.
@@ -2402,7 +2402,7 @@ if (!class_exists("UserListConversionTypeCategory", false)) {
   }
 }
 
-if (!class_exists("SizeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeRange", false)) {
   /**
    * Size range in terms of number of users of a UserList/UserInterest.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2435,7 +2435,7 @@ if (!class_exists("SizeRange", false)) {
   }
 }
 
-if (!class_exists("UserListErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListErrorReason", false)) {
   /**
    * Creating and updating external remarketing user lists is not supported.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2468,7 +2468,7 @@ if (!class_exists("UserListErrorReason", false)) {
   }
 }
 
-if (!class_exists("UserListLogicalRuleOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListLogicalRuleOperator", false)) {
   /**
    * And - all of the operands.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2501,7 +2501,7 @@ if (!class_exists("UserListLogicalRuleOperator", false)) {
   }
 }
 
-if (!class_exists("UserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserListMembershipStatus", false)) {
   /**
    * Membership status of the user list. This status indicates whether a user list
    * can accumulate more users and may be targeted to.
@@ -2535,7 +2535,7 @@ if (!class_exists("UserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2583,7 +2583,7 @@ if (!class_exists("AdwordsUserListServiceGet", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2623,7 +2623,7 @@ if (!class_exists("AdwordsUserListServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceMutate", false)) {
   /**
    * <span class="constraint CollectionSize">The minimum size of this collection is 1. The maximum size of this collection is 10000.</span>
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
@@ -2676,7 +2676,7 @@ if (!class_exists("AdwordsUserListServiceMutate", false)) {
   }
 }
 
-if (!class_exists("AdwordsUserListServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2716,7 +2716,7 @@ if (!class_exists("AdwordsUserListServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2765,7 +2765,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2814,7 +2814,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -2863,7 +2863,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -2912,7 +2912,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2962,7 +2962,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3013,7 +3013,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -3062,7 +3062,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -3104,7 +3104,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -3153,7 +3153,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -3202,7 +3202,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -3251,7 +3251,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3300,7 +3300,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3349,7 +3349,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3419,7 +3419,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3468,7 +3468,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3517,7 +3517,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3566,7 +3566,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3615,7 +3615,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3664,7 +3664,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3714,7 +3714,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3763,7 +3763,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3810,7 +3810,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ExternalRemarketingUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExternalRemarketingUserList", false)) {
   /**
    * User lists created in the DoubleClick platform that are mapped
    * from DoubleClick to AdWords.
@@ -3859,7 +3859,7 @@ if (!class_exists("ExternalRemarketingUserList", false)) {
   }
 }
 
-if (!class_exists("LogicalUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LogicalUserList", false)) {
   /**
    * Represents a user list that is a custom combination of user lists and user
    * interests.
@@ -3915,7 +3915,7 @@ if (!class_exists("LogicalUserList", false)) {
   }
 }
 
-if (!class_exists("BasicUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BasicUserList", false)) {
   /**
    * User list targeting as a collection of conversion types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3970,7 +3970,7 @@ if (!class_exists("BasicUserList", false)) {
   }
 }
 
-if (!class_exists("SimilarUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SimilarUserList", false)) {
   /**
    * SimilarUserList is a list of users which are similar to users from another UserList.
    * These lists are readonly and automatically created by google.
@@ -4060,7 +4060,7 @@ if (!class_exists("AdwordsUserListService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AdwordsUserListService extends AdWordsSoapClient {
+  class AdwordsUserListService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AdwordsUserListService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/rm/v201402";
@@ -4077,88 +4077,88 @@ if (!class_exists("AdwordsUserListService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ExternalRemarketingUserList" => "ExternalRemarketingUserList",
-      "CollectionSizeError" => "CollectionSizeError",
-      "UserListConversionType" => "UserListConversionType",
-      "LogicalUserList" => "LogicalUserList",
-      "LogicalUserListOperand" => "LogicalUserListOperand",
-      "BasicUserList" => "BasicUserList",
-      "SimilarUserList" => "SimilarUserList",
-      "UserList" => "UserList",
-      "UserListError" => "UserListError",
-      "UserListLogicalRule" => "UserListLogicalRule",
-      "UserListOperation" => "UserListOperation",
-      "UserListPage" => "UserListPage",
-      "UserListReturnValue" => "UserListReturnValue",
-      "AccessReason" => "AccessReason",
-      "AccountUserListStatus" => "AccountUserListStatus",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "UserListConversionType.Category" => "UserListConversionTypeCategory",
-      "SizeRange" => "SizeRange",
-      "UserListError.Reason" => "UserListErrorReason",
-      "UserListLogicalRule.Operator" => "UserListLogicalRuleOperator",
-      "UserListMembershipStatus" => "UserListMembershipStatus",
-      "get" => "AdwordsUserListServiceGet",
-      "getResponse" => "AdwordsUserListServiceGetResponse",
-      "mutate" => "AdwordsUserListServiceMutate",
-      "mutateResponse" => "AdwordsUserListServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201402\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "ExternalRemarketingUserList" => "Google_Api_Ads_AdWords_v201402\\ExternalRemarketingUserList",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "UserListConversionType" => "Google_Api_Ads_AdWords_v201402\\UserListConversionType",
+      "LogicalUserList" => "Google_Api_Ads_AdWords_v201402\\LogicalUserList",
+      "LogicalUserListOperand" => "Google_Api_Ads_AdWords_v201402\\LogicalUserListOperand",
+      "BasicUserList" => "Google_Api_Ads_AdWords_v201402\\BasicUserList",
+      "SimilarUserList" => "Google_Api_Ads_AdWords_v201402\\SimilarUserList",
+      "UserList" => "Google_Api_Ads_AdWords_v201402\\UserList",
+      "UserListError" => "Google_Api_Ads_AdWords_v201402\\UserListError",
+      "UserListLogicalRule" => "Google_Api_Ads_AdWords_v201402\\UserListLogicalRule",
+      "UserListOperation" => "Google_Api_Ads_AdWords_v201402\\UserListOperation",
+      "UserListPage" => "Google_Api_Ads_AdWords_v201402\\UserListPage",
+      "UserListReturnValue" => "Google_Api_Ads_AdWords_v201402\\UserListReturnValue",
+      "AccessReason" => "Google_Api_Ads_AdWords_v201402\\AccessReason",
+      "AccountUserListStatus" => "Google_Api_Ads_AdWords_v201402\\AccountUserListStatus",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "UserListConversionType.Category" => "Google_Api_Ads_AdWords_v201402\\UserListConversionTypeCategory",
+      "SizeRange" => "Google_Api_Ads_AdWords_v201402\\SizeRange",
+      "UserListError.Reason" => "Google_Api_Ads_AdWords_v201402\\UserListErrorReason",
+      "UserListLogicalRule.Operator" => "Google_Api_Ads_AdWords_v201402\\UserListLogicalRuleOperator",
+      "UserListMembershipStatus" => "Google_Api_Ads_AdWords_v201402\\UserListMembershipStatus",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\AdwordsUserListServiceMutateResponse",
     );
 
 
@@ -4211,3 +4211,4 @@ if (!class_exists("AdwordsUserListService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/AlertService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/AlertService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -83,7 +83,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -155,7 +155,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -227,7 +227,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -328,7 +328,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -411,7 +411,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -494,7 +494,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -531,7 +531,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -568,7 +568,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -606,7 +606,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -643,7 +643,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -680,7 +680,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -717,7 +717,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -754,7 +754,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -791,7 +791,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -828,7 +828,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -866,7 +866,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -903,7 +903,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -940,7 +940,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -977,7 +977,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1014,7 +1014,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1051,7 +1051,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1088,7 +1088,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1125,7 +1125,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1162,7 +1162,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AlertError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertError", false)) {
   /**
    * Errors that can occur when using {@link AlertService}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1207,7 +1207,7 @@ if (!class_exists("AlertError", false)) {
   }
 }
 
-if (!class_exists("AlertQuery", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertQuery", false)) {
   /**
    * Querying criteria for getting alerts.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1289,7 +1289,7 @@ if (!class_exists("AlertQuery", false)) {
   }
 }
 
-if (!class_exists("Detail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Detail", false)) {
   /**
    * Detail refers to a single event or condition that triggered its owning {@link Alert}.
    * Multiple details can cause the same {@code Alert} to occur.
@@ -1330,7 +1330,7 @@ if (!class_exists("Detail", false)) {
   }
 }
 
-if (!class_exists("Alert", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Alert", false)) {
   /**
    * Alert for a single client. Triggering events are grouped by {@link AlertType} into the same alert
    * with multiple {@link Details}.
@@ -1392,7 +1392,7 @@ if (!class_exists("Alert", false)) {
   }
 }
 
-if (!class_exists("AlertSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertSelector", false)) {
   /**
    * Selector for querying for alerts.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1439,7 +1439,7 @@ if (!class_exists("AlertSelector", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1475,7 +1475,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("AlertErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertErrorReason", false)) {
   /**
    * The possible reasons for an {@link AlertError} to occur.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1508,7 +1508,7 @@ if (!class_exists("AlertErrorReason", false)) {
   }
 }
 
-if (!class_exists("AlertSeverity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertSeverity", false)) {
   /**
    * Severity of an alert, represented as a "color".
    * @package Google_Api_Ads_AdWords_v201402
@@ -1541,7 +1541,7 @@ if (!class_exists("AlertSeverity", false)) {
   }
 }
 
-if (!class_exists("AlertType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertType", false)) {
   /**
    * Type of an alert.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1574,7 +1574,7 @@ if (!class_exists("AlertType", false)) {
   }
 }
 
-if (!class_exists("ClientSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientSpec", false)) {
   /**
    * Specification of which managed accounts a client manager is interested in.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1607,7 +1607,7 @@ if (!class_exists("ClientSpec", false)) {
   }
 }
 
-if (!class_exists("FilterSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FilterSpec", false)) {
   /**
    * Describes how a result set of alerts should be filtered based on the triggering account's
    * ability to manage clients.
@@ -1641,7 +1641,7 @@ if (!class_exists("FilterSpec", false)) {
   }
 }
 
-if (!class_exists("TriggerTimeSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TriggerTimeSpec", false)) {
   /**
    * Specification of what trigger time alerts should match.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1674,7 +1674,7 @@ if (!class_exists("TriggerTimeSpec", false)) {
   }
 }
 
-if (!class_exists("AlertServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1722,7 +1722,7 @@ if (!class_exists("AlertServiceGet", false)) {
   }
 }
 
-if (!class_exists("AlertServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1762,7 +1762,7 @@ if (!class_exists("AlertServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -1811,7 +1811,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -1860,7 +1860,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -1909,7 +1909,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -1958,7 +1958,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -2007,7 +2007,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -2056,7 +2056,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2107,7 +2107,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -2156,7 +2156,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2205,7 +2205,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2254,7 +2254,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2324,7 +2324,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2373,7 +2373,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2422,7 +2422,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2472,7 +2472,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2521,7 +2521,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2570,7 +2570,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2620,7 +2620,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -2669,7 +2669,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -2716,7 +2716,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("AlertPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AlertPage", false)) {
   /**
    * Contains a subset of {@link Alert}s resulting from the filtering and paging,
    * returned by {@link AlertService#get(AlertSelector)}.
@@ -2764,7 +2764,7 @@ if (!class_exists("AlertService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class AlertService extends AdWordsSoapClient {
+  class AlertService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "AlertService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201402";
@@ -2781,64 +2781,64 @@ if (!class_exists("AlertService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "Paging" => "Paging",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "AlertError" => "AlertError",
-      "AlertQuery" => "AlertQuery",
-      "Detail" => "Detail",
-      "Alert" => "Alert",
-      "AlertPage" => "AlertPage",
-      "AlertSelector" => "AlertSelector",
-      "NoStatsPage" => "NoStatsPage",
-      "AlertError.Reason" => "AlertErrorReason",
-      "AlertSeverity" => "AlertSeverity",
-      "AlertType" => "AlertType",
-      "ClientSpec" => "ClientSpec",
-      "FilterSpec" => "FilterSpec",
-      "TriggerTimeSpec" => "TriggerTimeSpec",
-      "get" => "AlertServiceGet",
-      "getResponse" => "AlertServiceGetResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "AlertError" => "Google_Api_Ads_AdWords_v201402\\AlertError",
+      "AlertQuery" => "Google_Api_Ads_AdWords_v201402\\AlertQuery",
+      "Detail" => "Google_Api_Ads_AdWords_v201402\\Detail",
+      "Alert" => "Google_Api_Ads_AdWords_v201402\\Alert",
+      "AlertPage" => "Google_Api_Ads_AdWords_v201402\\AlertPage",
+      "AlertSelector" => "Google_Api_Ads_AdWords_v201402\\AlertSelector",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "AlertError.Reason" => "Google_Api_Ads_AdWords_v201402\\AlertErrorReason",
+      "AlertSeverity" => "Google_Api_Ads_AdWords_v201402\\AlertSeverity",
+      "AlertType" => "Google_Api_Ads_AdWords_v201402\\AlertType",
+      "ClientSpec" => "Google_Api_Ads_AdWords_v201402\\ClientSpec",
+      "FilterSpec" => "Google_Api_Ads_AdWords_v201402\\FilterSpec",
+      "TriggerTimeSpec" => "Google_Api_Ads_AdWords_v201402\\TriggerTimeSpec",
+      "get" => "Google_Api_Ads_AdWords_v201402\\AlertServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\AlertServiceGetResponse",
     );
 
 
@@ -2870,3 +2870,4 @@ if (!class_exists("AlertService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/BiddingStrategyService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/BiddingStrategyService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -436,7 +436,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -533,7 +533,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -612,7 +612,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -680,7 +680,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -753,7 +753,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("SharedBiddingStrategy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SharedBiddingStrategy", false)) {
   /**
    * Bidding strategies store shared bidding configuration data and are account-level objects.
    * @package Google_Api_Ads_AdWords_v201402
@@ -821,7 +821,7 @@ if (!class_exists("SharedBiddingStrategy", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -893,7 +893,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -973,7 +973,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1052,7 +1052,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1085,7 +1085,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1118,7 +1118,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1151,7 +1151,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1184,7 +1184,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("SharedBiddingStrategyBiddingStrategyStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SharedBiddingStrategyBiddingStrategyStatus", false)) {
   /**
    * Status of the bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1217,7 +1217,7 @@ if (!class_exists("SharedBiddingStrategyBiddingStrategyStatus", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyErrorReason", false)) {
   /**
    * Each bidding strategy must have a unique name.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1250,7 +1250,7 @@ if (!class_exists("BiddingStrategyErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1283,7 +1283,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1317,7 +1317,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1350,7 +1350,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1383,7 +1383,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1416,7 +1416,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1449,7 +1449,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1482,7 +1482,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1515,7 +1515,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1549,7 +1549,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1582,7 +1582,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1615,7 +1615,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1648,7 +1648,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1681,7 +1681,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1714,7 +1714,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1747,7 +1747,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1780,9 +1780,9 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -1813,7 +1813,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1846,7 +1846,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1879,7 +1879,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1913,7 +1913,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1946,7 +1946,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1979,7 +1979,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2012,7 +2012,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2045,7 +2045,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2078,7 +2078,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2111,7 +2111,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2144,7 +2144,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2177,7 +2177,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2210,7 +2210,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2243,7 +2243,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2291,7 +2291,7 @@ if (!class_exists("BiddingStrategyServiceGet", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2331,7 +2331,7 @@ if (!class_exists("BiddingStrategyServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2381,7 +2381,7 @@ if (!class_exists("BiddingStrategyServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2421,7 +2421,7 @@ if (!class_exists("BiddingStrategyServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2468,7 +2468,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2508,7 +2508,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2553,7 +2553,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2598,7 +2598,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2643,7 +2643,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2688,7 +2688,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyError", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2733,7 +2733,7 @@ if (!class_exists("BiddingStrategyError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2778,7 +2778,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -2841,7 +2841,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2886,7 +2886,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2931,7 +2931,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -2970,7 +2970,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -3044,7 +3044,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -3090,7 +3090,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3135,7 +3135,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3182,7 +3182,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -3225,7 +3225,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3261,7 +3261,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3303,7 +3303,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3348,7 +3348,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3393,7 +3393,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3438,7 +3438,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3473,7 +3473,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3518,7 +3518,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -3559,7 +3559,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3611,7 +3611,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3656,7 +3656,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3701,7 +3701,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3767,7 +3767,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3812,7 +3812,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3857,7 +3857,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3903,7 +3903,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3948,7 +3948,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3993,7 +3993,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4038,7 +4038,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4084,7 +4084,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4129,7 +4129,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -4208,7 +4208,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -4275,7 +4275,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetRoasBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme", false)) {
   /**
    * Target Roas bidding strategy helps you maximize revenue while averaging a specific target
    * Return On Average Spend (ROAS).
@@ -4341,7 +4341,7 @@ if (!class_exists("TargetRoasBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -4393,7 +4393,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4436,7 +4436,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -4487,7 +4487,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyOperation", false)) {
   /**
    * Operations for adding/updating bidding strategies.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4530,7 +4530,7 @@ if (!class_exists("BiddingStrategyOperation", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyPage", false)) {
   /**
    * Contains a list of bidding strategies resulting from the filtering and paging
    * of {@link BiddingStrategy#get} call.
@@ -4574,7 +4574,7 @@ if (!class_exists("BiddingStrategyPage", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyReturnValue", false)) {
   /**
    * A container for return values from the {@link BiddingStrategyService#mutate} call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4616,7 +4616,7 @@ if (!class_exists("BiddingStrategyReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4657,7 +4657,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4704,7 +4704,7 @@ if (!class_exists("BiddingStrategyService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class BiddingStrategyService extends AdWordsSoapClient {
+  class BiddingStrategyService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BiddingStrategyService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4721,109 +4721,109 @@ if (!class_exists("BiddingStrategyService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingStrategyError" => "BiddingStrategyError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetRoasBiddingScheme" => "TargetRoasBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "Selector" => "Selector",
-      "BiddingScheme" => "BiddingScheme",
-      "SharedBiddingStrategy" => "SharedBiddingStrategy",
-      "BiddingStrategyOperation" => "BiddingStrategyOperation",
-      "BiddingStrategyPage" => "BiddingStrategyPage",
-      "BiddingStrategyReturnValue" => "BiddingStrategyReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "SharedBiddingStrategy.BiddingStrategyStatus" => "SharedBiddingStrategyBiddingStrategyStatus",
-      "BiddingStrategyError.Reason" => "BiddingStrategyErrorReason",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "BiddingStrategyServiceGet",
-      "getResponse" => "BiddingStrategyServiceGetResponse",
-      "mutate" => "BiddingStrategyServiceMutate",
-      "mutateResponse" => "BiddingStrategyServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201402\\BiddingErrors",
+      "BiddingStrategyError" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme",
+      "TargetRoasBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BiddingScheme",
+      "SharedBiddingStrategy" => "Google_Api_Ads_AdWords_v201402\\SharedBiddingStrategy",
+      "BiddingStrategyOperation" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyOperation",
+      "BiddingStrategyPage" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyPage",
+      "BiddingStrategyReturnValue" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason",
+      "SharedBiddingStrategy.BiddingStrategyStatus" => "Google_Api_Ads_AdWords_v201402\\SharedBiddingStrategyBiddingStrategyStatus",
+      "BiddingStrategyError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyErrorReason",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyType",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4888,3 +4888,4 @@ if (!class_exists("BiddingStrategyService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/BudgetOrderService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/BudgetOrderService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -135,7 +135,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -222,7 +222,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -275,7 +275,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -381,7 +381,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -461,7 +461,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -514,7 +514,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -567,7 +567,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -623,7 +623,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -676,7 +676,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -730,7 +730,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -783,7 +783,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -838,7 +838,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * 
@@ -918,7 +918,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -968,7 +968,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * 
@@ -1021,7 +1021,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1074,7 +1074,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * 
@@ -1094,6 +1094,12 @@ if (!class_exists("NotWhitelistedError", false)) {
     const XSI_TYPE = "NotWhitelistedError";
 
     /**
+     * @access public
+     * @var tnsNotWhitelistedErrorReason
+     */
+    public $reason;
+
+    /**
      * Gets the namesapce of this class
      * @return the namespace of this class
      */
@@ -1109,8 +1115,9 @@ if (!class_exists("NotWhitelistedError", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
+    public function __construct($reason = null, $fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
       parent::__construct();
+      $this->reason = $reason;
       $this->fieldPath = $fieldPath;
       $this->trigger = $trigger;
       $this->errorString = $errorString;
@@ -1120,7 +1127,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1173,7 +1180,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1216,7 +1223,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1304,7 +1311,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1357,7 +1364,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1410,7 +1417,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1465,7 +1472,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1552,7 +1559,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1609,7 +1616,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -1663,7 +1670,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -1725,7 +1732,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1778,7 +1785,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1831,7 +1838,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1905,7 +1912,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -1958,7 +1965,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2011,7 +2018,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2065,7 +2072,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2118,7 +2125,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2194,7 +2201,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2247,7 +2254,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2300,7 +2307,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2376,7 +2383,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2452,7 +2459,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * 
@@ -2505,7 +2512,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2559,7 +2566,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -2600,7 +2607,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2641,7 +2648,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2683,7 +2690,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2724,7 +2731,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2765,7 +2772,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -2806,7 +2813,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2848,7 +2855,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2889,7 +2896,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -2930,7 +2937,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * 
@@ -2971,7 +2978,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3012,7 +3019,48 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotWhitelistedErrorReason", false)) {
+  /**
+   * The single reason for the whitelist error.
+   * 
+   * 
+   * 
+   * The API error base class that provides details about an error that occurred
+   * while processing a service request.
+   * 
+   * <p>The OGNL field path is provided for parsers to identify the request data
+   * element that may have caused the error.</p>
+   * @package Google_Api_Ads_AdWords_v201402
+   * @subpackage v201402
+   */
+  class NotWhitelistedErrorReason {
+
+    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
+    const XSI_TYPE = "NotWhitelistedError.Reason";
+
+    /**
+     * Gets the namesapce of this class
+     * @return the namespace of this class
+     */
+    public function getNamespace() {
+      return self::WSDL_NAMESPACE;
+    }
+
+    /**
+     * Gets the xsi:type name of this class
+     * @return the xsi:type name of this class
+     */
+    public function getXsiTypeName() {
+      return self::XSI_TYPE;
+    }
+
+    public function __construct() {
+    }
+
+  }
+}
+
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3053,7 +3101,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3094,7 +3142,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -3135,7 +3183,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3176,7 +3224,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * 
@@ -3217,7 +3265,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -3258,7 +3306,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3300,7 +3348,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3341,7 +3389,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3382,7 +3430,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3423,7 +3471,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3464,7 +3512,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3505,7 +3553,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3546,7 +3594,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3587,7 +3635,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -3628,7 +3676,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -3669,7 +3717,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * 
@@ -3710,7 +3758,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3751,7 +3799,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BillingAccount", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BillingAccount", false)) {
   /**
    * Represents an BillingAccount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3819,7 +3867,7 @@ if (!class_exists("BillingAccount", false)) {
   }
 }
 
-if (!class_exists("BudgetOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrder", false)) {
   /**
    * A {@link BudgetOrder} links an account wide budget with a {@link BillingAccount}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3929,7 +3977,7 @@ if (!class_exists("BudgetOrder", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderError", false)) {
   /**
    * Error information for BudgetOrderService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3974,7 +4022,7 @@ if (!class_exists("BudgetOrderError", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderOperation", false)) {
   /**
    * Operation for {@link BudgetOrder}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4017,7 +4065,7 @@ if (!class_exists("BudgetOrderOperation", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderPage", false)) {
   /**
    * A page of {@link BudgetOrder}s from {@link BudgetOrderService#get}
    * method.
@@ -4061,7 +4109,7 @@ if (!class_exists("BudgetOrderPage", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderRequest", false)) {
   /**
    * Holds fields that provide information on the last set of values that were passed in through
    * the parent BudgetOrder for mutate.add and mutate.set.
@@ -4152,7 +4200,7 @@ if (!class_exists("BudgetOrderRequest", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderReturnValue", false)) {
   /**
    * A container for return values from the {@link BudgetOrderService#mutate}
    * method.
@@ -4195,7 +4243,7 @@ if (!class_exists("BudgetOrderReturnValue", false)) {
   }
 }
 
-if (!class_exists("CustomerOrderLineError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerOrderLineError", false)) {
   /**
    * Error information returned for CustomerOrderLineService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4240,7 +4288,7 @@ if (!class_exists("CustomerOrderLineError", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderErrorReason", false)) {
   /**
    * Customer is not whitelisted for new billing.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4273,7 +4321,7 @@ if (!class_exists("BudgetOrderErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderRequestStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderRequestStatus", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201402
@@ -4306,7 +4354,7 @@ if (!class_exists("BudgetOrderRequestStatus", false)) {
   }
 }
 
-if (!class_exists("CustomerOrderLineErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerOrderLineErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during a CustomerOrderLine mutate
    * operation.
@@ -4340,7 +4388,7 @@ if (!class_exists("CustomerOrderLineErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4388,7 +4436,7 @@ if (!class_exists("BudgetOrderServiceGet", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4428,7 +4476,7 @@ if (!class_exists("BudgetOrderServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetBillingAccounts", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetBillingAccounts", false)) {
   /**
    * Returns all the open/active BillingAccounts associated with the current
    * manager.
@@ -4464,7 +4512,7 @@ if (!class_exists("GetBillingAccounts", false)) {
   }
 }
 
-if (!class_exists("GetBillingAccountsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetBillingAccountsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4504,7 +4552,7 @@ if (!class_exists("GetBillingAccountsResponse", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -4563,7 +4611,7 @@ if (!class_exists("BudgetOrderServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BudgetOrderServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4603,7 +4651,7 @@ if (!class_exists("BudgetOrderServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4654,7 +4702,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -4703,7 +4751,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -4758,7 +4806,7 @@ if (!class_exists("BudgetOrderService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class BudgetOrderService extends AdWordsSoapClient {
+  class BudgetOrderService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BudgetOrderService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/billing/v201402";
@@ -4775,97 +4823,98 @@ if (!class_exists("BudgetOrderService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "BillingAccount" => "BillingAccount",
-      "BudgetOrder" => "BudgetOrder",
-      "BudgetOrderError" => "BudgetOrderError",
-      "BudgetOrderOperation" => "BudgetOrderOperation",
-      "BudgetOrderPage" => "BudgetOrderPage",
-      "BudgetOrderRequest" => "BudgetOrderRequest",
-      "BudgetOrderReturnValue" => "BudgetOrderReturnValue",
-      "CustomerOrderLineError" => "CustomerOrderLineError",
-      "BudgetOrderError.Reason" => "BudgetOrderErrorReason",
-      "BudgetOrderRequest.Status" => "BudgetOrderRequestStatus",
-      "CustomerOrderLineError.Reason" => "CustomerOrderLineErrorReason",
-      "get" => "BudgetOrderServiceGet",
-      "getResponse" => "BudgetOrderServiceGetResponse",
-      "getBillingAccounts" => "GetBillingAccounts",
-      "getBillingAccountsResponse" => "GetBillingAccountsResponse",
-      "mutate" => "BudgetOrderServiceMutate",
-      "mutateResponse" => "BudgetOrderServiceMutateResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201402\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "BillingAccount" => "Google_Api_Ads_AdWords_v201402\\BillingAccount",
+      "BudgetOrder" => "Google_Api_Ads_AdWords_v201402\\BudgetOrder",
+      "BudgetOrderError" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderError",
+      "BudgetOrderOperation" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderOperation",
+      "BudgetOrderPage" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderPage",
+      "BudgetOrderRequest" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderRequest",
+      "BudgetOrderReturnValue" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderReturnValue",
+      "CustomerOrderLineError" => "Google_Api_Ads_AdWords_v201402\\CustomerOrderLineError",
+      "BudgetOrderError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderErrorReason",
+      "BudgetOrderRequest.Status" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderRequestStatus",
+      "CustomerOrderLineError.Reason" => "Google_Api_Ads_AdWords_v201402\\CustomerOrderLineErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceGetResponse",
+      "getBillingAccounts" => "Google_Api_Ads_AdWords_v201402\\GetBillingAccounts",
+      "getBillingAccountsResponse" => "Google_Api_Ads_AdWords_v201402\\GetBillingAccountsResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\BudgetOrderServiceMutateResponse",
     );
 
 
@@ -4935,3 +4984,4 @@ if (!class_exists("BudgetOrderService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/BudgetService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/BudgetService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -436,7 +436,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -533,7 +533,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -612,7 +612,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -680,7 +680,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201402
@@ -769,7 +769,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -841,7 +841,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -921,7 +921,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1000,7 +1000,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1033,7 +1033,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1066,7 +1066,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1099,7 +1099,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1132,7 +1132,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1165,7 +1165,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1198,7 +1198,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1232,7 +1232,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1265,7 +1265,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1298,7 +1298,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1331,7 +1331,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1364,7 +1364,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1398,7 +1398,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1431,7 +1431,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1464,7 +1464,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1497,7 +1497,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1530,7 +1530,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1563,7 +1563,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1596,7 +1596,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1629,7 +1629,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1662,7 +1662,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1695,7 +1695,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1729,7 +1729,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1762,7 +1762,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1795,7 +1795,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1828,7 +1828,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1861,7 +1861,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1894,7 +1894,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1927,7 +1927,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1960,7 +1960,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1993,7 +1993,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2026,7 +2026,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2059,7 +2059,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2107,7 +2107,7 @@ if (!class_exists("BudgetServiceGet", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2147,7 +2147,7 @@ if (!class_exists("BudgetServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2198,7 +2198,7 @@ if (!class_exists("BudgetServiceMutate", false)) {
   }
 }
 
-if (!class_exists("BudgetServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2238,7 +2238,7 @@ if (!class_exists("BudgetServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2286,7 +2286,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2326,7 +2326,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2371,7 +2371,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2416,7 +2416,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2461,7 +2461,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2506,7 +2506,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2551,7 +2551,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2596,7 +2596,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2670,7 +2670,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2716,7 +2716,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2761,7 +2761,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2808,7 +2808,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2850,7 +2850,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2895,7 +2895,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2940,7 +2940,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2985,7 +2985,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3020,7 +3020,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3065,7 +3065,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3117,7 +3117,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3162,7 +3162,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3207,7 +3207,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3273,7 +3273,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3318,7 +3318,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3363,7 +3363,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3409,7 +3409,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3454,7 +3454,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3499,7 +3499,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3544,7 +3544,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3590,7 +3590,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3635,7 +3635,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3678,7 +3678,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOperation", false)) {
   /**
    * Operations for adding/updating Budget entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3721,7 +3721,7 @@ if (!class_exists("BudgetOperation", false)) {
   }
 }
 
-if (!class_exists("BudgetPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetPage", false)) {
   /**
    * Contains a list of budgets resulting from the filtering and paging of
    * {@link BudgetService#get} call.
@@ -3765,7 +3765,7 @@ if (!class_exists("BudgetPage", false)) {
   }
 }
 
-if (!class_exists("BudgetReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetReturnValue", false)) {
   /**
    * A container for return values from the {@link BudgetService#mutate} call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3814,7 +3814,7 @@ if (!class_exists("BudgetReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3855,7 +3855,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3902,7 +3902,7 @@ if (!class_exists("BudgetService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class BudgetService extends AdWordsSoapClient {
+  class BudgetService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "BudgetService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3919,92 +3919,92 @@ if (!class_exists("BudgetService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Budget" => "Budget",
-      "BudgetOperation" => "BudgetOperation",
-      "BudgetPage" => "BudgetPage",
-      "BudgetReturnValue" => "BudgetReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "BudgetServiceGet",
-      "getResponse" => "BudgetServiceGetResponse",
-      "mutate" => "BudgetServiceMutate",
-      "mutateResponse" => "BudgetServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201402\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "Budget" => "Google_Api_Ads_AdWords_v201402\\Budget",
+      "BudgetOperation" => "Google_Api_Ads_AdWords_v201402\\BudgetOperation",
+      "BudgetPage" => "Google_Api_Ads_AdWords_v201402\\BudgetPage",
+      "BudgetReturnValue" => "Google_Api_Ads_AdWords_v201402\\BudgetReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\BudgetServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\BudgetServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\BudgetServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\BudgetServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4071,3 +4071,4 @@ if (!class_exists("BudgetService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CampaignAdExtensionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CampaignAdExtensionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201402
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -160,7 +160,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201402
@@ -207,7 +207,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("OAuthInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OAuthInfo", false)) {
   /**
    * Data used for authorization using OAuth.
    * For more information about OAuth, see:
@@ -263,7 +263,7 @@ if (!class_exists("OAuthInfo", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -310,7 +310,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -359,7 +359,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -413,7 +413,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -481,7 +481,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -549,7 +549,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -646,7 +646,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -725,7 +725,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -793,7 +793,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtension", false)) {
   /**
    * Base class for AdExtension objects. An AdExtension is an extension to
    * an existing ad or metadata that will process into an extension.
@@ -873,7 +873,7 @@ if (!class_exists("AdExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtension", false)) {
   /**
    * Represents a campaign level ad extension. A campaign ad extension specifies
    * a campaign and an ad extension which can extend any ad under that campaign.
@@ -935,7 +935,7 @@ if (!class_exists("CampaignAdExtension", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1007,7 +1007,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1087,7 +1087,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1166,7 +1166,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionErrorReason", false)) {
   /**
    * Account has been deleted
    * @package Google_Api_Ads_AdWords_v201402
@@ -1199,7 +1199,7 @@ if (!class_exists("AdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1232,7 +1232,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1265,7 +1265,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1298,7 +1298,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionApprovalStatus", false)) {
   /**
    * Approval status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1331,7 +1331,7 @@ if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionStatus", false)) {
   /**
    * Status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1364,7 +1364,7 @@ if (!class_exists("CampaignAdExtensionStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionErrorReason", false)) {
   /**
    * Cannot operate on an adextensions under the wrong campaign
    * @package Google_Api_Ads_AdWords_v201402
@@ -1397,7 +1397,7 @@ if (!class_exists("CampaignAdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1431,7 +1431,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1464,7 +1464,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1497,7 +1497,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1530,7 +1530,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1564,7 +1564,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1597,7 +1597,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1630,7 +1630,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("LocationExtensionSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationExtensionSource", false)) {
   /**
    * From manual entry in adwords frontend
    * @package Google_Api_Ads_AdWords_v201402
@@ -1663,7 +1663,7 @@ if (!class_exists("LocationExtensionSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1696,7 +1696,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1729,7 +1729,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1762,7 +1762,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1795,7 +1795,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1828,7 +1828,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1861,7 +1861,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1894,7 +1894,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1927,7 +1927,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1961,7 +1961,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1994,7 +1994,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2027,7 +2027,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2060,7 +2060,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2093,7 +2093,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2126,7 +2126,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2159,7 +2159,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2192,7 +2192,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2225,7 +2225,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2258,7 +2258,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2291,7 +2291,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2324,7 +2324,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2373,7 +2373,7 @@ if (!class_exists("CampaignAdExtensionServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2413,7 +2413,7 @@ if (!class_exists("CampaignAdExtensionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2463,7 +2463,7 @@ if (!class_exists("CampaignAdExtensionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2503,7 +2503,7 @@ if (!class_exists("CampaignAdExtensionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionError", false)) {
   /**
    * AdExtension errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2548,7 +2548,7 @@ if (!class_exists("AdExtensionError", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2593,7 +2593,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2638,7 +2638,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2683,7 +2683,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionError", false)) {
   /**
    * CampaignAdExtension errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2728,7 +2728,7 @@ if (!class_exists("CampaignAdExtensionError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2773,7 +2773,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2818,7 +2818,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2892,7 +2892,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2938,7 +2938,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2983,7 +2983,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3030,7 +3030,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3075,7 +3075,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3120,7 +3120,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3165,7 +3165,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3210,7 +3210,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3255,7 +3255,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -3301,7 +3301,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3346,7 +3346,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3391,7 +3391,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3457,7 +3457,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3502,7 +3502,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3547,7 +3547,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3592,7 +3592,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3638,7 +3638,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3683,7 +3683,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3728,7 +3728,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3773,7 +3773,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3819,7 +3819,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3864,7 +3864,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("LocationExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationExtension", false)) {
   /**
    * Location based ad extension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3956,7 +3956,7 @@ if (!class_exists("LocationExtension", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3999,7 +3999,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("LocationSyncExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationSyncExtension", false)) {
   /**
    * Local business center(LBC) sync extension that ties a LBC account with a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4070,7 +4070,7 @@ if (!class_exists("LocationSyncExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionOperation", false)) {
   /**
    * CampaignAdExtension service operation. <b>Note:</b> The {@code SET} operator
    * is not supported.
@@ -4114,7 +4114,7 @@ if (!class_exists("CampaignAdExtensionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionPage", false)) {
   /**
    * Represents a page of {@link CampaignAdExtension}s resulting from the query
    * done by {@link CampaignAdExtensionService}.
@@ -4158,7 +4158,7 @@ if (!class_exists("CampaignAdExtensionPage", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionReturnValue", false)) {
   /**
    * A container for return values from the CampaignAdExtensionService.mutate().
    * @package Google_Api_Ads_AdWords_v201402
@@ -4213,7 +4213,7 @@ if (!class_exists("CampaignAdExtensionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CampaignAdExtensionService extends AdWordsSoapClient {
+  class CampaignAdExtensionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignAdExtensionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4230,97 +4230,97 @@ if (!class_exists("CampaignAdExtensionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdExtensionError" => "AdExtensionError",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "CampaignAdExtensionError" => "CampaignAdExtensionError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OAuthInfo" => "OAuthInfo",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "LocationExtension" => "LocationExtension",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "LocationSyncExtension" => "LocationSyncExtension",
-      "Selector" => "Selector",
-      "AdExtension" => "AdExtension",
-      "CampaignAdExtension" => "CampaignAdExtension",
-      "CampaignAdExtensionOperation" => "CampaignAdExtensionOperation",
-      "CampaignAdExtensionPage" => "CampaignAdExtensionPage",
-      "CampaignAdExtensionReturnValue" => "CampaignAdExtensionReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdExtensionError.Reason" => "AdExtensionErrorReason",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "CampaignAdExtension.ApprovalStatus" => "CampaignAdExtensionApprovalStatus",
-      "CampaignAdExtension.Status" => "CampaignAdExtensionStatus",
-      "CampaignAdExtensionError.Reason" => "CampaignAdExtensionErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "LocationExtension.Source" => "LocationExtensionSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CampaignAdExtensionServiceGet",
-      "getResponse" => "CampaignAdExtensionServiceGetResponse",
-      "mutate" => "CampaignAdExtensionServiceMutate",
-      "mutateResponse" => "CampaignAdExtensionServiceMutateResponse",
+      "AdExtensionError" => "Google_Api_Ads_AdWords_v201402\\AdExtensionError",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "CampaignAdExtensionError" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OAuthInfo" => "Google_Api_Ads_AdWords_v201402\\OAuthInfo",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "LocationExtension" => "Google_Api_Ads_AdWords_v201402\\LocationExtension",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "LocationSyncExtension" => "Google_Api_Ads_AdWords_v201402\\LocationSyncExtension",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AdExtension" => "Google_Api_Ads_AdWords_v201402\\AdExtension",
+      "CampaignAdExtension" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtension",
+      "CampaignAdExtensionOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionOperation",
+      "CampaignAdExtensionPage" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionPage",
+      "CampaignAdExtensionReturnValue" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdExtensionErrorReason",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "CampaignAdExtension.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionApprovalStatus",
+      "CampaignAdExtension.Status" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionStatus",
+      "CampaignAdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "LocationExtension.Source" => "Google_Api_Ads_AdWords_v201402\\LocationExtensionSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionServiceMutateResponse",
     );
 
 
@@ -4371,3 +4371,4 @@ if (!class_exists("CampaignAdExtensionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CampaignCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CampaignCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201402
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -209,7 +209,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -288,7 +288,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -333,7 +333,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -378,7 +378,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterion", false)) {
   /**
    * Represents a campaign level criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -485,7 +485,7 @@ if (!class_exists("CampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionError", false)) {
   /**
    * Base error class for Campaign Criterion Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -530,7 +530,7 @@ if (!class_exists("CampaignCriterionError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -575,7 +575,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -662,7 +662,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -707,7 +707,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -752,7 +752,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -800,7 +800,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -845,7 +845,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -919,7 +919,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -965,7 +965,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -1049,7 +1049,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1094,7 +1094,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Gender", false)) {
   /**
    * Represents a Gender criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
@@ -1140,7 +1140,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1187,7 +1187,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1232,7 +1232,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1279,7 +1279,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("IpBlock", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IpBlock", false)) {
   /**
    * Criterion used for IP exclusions. We allow:
    * 
@@ -1331,7 +1331,7 @@ if (!class_exists("IpBlock", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1383,7 +1383,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -1436,7 +1436,7 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1508,7 +1508,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
@@ -1575,7 +1575,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1629,7 +1629,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1681,7 +1681,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -1748,7 +1748,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("NegativeCampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeCampaignCriterion", false)) {
   /**
    * A negative campaign criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1788,7 +1788,7 @@ if (!class_exists("NegativeCampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1833,7 +1833,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1878,7 +1878,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1923,7 +1923,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1995,7 +1995,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -2062,7 +2062,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -2142,7 +2142,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2187,7 +2187,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2232,7 +2232,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2279,7 +2279,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2358,7 +2358,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -2407,7 +2407,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2453,7 +2453,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -2499,7 +2499,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("PlacesOfInterestOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperand", false)) {
   /**
    * This operand specifies a place of interest category for semantic targeting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2541,7 +2541,7 @@ if (!class_exists("PlacesOfInterestOperand", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Platform", false)) {
   /**
    * Represents Platform criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -2587,7 +2587,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2641,7 +2641,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2696,7 +2696,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2744,7 +2744,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2784,7 +2784,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("ProductDimension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimension", false)) {
   /**
    * Dimension by which to subdivide or filter products.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2856,7 +2856,7 @@ if (!class_exists("ProductDimension", false)) {
   }
 }
 
-if (!class_exists("ProductOfferId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductOfferId", false)) {
   /**
    * An offer ID as specified by the merchant.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2898,7 +2898,7 @@ if (!class_exists("ProductOfferId", false)) {
   }
 }
 
-if (!class_exists("ProductSalesChannel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductSalesChannel", false)) {
   /**
    * Defines the sales channel of the shopping products to be advertised.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -2936,7 +2936,7 @@ if (!class_exists("ProductSalesChannel", false)) {
   }
 }
 
-if (!class_exists("ProductScope", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductScope", false)) {
   /**
    * Scope of products. Contains a set of product dimensions, all of which a product has to match to
    * be included in the campaign. These product dimensions must have a value; the "everything else"
@@ -2987,7 +2987,7 @@ if (!class_exists("ProductScope", false)) {
   }
 }
 
-if (!class_exists("ProductType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductType", false)) {
   /**
    * One element of a product type string at a certain level. Top-level product types are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -3039,7 +3039,7 @@ if (!class_exists("ProductType", false)) {
   }
 }
 
-if (!class_exists("ProductTypeFull", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductTypeFull", false)) {
   /**
    * A full product type string. Category of the product according to the merchant's own
    * classification. Example:
@@ -3086,7 +3086,7 @@ if (!class_exists("ProductTypeFull", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -3158,7 +3158,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3210,7 +3210,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3255,7 +3255,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3300,7 +3300,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3366,7 +3366,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3411,7 +3411,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3456,7 +3456,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3501,7 +3501,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3547,7 +3547,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3592,7 +3592,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3660,7 +3660,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3705,10 +3705,10 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("LocationGroups", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationGroups", false)) {
   /**
    * Represents a criterion containing a function that when evaluated specifies how to target
-   * based on the type of the location. These ???location groups??? are custom, dynamic bundles of
+   * based on the type of the location. These "location groups" are custom, dynamic bundles of
    * locations (for instance "High income areas in California" or "Airports in France").
    * 
    * <p>Examples:</p>
@@ -3777,7 +3777,7 @@ if (!class_exists("LocationGroups", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3822,7 +3822,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3890,7 +3890,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3958,7 +3958,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4004,7 +4004,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -4052,7 +4052,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4104,7 +4104,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4163,7 +4163,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -4226,7 +4226,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4259,7 +4259,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201402
@@ -4292,7 +4292,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4325,7 +4325,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4358,7 +4358,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4391,7 +4391,7 @@ if (!class_exists("CampaignCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -4425,7 +4425,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ContentLabelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ContentLabelType", false)) {
   /**
    * Content label type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4458,7 +4458,7 @@ if (!class_exists("ContentLabelType", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4491,7 +4491,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4524,7 +4524,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4557,7 +4557,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4590,7 +4590,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4623,7 +4623,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4656,7 +4656,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -4690,7 +4690,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4723,7 +4723,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4756,7 +4756,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4789,7 +4789,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4822,7 +4822,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("IncomeTier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IncomeTier", false)) {
   /**
    * Income tiers that specify the income bracket a household falls under. TIER_1
    * belongs to the highest income bracket. The income bracket range associated with
@@ -4857,7 +4857,7 @@ if (!class_exists("IncomeTier", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4890,7 +4890,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -4924,7 +4924,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4957,7 +4957,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201402
@@ -4990,7 +4990,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -5023,7 +5023,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5056,7 +5056,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5089,7 +5089,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5122,7 +5122,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5155,7 +5155,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5188,7 +5188,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5221,7 +5221,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5254,7 +5254,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5287,7 +5287,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PlacesOfInterestOperandCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperandCategory", false)) {
   /**
    * Categories to identify places of interest.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5320,7 +5320,7 @@ if (!class_exists("PlacesOfInterestOperandCategory", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5353,7 +5353,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalConditionCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition", false)) {
   /**
    * A canonical product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5386,7 +5386,7 @@ if (!class_exists("ProductCanonicalConditionCondition", false)) {
   }
 }
 
-if (!class_exists("ProductDimensionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimensionType", false)) {
   /**
    * Type of product dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5419,7 +5419,7 @@ if (!class_exists("ProductDimensionType", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5452,7 +5452,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5485,7 +5485,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -5519,7 +5519,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5552,7 +5552,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5585,7 +5585,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5618,7 +5618,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5651,7 +5651,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5684,7 +5684,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5717,7 +5717,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5750,7 +5750,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5783,7 +5783,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5816,7 +5816,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5849,7 +5849,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5882,7 +5882,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5915,7 +5915,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -5963,7 +5963,7 @@ if (!class_exists("CampaignCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6003,7 +6003,7 @@ if (!class_exists("CampaignCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -6055,7 +6055,7 @@ if (!class_exists("CampaignCriterionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6095,7 +6095,7 @@ if (!class_exists("CampaignCriterionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -6143,7 +6143,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -6183,7 +6183,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdSchedule", false)) {
   /**
    * Represents an AdSchedule Criterion.
    * AdSchedule is specified as day and time of the week criteria to target
@@ -6260,7 +6260,7 @@ if (!class_exists("AdSchedule", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6305,7 +6305,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
@@ -6351,7 +6351,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6394,7 +6394,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionOperation", false)) {
   /**
    * Generic operation (add, remove and set) for campaign criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6437,7 +6437,7 @@ if (!class_exists("CampaignCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionPage", false)) {
   /**
    * Contains a subset of campaign criteria resulting from a call to
    * {@link CampaignCriterionService#get}.
@@ -6481,7 +6481,7 @@ if (!class_exists("CampaignCriterionPage", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionReturnValue", false)) {
   /**
    * A container for return values from the CampaignCriterionService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6530,7 +6530,7 @@ if (!class_exists("CampaignCriterionReturnValue", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
    * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
@@ -6583,7 +6583,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ContentLabel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ContentLabel", false)) {
   /**
    * Content Label for category exclusion.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -6628,7 +6628,7 @@ if (!class_exists("ContentLabel", false)) {
   }
 }
 
-if (!class_exists("GeoTargetOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetOperand", false)) {
   /**
    * Represents an operand containing geo information, specifying the scope of the
    * geographical area.
@@ -6671,7 +6671,7 @@ if (!class_exists("GeoTargetOperand", false)) {
   }
 }
 
-if (!class_exists("IncomeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IncomeOperand", false)) {
   /**
    * This operand specifies the income bracket a household falls under.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6713,7 +6713,7 @@ if (!class_exists("IncomeOperand", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsGrouping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping", false)) {
   /**
    * An {@code adwords grouping} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -6756,7 +6756,7 @@ if (!class_exists("ProductAdwordsGrouping", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsLabels", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels", false)) {
   /**
    * An {@code adwords labels} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -6799,7 +6799,7 @@ if (!class_exists("ProductAdwordsLabels", false)) {
   }
 }
 
-if (!class_exists("ProductBiddingCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory", false)) {
   /**
    * One element of a bidding category at a certain level. Top-level categories are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -6851,7 +6851,7 @@ if (!class_exists("ProductBiddingCategory", false)) {
   }
 }
 
-if (!class_exists("ProductBrand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBrand", false)) {
   /**
    * A brand string.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6893,7 +6893,7 @@ if (!class_exists("ProductBrand", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition", false)) {
   /**
    * A canonical condition. Only supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -6936,7 +6936,7 @@ if (!class_exists("ProductCanonicalCondition", false)) {
   }
 }
 
-if (!class_exists("ProductLegacyCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition", false)) {
   /**
    * A plain condition string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -6979,7 +6979,7 @@ if (!class_exists("ProductLegacyCondition", false)) {
   }
 }
 
-if (!class_exists("ProductCustomAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute", false)) {
   /**
    * A custom attribute value. As a product can have multiple custom attributes, the user must specify
    * a dimension type that indicates the index of the attribute by which to subdivide. All cases of
@@ -7036,7 +7036,7 @@ if (!class_exists("CampaignCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CampaignCriterionService extends AdWordsSoapClient {
+  class CampaignCriterionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -7053,157 +7053,157 @@ if (!class_exists("CampaignCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdSchedule" => "AdSchedule",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "CampaignCriterion" => "CampaignCriterion",
-      "CampaignCriterionError" => "CampaignCriterionError",
-      "CampaignCriterionOperation" => "CampaignCriterionOperation",
-      "CampaignCriterionPage" => "CampaignCriterionPage",
-      "CampaignCriterionReturnValue" => "CampaignCriterionReturnValue",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "ContentLabel" => "ContentLabel",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "Gender" => "Gender",
-      "GeoPoint" => "GeoPoint",
-      "GeoTargetOperand" => "GeoTargetOperand",
-      "IdError" => "IdError",
-      "IncomeOperand" => "IncomeOperand",
-      "InternalApiError" => "InternalApiError",
-      "IpBlock" => "IpBlock",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "ListReturnValue" => "ListReturnValue",
-      "Location" => "Location",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "NegativeCampaignCriterion" => "NegativeCampaignCriterion",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "PagingError" => "PagingError",
-      "Placement" => "Placement",
-      "PlacesOfInterestOperand" => "PlacesOfInterestOperand",
-      "Platform" => "Platform",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductAdwordsGrouping" => "ProductAdwordsGrouping",
-      "ProductAdwordsLabels" => "ProductAdwordsLabels",
-      "ProductBiddingCategory" => "ProductBiddingCategory",
-      "ProductBrand" => "ProductBrand",
-      "ProductCanonicalCondition" => "ProductCanonicalCondition",
-      "ProductCondition" => "ProductCondition",
-      "ProductLegacyCondition" => "ProductLegacyCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "ProductCustomAttribute" => "ProductCustomAttribute",
-      "ProductDimension" => "ProductDimension",
-      "ProductOfferId" => "ProductOfferId",
-      "ProductSalesChannel" => "ProductSalesChannel",
-      "ProductScope" => "ProductScope",
-      "ProductType" => "ProductType",
-      "ProductTypeFull" => "ProductTypeFull",
-      "Proximity" => "Proximity",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "LocationGroups" => "LocationGroups",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "CampaignCriterionError.Reason" => "CampaignCriterionErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ContentLabelType" => "ContentLabelType",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "IncomeTier" => "IncomeTier",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "MinuteOfHour" => "MinuteOfHour",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "PlacesOfInterestOperand.Category" => "PlacesOfInterestOperandCategory",
-      "Predicate.Operator" => "PredicateOperator",
-      "ProductCanonicalCondition.Condition" => "ProductCanonicalConditionCondition",
-      "ProductDimensionType" => "ProductDimensionType",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "get" => "CampaignCriterionServiceGet",
-      "getResponse" => "CampaignCriterionServiceGetResponse",
-      "mutate" => "CampaignCriterionServiceMutate",
-      "mutateResponse" => "CampaignCriterionServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdSchedule" => "Google_Api_Ads_AdWords_v201402\\AdSchedule",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201402\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "CampaignCriterion" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterion",
+      "CampaignCriterionError" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionError",
+      "CampaignCriterionOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionOperation",
+      "CampaignCriterionPage" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionPage",
+      "CampaignCriterionReturnValue" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionReturnValue",
+      "Carrier" => "Google_Api_Ads_AdWords_v201402\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ContentLabel" => "Google_Api_Ads_AdWords_v201402\\ContentLabel",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201402\\CriterionError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "Function" => "Google_Api_Ads_AdWords_v201402\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201402\\FunctionError",
+      "Gender" => "Google_Api_Ads_AdWords_v201402\\Gender",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "GeoTargetOperand" => "Google_Api_Ads_AdWords_v201402\\GeoTargetOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "IncomeOperand" => "Google_Api_Ads_AdWords_v201402\\IncomeOperand",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "IpBlock" => "Google_Api_Ads_AdWords_v201402\\IpBlock",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201402\\MobileDevice",
+      "NegativeCampaignCriterion" => "Google_Api_Ads_AdWords_v201402\\NegativeCampaignCriterion",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "PlacesOfInterestOperand" => "Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperand",
+      "Platform" => "Google_Api_Ads_AdWords_v201402\\Platform",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductAdwordsGrouping" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping",
+      "ProductAdwordsLabels" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels",
+      "ProductBiddingCategory" => "Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory",
+      "ProductBrand" => "Google_Api_Ads_AdWords_v201402\\ProductBrand",
+      "ProductCanonicalCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductLegacyCondition" => "Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "ProductCustomAttribute" => "Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute",
+      "ProductDimension" => "Google_Api_Ads_AdWords_v201402\\ProductDimension",
+      "ProductOfferId" => "Google_Api_Ads_AdWords_v201402\\ProductOfferId",
+      "ProductSalesChannel" => "Google_Api_Ads_AdWords_v201402\\ProductSalesChannel",
+      "ProductScope" => "Google_Api_Ads_AdWords_v201402\\ProductScope",
+      "ProductType" => "Google_Api_Ads_AdWords_v201402\\ProductType",
+      "ProductTypeFull" => "Google_Api_Ads_AdWords_v201402\\ProductTypeFull",
+      "Proximity" => "Google_Api_Ads_AdWords_v201402\\Proximity",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "LocationGroups" => "Google_Api_Ads_AdWords_v201402\\LocationGroups",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "CampaignCriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ContentLabelType" => "Google_Api_Ads_AdWords_v201402\\ContentLabelType",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201402\\DayOfWeek",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201402\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201402\\FunctionErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201402\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "IncomeTier" => "Google_Api_Ads_AdWords_v201402\\IncomeTier",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201402\\MinuteOfHour",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "PlacesOfInterestOperand.Category" => "Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperandCategory",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "ProductCanonicalCondition.Condition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition",
+      "ProductDimensionType" => "Google_Api_Ads_AdWords_v201402\\ProductDimensionType",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -7271,3 +7271,4 @@ if (!class_exists("CampaignCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CampaignFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CampaignFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -127,7 +127,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -206,7 +206,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -251,7 +251,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("CampaignFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeed", false)) {
   /**
    * CampaignFeeds are used to link a feed to a campaign using a matching function,
    * making the feed's feed items available in the campaign's ads for substitution.
@@ -365,7 +365,7 @@ if (!class_exists("CampaignFeed", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedError", false)) {
   /**
    * Represents an error for the CampaignFeedService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -410,7 +410,7 @@ if (!class_exists("CampaignFeedError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -455,7 +455,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -501,7 +501,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -546,7 +546,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -594,7 +594,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -639,7 +639,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -713,7 +713,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -759,7 +759,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -843,7 +843,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -888,7 +888,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -933,7 +933,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -980,7 +980,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1052,7 +1052,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1097,7 +1097,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1142,7 +1142,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1214,7 +1214,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1294,7 +1294,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1339,7 +1339,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1386,7 +1386,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1465,7 +1465,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1514,7 +1514,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1568,7 +1568,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1620,7 +1620,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1665,7 +1665,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1710,7 +1710,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1776,7 +1776,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1821,7 +1821,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1866,7 +1866,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperand", false)) {
   /**
    * An operand in a function referring to a value in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1908,7 +1908,7 @@ if (!class_exists("RequestContextOperand", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1954,7 +1954,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1999,7 +1999,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2067,7 +2067,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2112,7 +2112,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2157,7 +2157,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2225,7 +2225,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2293,7 +2293,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2339,7 +2339,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2372,7 +2372,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2405,7 +2405,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedStatus", false)) {
   /**
    * Status of the CampaignFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2438,7 +2438,7 @@ if (!class_exists("CampaignFeedStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2471,7 +2471,7 @@ if (!class_exists("CampaignFeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2505,7 +2505,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2538,7 +2538,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantOperandConstantType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType", false)) {
   /**
    * The types of constant operands.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2571,7 +2571,7 @@ if (!class_exists("ConstantOperandConstantType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2604,7 +2604,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2637,7 +2637,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2670,7 +2670,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2704,7 +2704,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2737,7 +2737,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2770,7 +2770,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2803,7 +2803,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2836,7 +2836,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2869,7 +2869,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2902,7 +2902,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2935,7 +2935,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2968,7 +2968,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3001,7 +3001,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3034,7 +3034,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3068,7 +3068,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3101,7 +3101,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3134,7 +3134,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3167,7 +3167,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3200,7 +3200,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperandContextType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType", false)) {
   /**
    * Campaign Id in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3233,7 +3233,7 @@ if (!class_exists("RequestContextOperandContextType", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3266,7 +3266,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3299,7 +3299,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3332,7 +3332,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3365,7 +3365,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3398,7 +3398,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3431,7 +3431,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3480,7 +3480,7 @@ if (!class_exists("CampaignFeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3520,7 +3520,7 @@ if (!class_exists("CampaignFeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -3571,7 +3571,7 @@ if (!class_exists("CampaignFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3611,7 +3611,7 @@ if (!class_exists("CampaignFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3659,7 +3659,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3699,7 +3699,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3742,7 +3742,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedOperation", false)) {
   /**
    * Operation used to create or mutate a CampaignFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3785,7 +3785,7 @@ if (!class_exists("CampaignFeedOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedReturnValue", false)) {
   /**
    * The result of a call to {@link CampaignFeedService#mutate}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3827,7 +3827,7 @@ if (!class_exists("CampaignFeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("ConstantOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperand", false)) {
   /**
    * A constant operand in a matching function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3897,7 +3897,7 @@ if (!class_exists("ConstantOperand", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand", false)) {
   /**
    * Represents a feed attribute reference to use in a function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3946,7 +3946,7 @@ if (!class_exists("FeedAttributeOperand", false)) {
   }
 }
 
-if (!class_exists("FunctionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperand", false)) {
   /**
    * A function operand in a matching function.
    * Used to represent nested functions.
@@ -3989,7 +3989,7 @@ if (!class_exists("FunctionOperand", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4025,7 +4025,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("CampaignFeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignFeedPage", false)) {
   /**
    * The result of a call to {@link CampaignFeedService#get}. Contains a list of
    * associations between campaign and feeds.
@@ -4073,7 +4073,7 @@ if (!class_exists("CampaignFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CampaignFeedService extends AdWordsSoapClient {
+  class CampaignFeedService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4090,95 +4090,95 @@ if (!class_exists("CampaignFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "CampaignFeed" => "CampaignFeed",
-      "CampaignFeedError" => "CampaignFeedError",
-      "CampaignFeedOperation" => "CampaignFeedOperation",
-      "CampaignFeedPage" => "CampaignFeedPage",
-      "CampaignFeedReturnValue" => "CampaignFeedReturnValue",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ConstantOperand" => "ConstantOperand",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttributeOperand" => "FeedAttributeOperand",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "FunctionOperand" => "FunctionOperand",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NullStatsPage" => "NullStatsPage",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestContextOperand" => "RequestContextOperand",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "CampaignFeed.Status" => "CampaignFeedStatus",
-      "CampaignFeedError.Reason" => "CampaignFeedErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "ConstantOperand.ConstantType" => "ConstantOperandConstantType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestContextOperand.ContextType" => "RequestContextOperandContextType",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CampaignFeedServiceGet",
-      "getResponse" => "CampaignFeedServiceGetResponse",
-      "mutate" => "CampaignFeedServiceMutate",
-      "mutateResponse" => "CampaignFeedServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "CampaignFeed" => "Google_Api_Ads_AdWords_v201402\\CampaignFeed",
+      "CampaignFeedError" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedError",
+      "CampaignFeedOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedOperation",
+      "CampaignFeedPage" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedPage",
+      "CampaignFeedReturnValue" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedReturnValue",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "ConstantOperand" => "Google_Api_Ads_AdWords_v201402\\ConstantOperand",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedAttributeOperand" => "Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand",
+      "Function" => "Google_Api_Ads_AdWords_v201402\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201402\\FunctionError",
+      "FunctionOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestContextOperand" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperand",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "CampaignFeed.Status" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedStatus",
+      "CampaignFeedError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "ConstantOperand.ConstantType" => "Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201402\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201402\\FunctionErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestContextOperand.ContextType" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignFeedServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4246,3 +4246,4 @@ if (!class_exists("CampaignFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CampaignService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CampaignService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ConversionOptimizerEligibility", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibility", false)) {
   /**
    * Eligibility data for Campaign to transition to Conversion Optimizer
    * @package Google_Api_Ads_AdWords_v201402
@@ -77,7 +77,7 @@ if (!class_exists("ConversionOptimizerEligibility", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -125,7 +125,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FrequencyCap", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FrequencyCap", false)) {
   /**
    * A frequency cap is the maximum number of times an ad (or some set of ads) can
    * be shown to a user over a particular time period.
@@ -180,7 +180,7 @@ if (!class_exists("FrequencyCap", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -241,7 +241,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -288,7 +288,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -337,7 +337,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -391,7 +391,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -459,7 +459,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -527,7 +527,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -575,7 +575,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -647,7 +647,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -719,7 +719,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -816,7 +816,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -895,7 +895,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -967,7 +967,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1035,7 +1035,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -1108,7 +1108,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -1200,7 +1200,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1289,7 +1289,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("Campaign", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Campaign", false)) {
   /**
    * Data representing an AdWords campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1434,7 +1434,7 @@ if (!class_exists("Campaign", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1506,7 +1506,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1586,7 +1586,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1665,7 +1665,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdServingOptimizationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdServingOptimizationStatus", false)) {
   /**
    * Ad serving status of campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1698,7 +1698,7 @@ if (!class_exists("AdServingOptimizationStatus", false)) {
   }
 }
 
-if (!class_exists("AdvertisingChannelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdvertisingChannelType", false)) {
   /**
    * The channel type a campaign may target to serve on.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1731,7 +1731,7 @@ if (!class_exists("AdvertisingChannelType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1764,7 +1764,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1797,7 +1797,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1830,7 +1830,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -1864,7 +1864,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1897,7 +1897,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1930,7 +1930,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1963,7 +1963,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1996,7 +1996,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingTransitionErrorReason", false)) {
   /**
    * Reason for bidding transition error.
    * It is used by capability service as denial reasons, for bidding transition
@@ -2031,7 +2031,7 @@ if (!class_exists("BiddingTransitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2064,7 +2064,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2097,7 +2097,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2130,7 +2130,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2163,7 +2163,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2196,7 +2196,7 @@ if (!class_exists("CampaignErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignStatus", false)) {
   /**
    * Campaign status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2229,7 +2229,7 @@ if (!class_exists("CampaignStatus", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2263,7 +2263,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2296,7 +2296,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2329,7 +2329,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibilityRejectionReason", false)) {
   /**
    * Campaign is not active
    * @package Google_Api_Ads_AdWords_v201402
@@ -2362,7 +2362,7 @@ if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2395,7 +2395,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2428,7 +2428,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2461,7 +2461,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2494,7 +2494,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2528,7 +2528,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2561,7 +2561,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   /**
    * The various signals a negative location target may use.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2594,7 +2594,7 @@ if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   /**
    * The various signals a positive location target may use.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2627,7 +2627,7 @@ if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2660,7 +2660,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2693,7 +2693,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("Level", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Level", false)) {
   /**
    * The level on which the cap is to be applied.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2726,7 +2726,7 @@ if (!class_exists("Level", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2759,7 +2759,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2792,7 +2792,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2825,7 +2825,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2858,7 +2858,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2891,7 +2891,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2924,9 +2924,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -2957,7 +2957,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2990,7 +2990,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3023,7 +3023,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3057,7 +3057,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3090,7 +3090,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3123,7 +3123,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3156,7 +3156,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3189,7 +3189,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3222,7 +3222,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3255,7 +3255,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3288,7 +3288,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3321,7 +3321,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("ServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ServingStatus", false)) {
   /**
    * Campaign serving status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3354,7 +3354,7 @@ if (!class_exists("ServingStatus", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3387,7 +3387,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3420,7 +3420,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3453,7 +3453,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3486,7 +3486,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3519,7 +3519,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3552,7 +3552,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("TimeUnit", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TimeUnit", false)) {
   /**
    * Unit of time the cap is defined at.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3585,7 +3585,7 @@ if (!class_exists("TimeUnit", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3633,7 +3633,7 @@ if (!class_exists("CampaignServiceGet", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3673,7 +3673,7 @@ if (!class_exists("CampaignServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -3729,7 +3729,7 @@ if (!class_exists("CampaignServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CampaignServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3769,7 +3769,7 @@ if (!class_exists("CampaignServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3818,7 +3818,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3858,7 +3858,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3903,7 +3903,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3948,7 +3948,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3993,7 +3993,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4038,7 +4038,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4083,7 +4083,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingTransitionError", false)) {
   /**
    * Bidding transition errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4128,7 +4128,7 @@ if (!class_exists("BiddingTransitionError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4173,7 +4173,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("CampaignError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignError", false)) {
   /**
    * Base error class for Campaign Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4218,7 +4218,7 @@ if (!class_exists("CampaignError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4263,7 +4263,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -4326,7 +4326,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4371,7 +4371,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4416,7 +4416,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAdsSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DynamicSearchAdsSetting", false)) {
   /**
    * Setting for controlling Dynamic Search Ads (DSA). Contains the domain name and the language
    * used by the DSA system to automatically generate landing pages and keywords for a campaign.
@@ -4466,7 +4466,7 @@ if (!class_exists("DynamicSearchAdsSetting", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4505,7 +4505,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4579,7 +4579,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4625,7 +4625,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -4671,7 +4671,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSetting", false)) {
   /**
    * Represents a collection of settings related to ads geotargeting.
    * 
@@ -4745,7 +4745,7 @@ if (!class_exists("GeoTargetTypeSetting", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4790,7 +4790,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -4837,7 +4837,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchSetting", false)) {
   /**
    * Improved exact and phrase match option includes misspellings, plurals,
    * and other close variants of your keywords.
@@ -4887,7 +4887,7 @@ if (!class_exists("KeywordMatchSetting", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -4930,7 +4930,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4966,7 +4966,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5008,7 +5008,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5053,7 +5053,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5098,7 +5098,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5143,7 +5143,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5178,7 +5178,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5223,7 +5223,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5268,7 +5268,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5317,7 +5317,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -5358,7 +5358,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5410,7 +5410,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5455,7 +5455,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5507,7 +5507,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5552,7 +5552,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5618,7 +5618,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5663,7 +5663,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RealTimeBiddingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RealTimeBiddingSetting", false)) {
   /**
    * Settings for Real-Time Bidding, a feature only available for campaigns
    * targeting the Ad Exchange network.
@@ -5706,7 +5706,7 @@ if (!class_exists("RealTimeBiddingSetting", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5751,7 +5751,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -5797,7 +5797,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5842,7 +5842,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5887,7 +5887,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5932,7 +5932,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("ShoppingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ShoppingSetting", false)) {
   /**
    * Setting for shopping campaigns. Defines the universe of products covered by the campaign.
    * Encapsulates a merchant ID, sales country, and campaign priority.
@@ -5989,7 +5989,7 @@ if (!class_exists("ShoppingSetting", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6034,7 +6034,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6079,7 +6079,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -6125,7 +6125,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6170,7 +6170,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("TrackingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrackingSetting", false)) {
   /**
    * Campaign level settings for tracking information.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6212,7 +6212,7 @@ if (!class_exists("TrackingSetting", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6254,7 +6254,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6310,7 +6310,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6359,7 +6359,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6404,7 +6404,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -6483,7 +6483,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -6550,7 +6550,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetRoasBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme", false)) {
   /**
    * Target Roas bidding strategy helps you maximize revenue while averaging a specific target
    * Return On Average Spend (ROAS).
@@ -6616,7 +6616,7 @@ if (!class_exists("TargetRoasBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -6668,7 +6668,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6711,7 +6711,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -6762,7 +6762,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("CampaignOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignOperation", false)) {
   /**
    * An operation on an AdWords campaign.
    * <p class="note"><b>Note:</b> The <code>REMOVE</code> operator is not
@@ -6808,7 +6808,7 @@ if (!class_exists("CampaignOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignPage", false)) {
   /**
    * Contains a subset of campaign resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.campaign.CampaignService#get} call.
@@ -6852,7 +6852,7 @@ if (!class_exists("CampaignPage", false)) {
   }
 }
 
-if (!class_exists("CampaignReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignReturnValue", false)) {
   /**
    * A container for return values from the CampaignService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6901,7 +6901,7 @@ if (!class_exists("CampaignReturnValue", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6942,7 +6942,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6989,7 +6989,7 @@ if (!class_exists("CampaignService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CampaignService extends AdWordsSoapClient {
+  class CampaignService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CampaignService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -7006,158 +7006,158 @@ if (!class_exists("CampaignService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingTransitionError" => "BiddingTransitionError",
-      "BudgetError" => "BudgetError",
-      "CampaignError" => "CampaignError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "ConversionOptimizerEligibility" => "ConversionOptimizerEligibility",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "DynamicSearchAdsSetting" => "DynamicSearchAdsSetting",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "FrequencyCap" => "FrequencyCap",
-      "GeoTargetTypeSetting" => "GeoTargetTypeSetting",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "KeywordMatchSetting" => "KeywordMatchSetting",
-      "LongValue" => "LongValue",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RealTimeBiddingSetting" => "RealTimeBiddingSetting",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SettingError" => "SettingError",
-      "ShoppingSetting" => "ShoppingSetting",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "TargetError" => "TargetError",
-      "TrackingSetting" => "TrackingSetting",
-      "ComparableValue" => "ComparableValue",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "DatabaseError" => "DatabaseError",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "Setting" => "Setting",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetRoasBiddingScheme" => "TargetRoasBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Bids" => "Bids",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "Selector" => "Selector",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "Budget" => "Budget",
-      "Campaign" => "Campaign",
-      "CampaignOperation" => "CampaignOperation",
-      "CampaignPage" => "CampaignPage",
-      "CampaignReturnValue" => "CampaignReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AdServingOptimizationStatus" => "AdServingOptimizationStatus",
-      "AdvertisingChannelType" => "AdvertisingChannelType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "BiddingTransitionError.Reason" => "BiddingTransitionErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "CampaignError.Reason" => "CampaignErrorReason",
-      "CampaignStatus" => "CampaignStatus",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "ConversionOptimizerEligibility.RejectionReason" => "ConversionOptimizerEligibilityRejectionReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "GeoTargetTypeSetting.NegativeGeoTargetType" => "GeoTargetTypeSettingNegativeGeoTargetType",
-      "GeoTargetTypeSetting.PositiveGeoTargetType" => "GeoTargetTypeSettingPositiveGeoTargetType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "Level" => "Level",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "ServingStatus" => "ServingStatus",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "TimeUnit" => "TimeUnit",
-      "get" => "CampaignServiceGet",
-      "getResponse" => "CampaignServiceGetResponse",
-      "mutate" => "CampaignServiceMutate",
-      "mutateResponse" => "CampaignServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201402\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201402\\BiddingErrors",
+      "BiddingTransitionError" => "Google_Api_Ads_AdWords_v201402\\BiddingTransitionError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201402\\BudgetError",
+      "CampaignError" => "Google_Api_Ads_AdWords_v201402\\CampaignError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme",
+      "ConversionOptimizerEligibility" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibility",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "DynamicSearchAdsSetting" => "Google_Api_Ads_AdWords_v201402\\DynamicSearchAdsSetting",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError",
+      "FrequencyCap" => "Google_Api_Ads_AdWords_v201402\\FrequencyCap",
+      "GeoTargetTypeSetting" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSetting",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "KeywordMatchSetting" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchSetting",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201402\\NetworkSetting",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201402\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RealTimeBiddingSetting" => "Google_Api_Ads_AdWords_v201402\\RealTimeBiddingSetting",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SettingError" => "Google_Api_Ads_AdWords_v201402\\SettingError",
+      "ShoppingSetting" => "Google_Api_Ads_AdWords_v201402\\ShoppingSetting",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "TargetError" => "Google_Api_Ads_AdWords_v201402\\TargetError",
+      "TrackingSetting" => "Google_Api_Ads_AdWords_v201402\\TrackingSetting",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201402\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201402\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201402\\CpmBid",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme",
+      "Setting" => "Google_Api_Ads_AdWords_v201402\\Setting",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme",
+      "TargetRoasBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Bids" => "Google_Api_Ads_AdWords_v201402\\Bids",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration",
+      "Budget" => "Google_Api_Ads_AdWords_v201402\\Budget",
+      "Campaign" => "Google_Api_Ads_AdWords_v201402\\Campaign",
+      "CampaignOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignOperation",
+      "CampaignPage" => "Google_Api_Ads_AdWords_v201402\\CampaignPage",
+      "CampaignReturnValue" => "Google_Api_Ads_AdWords_v201402\\CampaignReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AdServingOptimizationStatus" => "Google_Api_Ads_AdWords_v201402\\AdServingOptimizationStatus",
+      "AdvertisingChannelType" => "Google_Api_Ads_AdWords_v201402\\AdvertisingChannelType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BidSource" => "Google_Api_Ads_AdWords_v201402\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyType",
+      "BiddingTransitionError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingTransitionErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetErrorReason",
+      "CampaignError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignErrorReason",
+      "CampaignStatus" => "Google_Api_Ads_AdWords_v201402\\CampaignStatus",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode",
+      "ConversionOptimizerEligibility.RejectionReason" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibilityRejectionReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason",
+      "GeoTargetTypeSetting.NegativeGeoTargetType" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingNegativeGeoTargetType",
+      "GeoTargetTypeSetting.PositiveGeoTargetType" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingPositiveGeoTargetType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "Level" => "Google_Api_Ads_AdWords_v201402\\Level",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "ServingStatus" => "Google_Api_Ads_AdWords_v201402\\ServingStatus",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201402\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201402\\TargetErrorReason",
+      "TimeUnit" => "Google_Api_Ads_AdWords_v201402\\TimeUnit",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CampaignServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CampaignServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CampaignServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -7230,3 +7230,4 @@ if (!class_exists("CampaignService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ConstantDataService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ConstantDataService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -268,7 +268,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -336,7 +336,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -404,7 +404,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -452,7 +452,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -500,7 +500,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductDimension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimension", false)) {
   /**
    * Dimension by which to subdivide or filter products.
    * @package Google_Api_Ads_AdWords_v201402
@@ -572,7 +572,7 @@ if (!class_exists("ProductDimension", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -669,7 +669,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -748,7 +748,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -816,7 +816,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("ConstantData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantData", false)) {
   /**
    * Marker interface for ConstantDataService objects. This is primarily required for field
    * catalog generation.
@@ -889,7 +889,7 @@ if (!class_exists("ConstantData", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -976,7 +976,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1009,7 +1009,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201402
@@ -1042,7 +1042,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1075,7 +1075,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1108,7 +1108,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1142,7 +1142,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantDataServiceUserInterestTaxonomyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantDataServiceUserInterestTaxonomyType", false)) {
   /**
    * An enumeration of possible user interest taxonomy types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1175,7 +1175,7 @@ if (!class_exists("ConstantDataServiceUserInterestTaxonomyType", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1208,7 +1208,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1241,7 +1241,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1274,7 +1274,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1307,7 +1307,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1340,7 +1340,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1373,7 +1373,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1406,7 +1406,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -1440,7 +1440,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1473,7 +1473,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1506,7 +1506,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1539,7 +1539,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1572,7 +1572,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1605,7 +1605,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalConditionCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition", false)) {
   /**
    * A canonical product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1638,7 +1638,7 @@ if (!class_exists("ProductCanonicalConditionCondition", false)) {
   }
 }
 
-if (!class_exists("ProductDimensionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimensionType", false)) {
   /**
    * Type of product dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1671,7 +1671,7 @@ if (!class_exists("ProductDimensionType", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1705,7 +1705,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1738,7 +1738,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1771,7 +1771,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1804,7 +1804,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1837,7 +1837,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1870,7 +1870,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1903,7 +1903,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1936,7 +1936,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1969,7 +1969,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2002,7 +2002,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2035,7 +2035,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2068,7 +2068,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("GetAgeRangeCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetAgeRangeCriterion", false)) {
   /**
    * Returns a list of all age range criteria.
    * 
@@ -2104,7 +2104,7 @@ if (!class_exists("GetAgeRangeCriterion", false)) {
   }
 }
 
-if (!class_exists("GetAgeRangeCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetAgeRangeCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2144,7 +2144,7 @@ if (!class_exists("GetAgeRangeCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetCarrierCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetCarrierCriterion", false)) {
   /**
    * Returns a list of all carrier criteria.
    * 
@@ -2180,7 +2180,7 @@ if (!class_exists("GetCarrierCriterion", false)) {
   }
 }
 
-if (!class_exists("GetCarrierCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetCarrierCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2220,7 +2220,7 @@ if (!class_exists("GetCarrierCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetGenderCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetGenderCriterion", false)) {
   /**
    * Returns a list of all gender criteria.
    * 
@@ -2256,7 +2256,7 @@ if (!class_exists("GetGenderCriterion", false)) {
   }
 }
 
-if (!class_exists("GetGenderCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetGenderCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2296,7 +2296,7 @@ if (!class_exists("GetGenderCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetLanguageCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetLanguageCriterion", false)) {
   /**
    * Returns a list of all language criteria.
    * 
@@ -2332,7 +2332,7 @@ if (!class_exists("GetLanguageCriterion", false)) {
   }
 }
 
-if (!class_exists("GetLanguageCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetLanguageCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2372,7 +2372,7 @@ if (!class_exists("GetLanguageCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetMobileDeviceCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetMobileDeviceCriterion", false)) {
   /**
    * Returns a list of all mobile devices.
    * 
@@ -2408,7 +2408,7 @@ if (!class_exists("GetMobileDeviceCriterion", false)) {
   }
 }
 
-if (!class_exists("GetMobileDeviceCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetMobileDeviceCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2448,7 +2448,7 @@ if (!class_exists("GetMobileDeviceCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetOperatingSystemVersionCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetOperatingSystemVersionCriterion", false)) {
   /**
    * Returns a list of all operating system version criteria.
    * 
@@ -2484,7 +2484,7 @@ if (!class_exists("GetOperatingSystemVersionCriterion", false)) {
   }
 }
 
-if (!class_exists("GetOperatingSystemVersionCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetOperatingSystemVersionCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2524,7 +2524,7 @@ if (!class_exists("GetOperatingSystemVersionCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetProductBiddingCategoryData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetProductBiddingCategoryData", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2574,7 +2574,7 @@ if (!class_exists("GetProductBiddingCategoryData", false)) {
   }
 }
 
-if (!class_exists("GetProductBiddingCategoryDataResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetProductBiddingCategoryDataResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2614,7 +2614,7 @@ if (!class_exists("GetProductBiddingCategoryDataResponse", false)) {
   }
 }
 
-if (!class_exists("GetUserInterestCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetUserInterestCriterion", false)) {
   /**
    * Returns a list of user interests.
    * 
@@ -2658,7 +2658,7 @@ if (!class_exists("GetUserInterestCriterion", false)) {
   }
 }
 
-if (!class_exists("GetUserInterestCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetUserInterestCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2698,7 +2698,7 @@ if (!class_exists("GetUserInterestCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("GetVerticalCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetVerticalCriterion", false)) {
   /**
    * Returns a list of content verticals.
    * 
@@ -2734,7 +2734,7 @@ if (!class_exists("GetVerticalCriterion", false)) {
   }
 }
 
-if (!class_exists("GetVerticalCriterionResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetVerticalCriterionResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2774,7 +2774,7 @@ if (!class_exists("GetVerticalCriterionResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2819,10 +2819,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -2865,7 +2865,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2910,7 +2910,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2955,10 +2955,10 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -3008,7 +3008,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3053,7 +3053,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3098,7 +3098,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3143,10 +3143,10 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -3189,7 +3189,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3234,7 +3234,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3281,7 +3281,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3333,10 +3333,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -3386,7 +3386,7 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -3440,7 +3440,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3492,10 +3492,10 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -3559,7 +3559,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3604,7 +3604,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3649,10 +3649,10 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -3716,7 +3716,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -3762,7 +3762,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsGrouping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping", false)) {
   /**
    * An {@code adwords grouping} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -3805,7 +3805,7 @@ if (!class_exists("ProductAdwordsGrouping", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsLabels", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels", false)) {
   /**
    * An {@code adwords labels} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -3848,7 +3848,7 @@ if (!class_exists("ProductAdwordsLabels", false)) {
   }
 }
 
-if (!class_exists("ProductBiddingCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory", false)) {
   /**
    * One element of a bidding category at a certain level. Top-level categories are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -3900,7 +3900,7 @@ if (!class_exists("ProductBiddingCategory", false)) {
   }
 }
 
-if (!class_exists("ProductBrand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBrand", false)) {
   /**
    * A brand string.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3942,7 +3942,7 @@ if (!class_exists("ProductBrand", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition", false)) {
   /**
    * A canonical condition. Only supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -3985,7 +3985,7 @@ if (!class_exists("ProductCanonicalCondition", false)) {
   }
 }
 
-if (!class_exists("ProductLegacyCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition", false)) {
   /**
    * A plain condition string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -4028,7 +4028,7 @@ if (!class_exists("ProductLegacyCondition", false)) {
   }
 }
 
-if (!class_exists("ProductCustomAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute", false)) {
   /**
    * A custom attribute value. As a product can have multiple custom attributes, the user must specify
    * a dimension type that indicates the index of the attribute by which to subdivide. All cases of
@@ -4079,7 +4079,7 @@ if (!class_exists("ProductCustomAttribute", false)) {
   }
 }
 
-if (!class_exists("ProductOfferId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductOfferId", false)) {
   /**
    * An offer ID as specified by the merchant.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4121,7 +4121,7 @@ if (!class_exists("ProductOfferId", false)) {
   }
 }
 
-if (!class_exists("ProductType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductType", false)) {
   /**
    * One element of a product type string at a certain level. Top-level product types are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -4173,7 +4173,7 @@ if (!class_exists("ProductType", false)) {
   }
 }
 
-if (!class_exists("ProductTypeFull", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductTypeFull", false)) {
   /**
    * A full product type string. Category of the product according to the merchant's own
    * classification. Example:
@@ -4220,7 +4220,7 @@ if (!class_exists("ProductTypeFull", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4265,7 +4265,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4310,7 +4310,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4376,7 +4376,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4421,7 +4421,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4466,7 +4466,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -4512,7 +4512,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4557,7 +4557,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4602,7 +4602,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4647,7 +4647,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -4693,7 +4693,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4745,7 +4745,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -4804,7 +4804,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -4867,7 +4867,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4912,7 +4912,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4955,7 +4955,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -5010,7 +5010,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductBiddingCategoryData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBiddingCategoryData", false)) {
   /**
    * The taxonomy of ProductBiddingCategory dimension values.
    * 
@@ -5082,7 +5082,7 @@ if (!class_exists("ConstantDataService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ConstantDataService extends AdWordsSoapClient {
+  class ConstantDataService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ConstantDataService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -5099,119 +5099,119 @@ if (!class_exists("ConstantDataService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "Gender" => "Gender",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "ProductAdwordsGrouping" => "ProductAdwordsGrouping",
-      "ProductAdwordsLabels" => "ProductAdwordsLabels",
-      "ProductBiddingCategory" => "ProductBiddingCategory",
-      "ProductBrand" => "ProductBrand",
-      "ProductCanonicalCondition" => "ProductCanonicalCondition",
-      "ProductLegacyCondition" => "ProductLegacyCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "ProductCustomAttribute" => "ProductCustomAttribute",
-      "ProductOfferId" => "ProductOfferId",
-      "ProductType" => "ProductType",
-      "ProductTypeFull" => "ProductTypeFull",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "DatabaseError" => "DatabaseError",
-      "ProductCondition" => "ProductCondition",
-      "ProductDimension" => "ProductDimension",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Product" => "Product",
-      "ProductBiddingCategoryData" => "ProductBiddingCategoryData",
-      "Selector" => "Selector",
-      "ConstantData" => "ConstantData",
-      "Criterion" => "Criterion",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConstantDataService.UserInterestTaxonomyType" => "ConstantDataServiceUserInterestTaxonomyType",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "Predicate.Operator" => "PredicateOperator",
-      "ProductCanonicalCondition.Condition" => "ProductCanonicalConditionCondition",
-      "ProductDimensionType" => "ProductDimensionType",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "getAgeRangeCriterion" => "GetAgeRangeCriterion",
-      "getAgeRangeCriterionResponse" => "GetAgeRangeCriterionResponse",
-      "getCarrierCriterion" => "GetCarrierCriterion",
-      "getCarrierCriterionResponse" => "GetCarrierCriterionResponse",
-      "getGenderCriterion" => "GetGenderCriterion",
-      "getGenderCriterionResponse" => "GetGenderCriterionResponse",
-      "getLanguageCriterion" => "GetLanguageCriterion",
-      "getLanguageCriterionResponse" => "GetLanguageCriterionResponse",
-      "getMobileDeviceCriterion" => "GetMobileDeviceCriterion",
-      "getMobileDeviceCriterionResponse" => "GetMobileDeviceCriterionResponse",
-      "getOperatingSystemVersionCriterion" => "GetOperatingSystemVersionCriterion",
-      "getOperatingSystemVersionCriterionResponse" => "GetOperatingSystemVersionCriterionResponse",
-      "getProductBiddingCategoryData" => "GetProductBiddingCategoryData",
-      "getProductBiddingCategoryDataResponse" => "GetProductBiddingCategoryDataResponse",
-      "getUserInterestCriterion" => "GetUserInterestCriterion",
-      "getUserInterestCriterionResponse" => "GetUserInterestCriterionResponse",
-      "getVerticalCriterion" => "GetVerticalCriterion",
-      "getVerticalCriterionResponse" => "GetVerticalCriterionResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201402\\AgeRange",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "Carrier" => "Google_Api_Ads_AdWords_v201402\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "Gender" => "Google_Api_Ads_AdWords_v201402\\Gender",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201402\\MobileDevice",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "ProductAdwordsGrouping" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping",
+      "ProductAdwordsLabels" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels",
+      "ProductBiddingCategory" => "Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory",
+      "ProductBrand" => "Google_Api_Ads_AdWords_v201402\\ProductBrand",
+      "ProductCanonicalCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition",
+      "ProductLegacyCondition" => "Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "ProductCustomAttribute" => "Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute",
+      "ProductOfferId" => "Google_Api_Ads_AdWords_v201402\\ProductOfferId",
+      "ProductType" => "Google_Api_Ads_AdWords_v201402\\ProductType",
+      "ProductTypeFull" => "Google_Api_Ads_AdWords_v201402\\ProductTypeFull",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductDimension" => "Google_Api_Ads_AdWords_v201402\\ProductDimension",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductBiddingCategoryData" => "Google_Api_Ads_AdWords_v201402\\ProductBiddingCategoryData",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "ConstantData" => "Google_Api_Ads_AdWords_v201402\\ConstantData",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConstantDataService.UserInterestTaxonomyType" => "Google_Api_Ads_AdWords_v201402\\ConstantDataServiceUserInterestTaxonomyType",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201402\\GenderGenderType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "ProductCanonicalCondition.Condition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition",
+      "ProductDimensionType" => "Google_Api_Ads_AdWords_v201402\\ProductDimensionType",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "getAgeRangeCriterion" => "Google_Api_Ads_AdWords_v201402\\GetAgeRangeCriterion",
+      "getAgeRangeCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetAgeRangeCriterionResponse",
+      "getCarrierCriterion" => "Google_Api_Ads_AdWords_v201402\\GetCarrierCriterion",
+      "getCarrierCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetCarrierCriterionResponse",
+      "getGenderCriterion" => "Google_Api_Ads_AdWords_v201402\\GetGenderCriterion",
+      "getGenderCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetGenderCriterionResponse",
+      "getLanguageCriterion" => "Google_Api_Ads_AdWords_v201402\\GetLanguageCriterion",
+      "getLanguageCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetLanguageCriterionResponse",
+      "getMobileDeviceCriterion" => "Google_Api_Ads_AdWords_v201402\\GetMobileDeviceCriterion",
+      "getMobileDeviceCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetMobileDeviceCriterionResponse",
+      "getOperatingSystemVersionCriterion" => "Google_Api_Ads_AdWords_v201402\\GetOperatingSystemVersionCriterion",
+      "getOperatingSystemVersionCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetOperatingSystemVersionCriterionResponse",
+      "getProductBiddingCategoryData" => "Google_Api_Ads_AdWords_v201402\\GetProductBiddingCategoryData",
+      "getProductBiddingCategoryDataResponse" => "Google_Api_Ads_AdWords_v201402\\GetProductBiddingCategoryDataResponse",
+      "getUserInterestCriterion" => "Google_Api_Ads_AdWords_v201402\\GetUserInterestCriterion",
+      "getUserInterestCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetUserInterestCriterionResponse",
+      "getVerticalCriterion" => "Google_Api_Ads_AdWords_v201402\\GetVerticalCriterion",
+      "getVerticalCriterionResponse" => "Google_Api_Ads_AdWords_v201402\\GetVerticalCriterionResponse",
     );
 
 
@@ -5334,3 +5334,4 @@ if (!class_exists("ConstantDataService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ConversionTrackerService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ConversionTrackerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -436,7 +436,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerStats", false)) {
   /**
    * Usage stats about a single {@link ConversionTracker}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -497,7 +497,7 @@ if (!class_exists("ConversionTrackerStats", false)) {
   }
 }
 
-if (!class_exists("ConversionTracker", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTracker", false)) {
   /**
    * An abstract Conversion base class.
    * @package Google_Api_Ads_AdWords_v201402
@@ -653,7 +653,7 @@ if (!class_exists("ConversionTracker", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -725,7 +725,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -805,7 +805,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -902,7 +902,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -981,7 +981,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1060,7 +1060,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1128,7 +1128,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerMarkupLanguage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerMarkupLanguage", false)) {
   /**
    * Controls the markup language in which the snippet will be written.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1161,7 +1161,7 @@ if (!class_exists("AdWordsConversionTrackerMarkupLanguage", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerTextFormat", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerTextFormat", false)) {
   /**
    * Text format to display on the conversion page.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1194,7 +1194,7 @@ if (!class_exists("AdWordsConversionTrackerTextFormat", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTrackerTrackingCodeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerTrackingCodeType", false)) {
   /**
    * Type of snippet code to generate.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1227,7 +1227,7 @@ if (!class_exists("AdWordsConversionTrackerTrackingCodeType", false)) {
   }
 }
 
-if (!class_exists("AppConversionAppConversionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AppConversionAppConversionType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1260,7 +1260,7 @@ if (!class_exists("AppConversionAppConversionType", false)) {
   }
 }
 
-if (!class_exists("AppConversionAppPlatform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AppConversionAppPlatform", false)) {
   /**
    * App platform for the AppConversionTracker.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1293,7 +1293,7 @@ if (!class_exists("AppConversionAppPlatform", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1326,7 +1326,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1359,7 +1359,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1393,7 +1393,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionDeduplicationMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionDeduplicationMode", false)) {
   /**
    * Conversion deduplication mode for Conversion Optimizer. That is, whether to
    * optimize for number of clicks that get at least one conversion, or total number
@@ -1428,7 +1428,7 @@ if (!class_exists("ConversionDeduplicationMode", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerCategory", false)) {
   /**
    * The category of conversion tracker that is being tracked.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1461,7 +1461,7 @@ if (!class_exists("ConversionTrackerCategory", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerStatus", false)) {
   /**
    * Status of the conversion tracker. The user cannot ADD or SET the
    * status to {@code HIDDEN}.
@@ -1495,7 +1495,7 @@ if (!class_exists("ConversionTrackerStatus", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackingErrorReason", false)) {
   /**
    * Enumerates all the possible reasons for a ConversionTypeError.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1528,7 +1528,7 @@ if (!class_exists("ConversionTrackingErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1561,7 +1561,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1594,7 +1594,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1627,7 +1627,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1660,7 +1660,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1693,7 +1693,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1726,7 +1726,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1759,7 +1759,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1792,7 +1792,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1825,7 +1825,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1858,7 +1858,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1892,7 +1892,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1925,7 +1925,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1958,7 +1958,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1991,7 +1991,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2024,7 +2024,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2057,7 +2057,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2090,7 +2090,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2123,7 +2123,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2156,7 +2156,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2189,7 +2189,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2222,7 +2222,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2274,7 +2274,7 @@ if (!class_exists("ConversionTrackerServiceGet", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2314,7 +2314,7 @@ if (!class_exists("ConversionTrackerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2372,7 +2372,7 @@ if (!class_exists("ConversionTrackerServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2412,7 +2412,7 @@ if (!class_exists("ConversionTrackerServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdCallMetricsConversion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdCallMetricsConversion", false)) {
   /**
    * A ConversionTracker for phone calls from conversion-tracked call extensions.
    * A call made from the call extension is reported as a conversion if it lasts longer
@@ -2469,7 +2469,7 @@ if (!class_exists("AdCallMetricsConversion", false)) {
   }
 }
 
-if (!class_exists("AdWordsConversionTracker", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdWordsConversionTracker", false)) {
   /**
    * A conversion tracker created through AdWords Conversion Tracking.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2558,7 +2558,7 @@ if (!class_exists("AdWordsConversionTracker", false)) {
   }
 }
 
-if (!class_exists("AppConversion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AppConversion", false)) {
   /**
    * A ConversionTracker for mobile apps.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2640,7 +2640,7 @@ if (!class_exists("AppConversion", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2685,7 +2685,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2730,7 +2730,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2775,7 +2775,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackingError", false)) {
   /**
    * An error that can occur during calls to the ConversionTypeService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2820,7 +2820,7 @@ if (!class_exists("ConversionTrackingError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2865,7 +2865,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2910,7 +2910,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2955,7 +2955,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3002,7 +3002,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3044,7 +3044,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3089,7 +3089,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3124,7 +3124,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3169,7 +3169,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3214,7 +3214,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3259,7 +3259,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3304,7 +3304,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3370,7 +3370,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3415,7 +3415,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3460,7 +3460,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3506,7 +3506,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3551,7 +3551,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3596,7 +3596,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3641,7 +3641,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3687,7 +3687,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("UploadConversion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UploadConversion", false)) {
   /**
    * A conversion type that receives conversions by having them uploaded
    * through the OfflineConversionFeedService.
@@ -3739,7 +3739,7 @@ if (!class_exists("UploadConversion", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerOperation", false)) {
   /**
    * Operations for conversion tracker.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3782,7 +3782,7 @@ if (!class_exists("ConversionTrackerOperation", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerReturnValue", false)) {
   /**
    * A container for return values from the ConversionTrackerService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3824,7 +3824,7 @@ if (!class_exists("ConversionTrackerReturnValue", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3869,7 +3869,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3912,7 +3912,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3948,7 +3948,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3989,7 +3989,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4030,7 +4030,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("ConversionTrackerPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionTrackerPage", false)) {
   /**
    * Contains a subset of {@link ConversionTracker}s resulting from the filtering
    * and paging of the {@link ConversionTrackerService#get} call.
@@ -4078,7 +4078,7 @@ if (!class_exists("ConversionTrackerService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ConversionTrackerService extends AdWordsSoapClient {
+  class ConversionTrackerService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ConversionTrackerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4095,93 +4095,93 @@ if (!class_exists("ConversionTrackerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdCallMetricsConversion" => "AdCallMetricsConversion",
-      "AdWordsConversionTracker" => "AdWordsConversionTracker",
-      "AppConversion" => "AppConversion",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ConversionTrackingError" => "ConversionTrackingError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "UploadConversion" => "UploadConversion",
-      "ComparableValue" => "ComparableValue",
-      "ConversionTrackerStats" => "ConversionTrackerStats",
-      "ConversionTracker" => "ConversionTracker",
-      "ConversionTrackerOperation" => "ConversionTrackerOperation",
-      "ConversionTrackerReturnValue" => "ConversionTrackerReturnValue",
-      "DatabaseError" => "DatabaseError",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "ConversionTrackerPage" => "ConversionTrackerPage",
-      "NoStatsPage" => "NoStatsPage",
-      "Page" => "Page",
-      "Selector" => "Selector",
-      "AdWordsConversionTracker.MarkupLanguage" => "AdWordsConversionTrackerMarkupLanguage",
-      "AdWordsConversionTracker.TextFormat" => "AdWordsConversionTrackerTextFormat",
-      "AdWordsConversionTracker.TrackingCodeType" => "AdWordsConversionTrackerTrackingCodeType",
-      "AppConversion.AppConversionType" => "AppConversionAppConversionType",
-      "AppConversion.AppPlatform" => "AppConversionAppPlatform",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ConversionDeduplicationMode" => "ConversionDeduplicationMode",
-      "ConversionTracker.Category" => "ConversionTrackerCategory",
-      "ConversionTracker.Status" => "ConversionTrackerStatus",
-      "ConversionTrackingError.Reason" => "ConversionTrackingErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "ConversionTrackerServiceGet",
-      "getResponse" => "ConversionTrackerServiceGetResponse",
-      "mutate" => "ConversionTrackerServiceMutate",
-      "mutateResponse" => "ConversionTrackerServiceMutateResponse",
+      "AdCallMetricsConversion" => "Google_Api_Ads_AdWords_v201402\\AdCallMetricsConversion",
+      "AdWordsConversionTracker" => "Google_Api_Ads_AdWords_v201402\\AdWordsConversionTracker",
+      "AppConversion" => "Google_Api_Ads_AdWords_v201402\\AppConversion",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ConversionTrackingError" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackingError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "UploadConversion" => "Google_Api_Ads_AdWords_v201402\\UploadConversion",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "ConversionTrackerStats" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerStats",
+      "ConversionTracker" => "Google_Api_Ads_AdWords_v201402\\ConversionTracker",
+      "ConversionTrackerOperation" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerOperation",
+      "ConversionTrackerReturnValue" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerReturnValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "ConversionTrackerPage" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerPage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AdWordsConversionTracker.MarkupLanguage" => "Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerMarkupLanguage",
+      "AdWordsConversionTracker.TextFormat" => "Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerTextFormat",
+      "AdWordsConversionTracker.TrackingCodeType" => "Google_Api_Ads_AdWords_v201402\\AdWordsConversionTrackerTrackingCodeType",
+      "AppConversion.AppConversionType" => "Google_Api_Ads_AdWords_v201402\\AppConversionAppConversionType",
+      "AppConversion.AppPlatform" => "Google_Api_Ads_AdWords_v201402\\AppConversionAppPlatform",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ConversionDeduplicationMode" => "Google_Api_Ads_AdWords_v201402\\ConversionDeduplicationMode",
+      "ConversionTracker.Category" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerCategory",
+      "ConversionTracker.Status" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerStatus",
+      "ConversionTrackingError.Reason" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackingErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\ConversionTrackerServiceMutateResponse",
     );
 
 
@@ -4243,3 +4243,4 @@ if (!class_exists("ConversionTrackerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CustomerFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CustomerFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -127,7 +127,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -206,7 +206,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -251,7 +251,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -341,7 +341,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -387,7 +387,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("CustomerFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeed", false)) {
   /**
    * CustomerFeeds are used to link a feed to the customer using a matching function,
    * making the feed's feed items available in the customer's ads for substitution.
@@ -449,7 +449,7 @@ if (!class_exists("CustomerFeed", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedError", false)) {
   /**
    * Represents an error for the CustomerFeedService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -494,7 +494,7 @@ if (!class_exists("CustomerFeedError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -539,7 +539,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -587,7 +587,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -632,7 +632,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -678,7 +678,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -762,7 +762,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -807,7 +807,7 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -852,7 +852,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -899,7 +899,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -971,7 +971,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1016,7 +1016,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1088,7 +1088,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1168,7 +1168,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1213,7 +1213,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1260,7 +1260,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1339,7 +1339,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1388,7 +1388,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1442,7 +1442,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1494,7 +1494,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1539,7 +1539,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1584,7 +1584,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1650,7 +1650,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1695,7 +1695,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1740,7 +1740,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperand", false)) {
   /**
    * An operand in a function referring to a value in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1782,7 +1782,7 @@ if (!class_exists("RequestContextOperand", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1828,7 +1828,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1873,7 +1873,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1941,7 +1941,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1986,7 +1986,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2031,7 +2031,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2099,7 +2099,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2167,7 +2167,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2213,7 +2213,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2246,7 +2246,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2279,7 +2279,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2313,7 +2313,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2346,7 +2346,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("ConstantOperandConstantType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType", false)) {
   /**
    * The types of constant operands.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2379,7 +2379,7 @@ if (!class_exists("ConstantOperandConstantType", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedStatus", false)) {
   /**
    * Status of the CustomerFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2412,7 +2412,7 @@ if (!class_exists("CustomerFeedStatus", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2445,7 +2445,7 @@ if (!class_exists("CustomerFeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2478,7 +2478,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2511,7 +2511,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -2545,7 +2545,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2578,7 +2578,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2611,7 +2611,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2644,7 +2644,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2677,7 +2677,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2710,7 +2710,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2743,7 +2743,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2776,7 +2776,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2809,7 +2809,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2842,7 +2842,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2876,7 +2876,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2909,7 +2909,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2942,7 +2942,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2975,7 +2975,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3008,7 +3008,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestContextOperandContextType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType", false)) {
   /**
    * Campaign Id in the request context.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3041,7 +3041,7 @@ if (!class_exists("RequestContextOperandContextType", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3074,7 +3074,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3107,7 +3107,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3140,7 +3140,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3173,7 +3173,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3206,7 +3206,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3239,7 +3239,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3288,7 +3288,7 @@ if (!class_exists("CustomerFeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3328,7 +3328,7 @@ if (!class_exists("CustomerFeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -3378,7 +3378,7 @@ if (!class_exists("CustomerFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3418,7 +3418,7 @@ if (!class_exists("CustomerFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3466,7 +3466,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3506,7 +3506,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3549,7 +3549,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ConstantOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConstantOperand", false)) {
   /**
    * A constant operand in a matching function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3619,7 +3619,7 @@ if (!class_exists("ConstantOperand", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedOperation", false)) {
   /**
    * Operation used to create or mutate a CustomerFeed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3662,7 +3662,7 @@ if (!class_exists("CustomerFeedOperation", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedReturnValue", false)) {
   /**
    * The result of a call to {@link CustomerFeedService#mutate}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3704,7 +3704,7 @@ if (!class_exists("CustomerFeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand", false)) {
   /**
    * Represents a feed attribute reference to use in a function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3753,7 +3753,7 @@ if (!class_exists("FeedAttributeOperand", false)) {
   }
 }
 
-if (!class_exists("FunctionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperand", false)) {
   /**
    * A function operand in a matching function.
    * Used to represent nested functions.
@@ -3796,7 +3796,7 @@ if (!class_exists("FunctionOperand", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3832,7 +3832,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("CustomerFeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerFeedPage", false)) {
   /**
    * The result of a call to {@link CustomerFeedService#get}. Contains a list of
    * associations between customer and feeds.
@@ -3880,7 +3880,7 @@ if (!class_exists("CustomerFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CustomerFeedService extends AdWordsSoapClient {
+  class CustomerFeedService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CustomerFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3897,91 +3897,91 @@ if (!class_exists("CustomerFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ConstantOperand" => "ConstantOperand",
-      "CustomerFeed" => "CustomerFeed",
-      "CustomerFeedError" => "CustomerFeedError",
-      "CustomerFeedOperation" => "CustomerFeedOperation",
-      "CustomerFeedPage" => "CustomerFeedPage",
-      "CustomerFeedReturnValue" => "CustomerFeedReturnValue",
-      "DatabaseError" => "DatabaseError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttributeOperand" => "FeedAttributeOperand",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "FunctionOperand" => "FunctionOperand",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NullStatsPage" => "NullStatsPage",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestContextOperand" => "RequestContextOperand",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "ConstantOperand.ConstantType" => "ConstantOperandConstantType",
-      "CustomerFeed.Status" => "CustomerFeedStatus",
-      "CustomerFeedError.Reason" => "CustomerFeedErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestContextOperand.ContextType" => "RequestContextOperandContextType",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "CustomerFeedServiceGet",
-      "getResponse" => "CustomerFeedServiceGetResponse",
-      "mutate" => "CustomerFeedServiceMutate",
-      "mutateResponse" => "CustomerFeedServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "ConstantOperand" => "Google_Api_Ads_AdWords_v201402\\ConstantOperand",
+      "CustomerFeed" => "Google_Api_Ads_AdWords_v201402\\CustomerFeed",
+      "CustomerFeedError" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedError",
+      "CustomerFeedOperation" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedOperation",
+      "CustomerFeedPage" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedPage",
+      "CustomerFeedReturnValue" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedReturnValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedAttributeOperand" => "Google_Api_Ads_AdWords_v201402\\FeedAttributeOperand",
+      "Function" => "Google_Api_Ads_AdWords_v201402\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201402\\FunctionError",
+      "FunctionOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionOperand",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestContextOperand" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperand",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "ConstantOperand.ConstantType" => "Google_Api_Ads_AdWords_v201402\\ConstantOperandConstantType",
+      "CustomerFeed.Status" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedStatus",
+      "CustomerFeedError.Reason" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201402\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201402\\FunctionErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestContextOperand.ContextType" => "Google_Api_Ads_AdWords_v201402\\RequestContextOperandContextType",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CustomerFeedServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4048,3 +4048,4 @@ if (!class_exists("CustomerFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CustomerService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CustomerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -102,7 +102,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -174,7 +174,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -275,7 +275,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -358,7 +358,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -395,7 +395,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -432,7 +432,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -470,7 +470,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -507,7 +507,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -544,7 +544,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -581,7 +581,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -618,7 +618,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -655,7 +655,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -692,7 +692,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -729,7 +729,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -766,7 +766,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -804,7 +804,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -841,7 +841,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -878,7 +878,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -915,7 +915,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -952,7 +952,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -989,7 +989,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1026,7 +1026,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1063,7 +1063,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1100,7 +1100,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("Customer", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Customer", false)) {
   /**
    * Represents a customer for the CustomerService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1189,7 +1189,7 @@ if (!class_exists("Customer", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerServiceGet", false)) {
   /**
    * Returns details of the authorized customer.
    * 
@@ -1224,7 +1224,7 @@ if (!class_exists("CustomerServiceGet", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1264,7 +1264,7 @@ if (!class_exists("CustomerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerServiceMutate", false)) {
   /**
    * Update an authorized customer. The only update currently provided is to enable or disable <a
    * href="https://support.google.com/analytics/answer/1033981?hl=en"> auto-tagging </a>; see that
@@ -1309,7 +1309,7 @@ if (!class_exists("CustomerServiceMutate", false)) {
   }
 }
 
-if (!class_exists("CustomerServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1349,7 +1349,7 @@ if (!class_exists("CustomerServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -1398,7 +1398,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -1447,7 +1447,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -1496,7 +1496,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -1545,7 +1545,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -1594,7 +1594,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1645,7 +1645,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1694,7 +1694,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1743,7 +1743,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1792,7 +1792,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1841,7 +1841,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1890,7 +1890,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1939,7 +1939,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2009,7 +2009,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2058,7 +2058,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2107,7 +2107,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2157,7 +2157,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2206,7 +2206,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2255,7 +2255,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2305,7 +2305,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -2354,7 +2354,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -2407,7 +2407,7 @@ if (!class_exists("CustomerService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CustomerService extends AdWordsSoapClient {
+  class CustomerService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CustomerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201402";
@@ -2424,56 +2424,56 @@ if (!class_exists("CustomerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "Customer" => "Customer",
-      "get" => "CustomerServiceGet",
-      "getResponse" => "CustomerServiceGetResponse",
-      "mutate" => "CustomerServiceMutate",
-      "mutateResponse" => "CustomerServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "Customer" => "Google_Api_Ads_AdWords_v201402\\Customer",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CustomerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CustomerServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\CustomerServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\CustomerServiceMutateResponse",
     );
 
 
@@ -2512,3 +2512,4 @@ if (!class_exists("CustomerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/CustomerSyncService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/CustomerSyncService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateTimeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateTimeRange", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -79,7 +79,7 @@ if (!class_exists("DateTimeRange", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -149,7 +149,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -219,7 +219,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -320,7 +320,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Indicates that this instance is a subtype of ApplicationException.
    * Although this field is returned in the response, it is ignored on input
@@ -407,7 +407,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -442,7 +442,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -477,7 +477,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -512,7 +512,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -547,7 +547,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -582,7 +582,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -617,7 +617,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -652,7 +652,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -687,7 +687,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -722,7 +722,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -757,7 +757,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -792,7 +792,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -827,7 +827,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -862,7 +862,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -897,7 +897,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -932,7 +932,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -967,7 +967,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * 
@@ -1006,7 +1006,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1041,7 +1041,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupChangeData", false)) {
   /**
    * Holds information about a changed adgroup
    * @package Google_Api_Ads_AdWords_v201402
@@ -1137,7 +1137,7 @@ if (!class_exists("AdGroupChangeData", false)) {
   }
 }
 
-if (!class_exists("CampaignChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignChangeData", false)) {
   /**
    * Holds information about a changed campaign and any ad groups under
    * that have changed.
@@ -1241,7 +1241,7 @@ if (!class_exists("CampaignChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerSyncError", false)) {
   /**
    * Represents CustomerSyncService specific errors
    * @package Google_Api_Ads_AdWords_v201402
@@ -1293,7 +1293,7 @@ if (!class_exists("CustomerSyncError", false)) {
   }
 }
 
-if (!class_exists("FeedChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedChangeData", false)) {
   /**
    * Holds information about a changed feed and any feeds items within the feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1354,7 +1354,7 @@ if (!class_exists("FeedChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerChangeData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerChangeData", false)) {
   /**
    * Holds information about changes to a customer
    * @package Google_Api_Ads_AdWords_v201402
@@ -1408,7 +1408,7 @@ if (!class_exists("CustomerChangeData", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerSyncSelector", false)) {
   /**
    * A filter for selecting change history data for a customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1462,7 +1462,7 @@ if (!class_exists("CustomerSyncSelector", false)) {
   }
 }
 
-if (!class_exists("ChangeStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ChangeStatus", false)) {
   /**
    * An enum used to classify the types of changes that have been made to
    * an adgroup/campaign during a specified date range.  This only refers
@@ -1501,7 +1501,7 @@ if (!class_exists("ChangeStatus", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerSyncErrorReason", false)) {
   /**
    * The request attempted to access a campaign that either does not
    * exist or belongs to a different account.
@@ -1535,7 +1535,7 @@ if (!class_exists("CustomerSyncErrorReason", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerSyncServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1584,7 +1584,7 @@ if (!class_exists("CustomerSyncServiceGet", false)) {
   }
 }
 
-if (!class_exists("CustomerSyncServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CustomerSyncServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1624,7 +1624,7 @@ if (!class_exists("CustomerSyncServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1671,7 +1671,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1718,7 +1718,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1765,7 +1765,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1812,7 +1812,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1859,7 +1859,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1906,7 +1906,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -1953,7 +1953,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2000,7 +2000,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2047,7 +2047,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2094,7 +2094,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2162,7 +2162,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2209,7 +2209,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2256,7 +2256,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2303,7 +2303,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2350,7 +2350,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2397,7 +2397,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2444,7 +2444,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2491,7 +2491,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Indicates that this instance is a subtype of ApiError.
    * Although this field is returned in the response, it is ignored on input
@@ -2542,7 +2542,7 @@ if (!class_exists("CustomerSyncService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class CustomerSyncService extends AdWordsSoapClient {
+  class CustomerSyncService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "CustomerSyncService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/ch/v201402";
@@ -2559,58 +2559,58 @@ if (!class_exists("CustomerSyncService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateTimeRange" => "DateTimeRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "AdGroupChangeData" => "AdGroupChangeData",
-      "CampaignChangeData" => "CampaignChangeData",
-      "CustomerSyncError" => "CustomerSyncError",
-      "FeedChangeData" => "FeedChangeData",
-      "CustomerChangeData" => "CustomerChangeData",
-      "CustomerSyncSelector" => "CustomerSyncSelector",
-      "ChangeStatus" => "ChangeStatus",
-      "CustomerSyncError.Reason" => "CustomerSyncErrorReason",
-      "get" => "CustomerSyncServiceGet",
-      "getResponse" => "CustomerSyncServiceGetResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateTimeRange" => "Google_Api_Ads_AdWords_v201402\\DateTimeRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "AdGroupChangeData" => "Google_Api_Ads_AdWords_v201402\\AdGroupChangeData",
+      "CampaignChangeData" => "Google_Api_Ads_AdWords_v201402\\CampaignChangeData",
+      "CustomerSyncError" => "Google_Api_Ads_AdWords_v201402\\CustomerSyncError",
+      "FeedChangeData" => "Google_Api_Ads_AdWords_v201402\\FeedChangeData",
+      "CustomerChangeData" => "Google_Api_Ads_AdWords_v201402\\CustomerChangeData",
+      "CustomerSyncSelector" => "Google_Api_Ads_AdWords_v201402\\CustomerSyncSelector",
+      "ChangeStatus" => "Google_Api_Ads_AdWords_v201402\\ChangeStatus",
+      "CustomerSyncError.Reason" => "Google_Api_Ads_AdWords_v201402\\CustomerSyncErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\CustomerSyncServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\CustomerSyncServiceGetResponse",
     );
 
 
@@ -2643,3 +2643,4 @@ if (!class_exists("CustomerSyncService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/DataService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/DataService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -174,7 +174,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -228,7 +228,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -364,7 +364,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -436,7 +436,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -533,7 +533,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -612,7 +612,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeLandscapePoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidLandscapeLandscapePoint", false)) {
   /**
    * A set of estimates for a criterion's performance for a specific bid
    * amount.
@@ -688,7 +688,7 @@ if (!class_exists("BidLandscapeLandscapePoint", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -756,7 +756,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("DataEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DataEntry", false)) {
   /**
    * The base class of all return types of the table service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -828,7 +828,7 @@ if (!class_exists("DataEntry", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -907,7 +907,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapeType", false)) {
   /**
    * Used to specify the type of {@code AdGroupLandscape}
    * @package Google_Api_Ads_AdWords_v201402
@@ -940,7 +940,7 @@ if (!class_exists("AdGroupBidLandscapeType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -973,7 +973,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1006,7 +1006,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1039,7 +1039,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1073,7 +1073,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1106,7 +1106,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1139,7 +1139,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1172,7 +1172,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1205,7 +1205,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1238,7 +1238,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1271,7 +1271,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1304,7 +1304,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1337,7 +1337,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1370,7 +1370,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1404,7 +1404,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1437,7 +1437,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1470,7 +1470,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1503,7 +1503,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1536,7 +1536,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1569,7 +1569,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1602,7 +1602,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1635,7 +1635,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1668,7 +1668,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1701,7 +1701,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1734,7 +1734,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("DataErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DataErrorReason", false)) {
   /**
    * Reasons for error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1767,13 +1767,16 @@ if (!class_exists("DataErrorReason", false)) {
   }
 }
 
-if (!class_exists("GetAdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetAdGroupBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the ad groups specified in the selector.
+   * Returns a list of {@link AdGroupBidLandscape}s for the ad groups specified in the selector.
+   * In the result, the returned {@link LandscapePoint}s are grouped into
+   * {@link AdGroupBidLandscape}s by their ad groups, and numberResults of paging limits the total
+   * number of {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
    * 
    * @param serviceSelector Selects the entities to return bid landscapes for.
    * @return A list of bid landscapes.
@@ -1815,7 +1818,7 @@ if (!class_exists("GetAdGroupBidLandscape", false)) {
   }
 }
 
-if (!class_exists("GetAdGroupBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetAdGroupBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1855,13 +1858,16 @@ if (!class_exists("GetAdGroupBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("GetCriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetCriterionBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the criteria specified in the selector.
+   * Returns a list of {@link CriterionBidLandscape}s for the criteria specified in the selector.
+   * In the result, the returned {@link LandscapePoint}s are grouped into
+   * {@link CriterionBidLandscape}s by their criteria, and numberResults of paging limits the total
+   * number of {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
    * 
    * @param serviceSelector Selects the entities to return bid landscapes for.
    * @return A list of bid landscapes.
@@ -1903,7 +1909,7 @@ if (!class_exists("GetCriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("GetCriterionBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetCriterionBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1943,13 +1949,16 @@ if (!class_exists("GetCriterionBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("QueryAdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryAdGroupBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the ad groups that match the query.
+   * Returns a list of {@link AdGroupBidLandscape}s for the ad groups that match the query. In the
+   * result, the returned {@link LandscapePoint}s are grouped into {@link AdGroupBidLandscape}s
+   * by their ad groups, and numberResults of paging limits the total number of
+   * {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
    * 
    * @param query The SQL-like AWQL query string.
    * @return A list of bid landscapes.
@@ -1991,7 +2000,7 @@ if (!class_exists("QueryAdGroupBidLandscape", false)) {
   }
 }
 
-if (!class_exists("QueryAdGroupBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryAdGroupBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2031,13 +2040,16 @@ if (!class_exists("QueryAdGroupBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("QueryCriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryCriterionBidLandscape", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
    * 
    * 
-   * Returns a list of bid landscapes for the criteria that match the query.
+   * Returns a list of {@link CriterionBidLandscape}s for the criteria that match the query. In the
+   * result, the returned {@link LandscapePoint}s are grouped into {@link CriterionBidLandscape}s
+   * by their criteria, and numberResults of paging limits the total number of
+   * {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
    * 
    * @param query The SQL-like AWQL query string.
    * @return A list of bid landscapes.
@@ -2079,7 +2091,7 @@ if (!class_exists("QueryCriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("QueryCriterionBidLandscapeResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryCriterionBidLandscapeResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2119,7 +2131,7 @@ if (!class_exists("QueryCriterionBidLandscapeResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2164,7 +2176,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2209,7 +2221,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2254,7 +2266,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2299,7 +2311,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2344,7 +2356,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2389,7 +2401,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2434,7 +2446,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2481,7 +2493,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2523,7 +2535,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2568,7 +2580,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2613,7 +2625,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2648,7 +2660,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2700,7 +2712,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2745,7 +2757,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2790,7 +2802,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2856,7 +2868,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2901,7 +2913,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2946,7 +2958,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2992,7 +3004,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3037,7 +3049,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3082,7 +3094,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3127,7 +3139,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3173,7 +3185,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DataError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DataError", false)) {
   /**
    * Represents errors thrown by the get operation.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3218,7 +3230,7 @@ if (!class_exists("DataError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3263,7 +3275,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3306,7 +3318,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidLandscape", false)) {
   /**
    * Represents data about a bid landscape for an ad group or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3376,7 +3388,7 @@ if (!class_exists("BidLandscape", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3412,7 +3424,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscape", false)) {
   /**
    * Represents data about a bidlandscape for an adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3465,7 +3477,7 @@ if (!class_exists("AdGroupBidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionBidLandscape", false)) {
   /**
    * The bid landscape for a criterion.  A bid landscape estimates how a
    * a criterion will perform based on different bid amounts.
@@ -3512,7 +3524,7 @@ if (!class_exists("CriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3553,7 +3565,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3594,7 +3606,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapePage", false)) {
   /**
    * Contains a subset of {@link AdGroupBidLandscape} objects resulting from the
    * filtering and paging of
@@ -3638,7 +3650,7 @@ if (!class_exists("AdGroupBidLandscapePage", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscapePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionBidLandscapePage", false)) {
   /**
    * Contains a subset of {@link CriterionBidLandscapePage} objects resulting from the
    * filtering and paging of
@@ -3688,7 +3700,7 @@ if (!class_exists("DataService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class DataService extends AdWordsSoapClient {
+  class DataService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "DataService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3705,87 +3717,87 @@ if (!class_exists("DataService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupBidLandscape" => "AdGroupBidLandscape",
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CriterionBidLandscape" => "CriterionBidLandscape",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "LongValue" => "LongValue",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DataError" => "DataError",
-      "ComparableValue" => "ComparableValue",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "BidLandscape.LandscapePoint" => "BidLandscapeLandscapePoint",
-      "Selector" => "Selector",
-      "BidLandscape" => "BidLandscape",
-      "DataEntry" => "DataEntry",
-      "AdGroupBidLandscapePage" => "AdGroupBidLandscapePage",
-      "CriterionBidLandscapePage" => "CriterionBidLandscapePage",
-      "NoStatsPage" => "NoStatsPage",
-      "Page" => "Page",
-      "AdGroupBidLandscape.Type" => "AdGroupBidLandscapeType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "DataError.Reason" => "DataErrorReason",
-      "getAdGroupBidLandscape" => "GetAdGroupBidLandscape",
-      "getAdGroupBidLandscapeResponse" => "GetAdGroupBidLandscapeResponse",
-      "getCriterionBidLandscape" => "GetCriterionBidLandscape",
-      "getCriterionBidLandscapeResponse" => "GetCriterionBidLandscapeResponse",
-      "queryAdGroupBidLandscape" => "QueryAdGroupBidLandscape",
-      "queryAdGroupBidLandscapeResponse" => "QueryAdGroupBidLandscapeResponse",
-      "queryCriterionBidLandscape" => "QueryCriterionBidLandscape",
-      "queryCriterionBidLandscapeResponse" => "QueryCriterionBidLandscapeResponse",
+      "AdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscape",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CriterionBidLandscape" => "Google_Api_Ads_AdWords_v201402\\CriterionBidLandscape",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DataError" => "Google_Api_Ads_AdWords_v201402\\DataError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "BidLandscape.LandscapePoint" => "Google_Api_Ads_AdWords_v201402\\BidLandscapeLandscapePoint",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "BidLandscape" => "Google_Api_Ads_AdWords_v201402\\BidLandscape",
+      "DataEntry" => "Google_Api_Ads_AdWords_v201402\\DataEntry",
+      "AdGroupBidLandscapePage" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapePage",
+      "CriterionBidLandscapePage" => "Google_Api_Ads_AdWords_v201402\\CriterionBidLandscapePage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AdGroupBidLandscape.Type" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapeType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "DataError.Reason" => "Google_Api_Ads_AdWords_v201402\\DataErrorReason",
+      "getAdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201402\\GetAdGroupBidLandscape",
+      "getAdGroupBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201402\\GetAdGroupBidLandscapeResponse",
+      "getCriterionBidLandscape" => "Google_Api_Ads_AdWords_v201402\\GetCriterionBidLandscape",
+      "getCriterionBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201402\\GetCriterionBidLandscapeResponse",
+      "queryAdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201402\\QueryAdGroupBidLandscape",
+      "queryAdGroupBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201402\\QueryAdGroupBidLandscapeResponse",
+      "queryCriterionBidLandscape" => "Google_Api_Ads_AdWords_v201402\\QueryCriterionBidLandscape",
+      "queryCriterionBidLandscapeResponse" => "Google_Api_Ads_AdWords_v201402\\QueryCriterionBidLandscapeResponse",
     );
 
 
@@ -3804,7 +3816,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the ad groups specified in the selector.
+     * Returns a list of {@link AdGroupBidLandscape}s for the ad groups specified in the selector.
+     * In the result, the returned {@link LandscapePoint}s are grouped into
+     * {@link AdGroupBidLandscape}s by their ad groups, and numberResults of paging limits the total
+     * number of {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
      * 
      * @param serviceSelector Selects the entities to return bid landscapes for.
      * @return A list of bid landscapes.
@@ -3820,7 +3835,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the criteria specified in the selector.
+     * Returns a list of {@link CriterionBidLandscape}s for the criteria specified in the selector.
+     * In the result, the returned {@link LandscapePoint}s are grouped into
+     * {@link CriterionBidLandscape}s by their criteria, and numberResults of paging limits the total
+     * number of {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
      * 
      * @param serviceSelector Selects the entities to return bid landscapes for.
      * @return A list of bid landscapes.
@@ -3836,7 +3854,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the ad groups that match the query.
+     * Returns a list of {@link AdGroupBidLandscape}s for the ad groups that match the query. In the
+     * result, the returned {@link LandscapePoint}s are grouped into {@link AdGroupBidLandscape}s
+     * by their ad groups, and numberResults of paging limits the total number of
+     * {@link LandscapePoint}s instead of number of {@link AdGroupBidLandscape}s.
      * 
      * @param query The SQL-like AWQL query string.
      * @return A list of bid landscapes.
@@ -3852,7 +3873,10 @@ if (!class_exists("DataService", false)) {
      * 
      * 
      * 
-     * Returns a list of bid landscapes for the criteria that match the query.
+     * Returns a list of {@link CriterionBidLandscape}s for the criteria that match the query. In the
+     * result, the returned {@link LandscapePoint}s are grouped into {@link CriterionBidLandscape}s
+     * by their criteria, and numberResults of paging limits the total number of
+     * {@link LandscapePoint}s instead of number of {@link CriterionBidLandscape}s.
      * 
      * @param query The SQL-like AWQL query string.
      * @return A list of bid landscapes.
@@ -3865,3 +3889,4 @@ if (!class_exists("DataService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ExperimentService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ExperimentService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("ExperimentSummaryStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentSummaryStats", false)) {
   /**
    * Contains how many changes were made associated with an experiment at
    * the adgroup, critieria and creative levels
@@ -133,7 +133,7 @@ if (!class_exists("ExperimentSummaryStats", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -180,7 +180,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -229,7 +229,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -283,7 +283,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -351,7 +351,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -419,7 +419,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("Experiment", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Experiment", false)) {
   /**
    * Class representing a experiment for the ExperimentService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -529,7 +529,7 @@ if (!class_exists("Experiment", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -601,7 +601,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -681,7 +681,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -760,7 +760,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -857,7 +857,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -936,7 +936,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1004,7 +1004,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1037,7 +1037,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1070,7 +1070,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1103,7 +1103,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1136,7 +1136,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1170,7 +1170,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1203,7 +1203,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1236,7 +1236,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1269,7 +1269,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1303,7 +1303,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1336,7 +1336,7 @@ if (!class_exists("ExperimentServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServingStatus", false)) {
   /**
    * Experiment is currently active and receiving traffic
    * @package Google_Api_Ads_AdWords_v201402
@@ -1369,7 +1369,7 @@ if (!class_exists("ExperimentServingStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentStatus", false)) {
   /**
    * Experiment status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1402,7 +1402,7 @@ if (!class_exists("ExperimentStatus", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1435,7 +1435,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1468,7 +1468,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1501,7 +1501,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1534,7 +1534,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1567,7 +1567,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1600,7 +1600,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1633,7 +1633,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1666,7 +1666,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1699,7 +1699,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1733,7 +1733,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1766,7 +1766,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1799,7 +1799,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1832,7 +1832,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1865,7 +1865,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1898,7 +1898,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1931,7 +1931,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1964,7 +1964,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1997,7 +1997,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2030,7 +2030,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2063,7 +2063,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2096,7 +2096,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2145,7 +2145,7 @@ if (!class_exists("ExperimentServiceGet", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2185,7 +2185,7 @@ if (!class_exists("ExperimentServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2239,7 +2239,7 @@ if (!class_exists("ExperimentServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2279,7 +2279,7 @@ if (!class_exists("ExperimentServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2324,7 +2324,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2369,7 +2369,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2414,7 +2414,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2459,7 +2459,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2504,7 +2504,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2549,7 +2549,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2594,7 +2594,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2640,7 +2640,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExperimentServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentServiceError", false)) {
   /**
    * Base error class for Experiment Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2685,7 +2685,7 @@ if (!class_exists("ExperimentServiceError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2730,7 +2730,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2777,7 +2777,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2822,7 +2822,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2867,7 +2867,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2912,7 +2912,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2957,7 +2957,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3002,7 +3002,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3047,7 +3047,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3099,7 +3099,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3144,7 +3144,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3210,7 +3210,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3255,7 +3255,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3300,7 +3300,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3346,7 +3346,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3391,7 +3391,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3436,7 +3436,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3481,7 +3481,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3527,7 +3527,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3572,7 +3572,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ExperimentOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentOperation", false)) {
   /**
    * Operation for adding, updating or removing operations. For removing,
    * use SET and mark status as DELETED.
@@ -3616,7 +3616,7 @@ if (!class_exists("ExperimentOperation", false)) {
   }
 }
 
-if (!class_exists("ExperimentPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentPage", false)) {
   /**
    * Contains a subset of experiment resulting from the filtering and paging of the
    * {@link com.google.ads.api.services.campaignmgmt.campaign.ExperimentService#get} call.
@@ -3660,7 +3660,7 @@ if (!class_exists("ExperimentPage", false)) {
   }
 }
 
-if (!class_exists("ExperimentReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentReturnValue", false)) {
   /**
    * A container for return values from the ExperimentService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3702,7 +3702,7 @@ if (!class_exists("ExperimentReturnValue", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3751,7 +3751,7 @@ if (!class_exists("ExperimentService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ExperimentService extends AdWordsSoapClient {
+  class ExperimentService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ExperimentService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3768,89 +3768,89 @@ if (!class_exists("ExperimentService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "ExperimentServiceError" => "ExperimentServiceError",
-      "ExperimentSummaryStats" => "ExperimentSummaryStats",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "Experiment" => "Experiment",
-      "ExperimentOperation" => "ExperimentOperation",
-      "ExperimentPage" => "ExperimentPage",
-      "ExperimentReturnValue" => "ExperimentReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentServiceError.Reason" => "ExperimentServiceErrorReason",
-      "ExperimentServingStatus" => "ExperimentServingStatus",
-      "ExperimentStatus" => "ExperimentStatus",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "ExperimentServiceGet",
-      "getResponse" => "ExperimentServiceGetResponse",
-      "mutate" => "ExperimentServiceMutate",
-      "mutateResponse" => "ExperimentServiceMutateResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201402\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ExperimentServiceError" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceError",
+      "ExperimentSummaryStats" => "Google_Api_Ads_AdWords_v201402\\ExperimentSummaryStats",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201402\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "Experiment" => "Google_Api_Ads_AdWords_v201402\\Experiment",
+      "ExperimentOperation" => "Google_Api_Ads_AdWords_v201402\\ExperimentOperation",
+      "ExperimentPage" => "Google_Api_Ads_AdWords_v201402\\ExperimentPage",
+      "ExperimentReturnValue" => "Google_Api_Ads_AdWords_v201402\\ExperimentReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ExperimentServiceError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceErrorReason",
+      "ExperimentServingStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentServingStatus",
+      "ExperimentStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentStatus",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\ExperimentServiceMutateResponse",
     );
 
 
@@ -3905,3 +3905,4 @@ if (!class_exists("ExperimentService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ExpressBusinessService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ExpressBusinessService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * 
@@ -116,7 +116,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -174,7 +174,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -226,7 +226,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * 
@@ -277,7 +277,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -381,7 +381,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -439,7 +439,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -511,7 +511,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -583,7 +583,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -684,7 +684,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -767,7 +767,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -839,7 +839,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -923,7 +923,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1006,7 +1006,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -1043,7 +1043,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -1080,7 +1080,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1118,7 +1118,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -1155,7 +1155,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1192,7 +1192,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1229,7 +1229,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1266,7 +1266,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1303,7 +1303,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1340,7 +1340,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1377,7 +1377,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1414,7 +1414,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1451,7 +1451,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1488,7 +1488,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1526,7 +1526,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1563,7 +1563,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1600,7 +1600,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1637,7 +1637,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1674,7 +1674,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1711,7 +1711,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1748,7 +1748,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1785,7 +1785,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1822,7 +1822,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1859,7 +1859,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1896,7 +1896,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessError", false)) {
   /**
    * Express business related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1941,7 +1941,7 @@ if (!class_exists("ExpressBusinessError", false)) {
   }
 }
 
-if (!class_exists("PhoneNumber", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PhoneNumber", false)) {
   /**
    * Phone number which contains the phone number string plus the region that the number is to be
    * from.
@@ -1989,7 +1989,7 @@ if (!class_exists("PhoneNumber", false)) {
   }
 }
 
-if (!class_exists("ExpressBusiness", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusiness", false)) {
   /**
    * Information about an AdWords Express business.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2071,7 +2071,7 @@ if (!class_exists("ExpressBusiness", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessOperation", false)) {
   /**
    * A typed {@link Operation} class that uses an instance of {@link ExpressBusiness} as its operand.
    * 
@@ -2118,7 +2118,7 @@ if (!class_exists("ExpressBusinessOperation", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2154,7 +2154,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessStatus", false)) {
   /**
    * Possible statusus of this business.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2187,7 +2187,7 @@ if (!class_exists("ExpressBusinessStatus", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessErrorReason", false)) {
   /**
    * Reason behind the {@code BusinessError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2220,7 +2220,7 @@ if (!class_exists("ExpressBusinessErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCode", false)) {
   /**
    * A region (country, territory, continent, etc), as defined by Unicode's
    * "CLDR", itself based on ISO 3166 (UN country codes).
@@ -2319,7 +2319,7 @@ if (!class_exists("RegionCode", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2366,7 +2366,7 @@ if (!class_exists("ExpressBusinessServiceGet", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2406,7 +2406,7 @@ if (!class_exists("ExpressBusinessServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceMutate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: ADD, SET.</span>
@@ -2455,7 +2455,7 @@ if (!class_exists("ExpressBusinessServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2495,7 +2495,7 @@ if (!class_exists("ExpressBusinessServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2544,7 +2544,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2593,7 +2593,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -2642,7 +2642,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -2691,7 +2691,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -2740,7 +2740,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -2789,7 +2789,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2840,7 +2840,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -2889,7 +2889,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -2938,7 +2938,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -2987,7 +2987,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3036,7 +3036,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3085,7 +3085,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3155,7 +3155,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3204,7 +3204,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3253,7 +3253,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3303,7 +3303,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3352,7 +3352,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3401,7 +3401,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3450,7 +3450,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3500,7 +3500,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3549,7 +3549,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3596,7 +3596,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ExpressBusinessPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressBusinessPage", false)) {
   /**
    * Contains a page of {@link ExpressBusiness}es with no stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3643,7 +3643,7 @@ if (!class_exists("ExpressBusinessService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ExpressBusinessService extends AdWordsSoapClient {
+  class ExpressBusinessService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ExpressBusinessService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201402";
@@ -3660,79 +3660,79 @@ if (!class_exists("ExpressBusinessService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ExpressBusinessError" => "ExpressBusinessError",
-      "PhoneNumber" => "PhoneNumber",
-      "ExpressBusiness" => "ExpressBusiness",
-      "ExpressBusinessOperation" => "ExpressBusinessOperation",
-      "ExpressBusinessPage" => "ExpressBusinessPage",
-      "NoStatsPage" => "NoStatsPage",
-      "ExpressBusiness.Status" => "ExpressBusinessStatus",
-      "ExpressBusinessError.Reason" => "ExpressBusinessErrorReason",
-      "RegionCode" => "RegionCode",
-      "get" => "ExpressBusinessServiceGet",
-      "getResponse" => "ExpressBusinessServiceGetResponse",
-      "mutate" => "ExpressBusinessServiceMutate",
-      "mutateResponse" => "ExpressBusinessServiceMutateResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "Date" => "Google_Api_Ads_AdWords_v201402\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "ExpressBusinessError" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessError",
+      "PhoneNumber" => "Google_Api_Ads_AdWords_v201402\\PhoneNumber",
+      "ExpressBusiness" => "Google_Api_Ads_AdWords_v201402\\ExpressBusiness",
+      "ExpressBusinessOperation" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessOperation",
+      "ExpressBusinessPage" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessPage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "ExpressBusiness.Status" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessStatus",
+      "ExpressBusinessError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessErrorReason",
+      "RegionCode" => "Google_Api_Ads_AdWords_v201402\\RegionCode",
+      "get" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\ExpressBusinessServiceMutateResponse",
     );
 
 
@@ -3780,3 +3780,4 @@ if (!class_exists("ExpressBusinessService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/FeedItemService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/FeedItemService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemAttributeError", false)) {
   /**
    * Contains validation error details for a set of feed attributes.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("FeedItemAttributeError", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemAttributeValue", false)) {
   /**
    * Represents a feed item's value for a particular feed attribute. A feed item's value is
    * composed of a collection of these attribute values.
@@ -194,7 +194,7 @@ if (!class_exists("FeedItemAttributeValue", false)) {
   }
 }
 
-if (!class_exists("FeedItemDevicePreference", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemDevicePreference", false)) {
   /**
    * Represents a FeedItem device preference.
    * @package Google_Api_Ads_AdWords_v201402
@@ -234,7 +234,7 @@ if (!class_exists("FeedItemDevicePreference", false)) {
   }
 }
 
-if (!class_exists("FeedItemSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemSchedule", false)) {
   /**
    * Represents a FeedItem schedule, which specifies a time interval on a given day
    * when the feed item may serve. The FeedItemSchedule times are in the account's time zone.
@@ -303,7 +303,7 @@ if (!class_exists("FeedItemSchedule", false)) {
   }
 }
 
-if (!class_exists("FeedItemScheduling", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemScheduling", false)) {
   /**
    * Represents a collection of FeedItem schedules specifying all time intervals for which
    * the feed item may serve. Any time range not covered by the specified FeedItemSchedules will
@@ -345,7 +345,7 @@ if (!class_exists("FeedItemScheduling", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -392,7 +392,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -441,7 +441,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -495,7 +495,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -563,7 +563,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -631,7 +631,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetail", false)) {
   /**
    * Contains offline-validation and approval results for a given FeedItem and FeedMapping. Each
    * validation detail indicates any issues found on the feed item when used in the context
@@ -694,7 +694,7 @@ if (!class_exists("FeedItemValidationDetail", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -791,7 +791,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -870,7 +870,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("FeedItem", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItem", false)) {
   /**
    * Represents an item in a feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -966,7 +966,7 @@ if (!class_exists("FeedItem", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1038,7 +1038,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1118,7 +1118,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1186,7 +1186,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1265,7 +1265,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1298,7 +1298,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1331,7 +1331,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1365,7 +1365,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1398,7 +1398,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1431,7 +1431,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1464,7 +1464,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1497,7 +1497,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1530,7 +1530,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1564,7 +1564,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemStatus", false)) {
   /**
    * Feed item is active
    * @package Google_Api_Ads_AdWords_v201402
@@ -1597,7 +1597,7 @@ if (!class_exists("FeedItemStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemErrorReason", false)) {
   /**
    * The reasons for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1630,7 +1630,7 @@ if (!class_exists("FeedItemErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailApprovalStatus", false)) {
   /**
    * Feed item approval status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1663,7 +1663,7 @@ if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailValidationStatus", false)) {
   /**
    * Feed item validation status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1696,7 +1696,7 @@ if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1729,7 +1729,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1762,7 +1762,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201402
@@ -1795,7 +1795,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1828,7 +1828,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1861,7 +1861,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1894,7 +1894,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1927,7 +1927,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1960,7 +1960,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1993,7 +1993,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -2027,7 +2027,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2060,7 +2060,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2093,7 +2093,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2126,7 +2126,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2159,7 +2159,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2192,7 +2192,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2225,7 +2225,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2258,7 +2258,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2291,7 +2291,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2324,7 +2324,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2357,7 +2357,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2406,7 +2406,7 @@ if (!class_exists("FeedItemServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2446,7 +2446,7 @@ if (!class_exists("FeedItemServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2497,7 +2497,7 @@ if (!class_exists("FeedItemServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedItemServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2537,7 +2537,7 @@ if (!class_exists("FeedItemServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2585,7 +2585,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2625,7 +2625,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2670,7 +2670,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2715,7 +2715,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2760,7 +2760,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2805,7 +2805,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2850,7 +2850,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2924,7 +2924,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2970,7 +2970,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedItemError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemError", false)) {
   /**
    * FeedItemService related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3015,7 +3015,7 @@ if (!class_exists("FeedItemError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3060,7 +3060,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3107,7 +3107,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3152,7 +3152,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3197,7 +3197,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3242,7 +3242,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3294,7 +3294,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3339,7 +3339,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3384,7 +3384,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3450,7 +3450,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3495,7 +3495,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3540,7 +3540,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3586,7 +3586,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3631,7 +3631,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3676,7 +3676,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3721,7 +3721,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3767,7 +3767,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3812,7 +3812,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3855,7 +3855,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedItemOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemOperation", false)) {
   /**
    * FeedItem service mutate operation.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3898,7 +3898,7 @@ if (!class_exists("FeedItemOperation", false)) {
   }
 }
 
-if (!class_exists("FeedItemReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemReturnValue", false)) {
   /**
    * A container for return values from FeedItemService.mutate().
    * @package Google_Api_Ads_AdWords_v201402
@@ -3947,7 +3947,7 @@ if (!class_exists("FeedItemReturnValue", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3983,7 +3983,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("FeedItemPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemPage", false)) {
   /**
    * Contains a subset of feed items resulting from a {@link FeedItemService#get} call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4030,7 +4030,7 @@ if (!class_exists("FeedItemService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class FeedItemService extends AdWordsSoapClient {
+  class FeedItemService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedItemService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -4047,94 +4047,94 @@ if (!class_exists("FeedItemService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedItemAttributeError" => "FeedItemAttributeError",
-      "FeedItemAttributeValue" => "FeedItemAttributeValue",
-      "FeedItemDevicePreference" => "FeedItemDevicePreference",
-      "FeedItemError" => "FeedItemError",
-      "FeedItemSchedule" => "FeedItemSchedule",
-      "FeedItemScheduling" => "FeedItemScheduling",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "FeedItemValidationDetail" => "FeedItemValidationDetail",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "FeedItem" => "FeedItem",
-      "FeedItemOperation" => "FeedItemOperation",
-      "FeedItemPage" => "FeedItemPage",
-      "FeedItemReturnValue" => "FeedItemReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "Selector" => "Selector",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "FeedItem.Status" => "FeedItemStatus",
-      "FeedItemError.Reason" => "FeedItemErrorReason",
-      "FeedItemValidationDetail.ApprovalStatus" => "FeedItemValidationDetailApprovalStatus",
-      "FeedItemValidationDetail.ValidationStatus" => "FeedItemValidationDetailValidationStatus",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MinuteOfHour" => "MinuteOfHour",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedItemServiceGet",
-      "getResponse" => "FeedItemServiceGetResponse",
-      "mutate" => "FeedItemServiceMutate",
-      "mutateResponse" => "FeedItemServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedItemAttributeError" => "Google_Api_Ads_AdWords_v201402\\FeedItemAttributeError",
+      "FeedItemAttributeValue" => "Google_Api_Ads_AdWords_v201402\\FeedItemAttributeValue",
+      "FeedItemDevicePreference" => "Google_Api_Ads_AdWords_v201402\\FeedItemDevicePreference",
+      "FeedItemError" => "Google_Api_Ads_AdWords_v201402\\FeedItemError",
+      "FeedItemSchedule" => "Google_Api_Ads_AdWords_v201402\\FeedItemSchedule",
+      "FeedItemScheduling" => "Google_Api_Ads_AdWords_v201402\\FeedItemScheduling",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "FeedItemValidationDetail" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetail",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "FeedItem" => "Google_Api_Ads_AdWords_v201402\\FeedItem",
+      "FeedItemOperation" => "Google_Api_Ads_AdWords_v201402\\FeedItemOperation",
+      "FeedItemPage" => "Google_Api_Ads_AdWords_v201402\\FeedItemPage",
+      "FeedItemReturnValue" => "Google_Api_Ads_AdWords_v201402\\FeedItemReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201402\\DayOfWeek",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "FeedItem.Status" => "Google_Api_Ads_AdWords_v201402\\FeedItemStatus",
+      "FeedItemError.Reason" => "Google_Api_Ads_AdWords_v201402\\FeedItemErrorReason",
+      "FeedItemValidationDetail.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailApprovalStatus",
+      "FeedItemValidationDetail.ValidationStatus" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailValidationStatus",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201402\\MinuteOfHour",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\FeedItemServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\FeedItemServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\FeedItemServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\FeedItemServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4202,3 +4202,4 @@ if (!class_exists("FeedItemService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/FeedMappingService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/FeedMappingService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("AttributeFieldMapping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AttributeFieldMapping", false)) {
   /**
    * Represents a mapping between a feed attribute and a placeholder field.
    * 
@@ -82,7 +82,7 @@ if (!class_exists("AttributeFieldMapping", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -130,7 +130,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedMapping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMapping", false)) {
   /**
    * A FeedMapping represents a mapping between feed attributes in a specific feed
    * and placeholder fields for a specific placeholder type. This will tell the
@@ -214,7 +214,7 @@ if (!class_exists("FeedMapping", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -286,7 +286,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -366,7 +366,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -413,7 +413,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -492,7 +492,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -541,7 +541,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -595,7 +595,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -663,7 +663,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -731,7 +731,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -828,7 +828,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -907,7 +907,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -975,7 +975,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1008,7 +1008,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1041,7 +1041,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1075,7 +1075,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1108,7 +1108,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1141,7 +1141,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1175,7 +1175,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedMappingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingStatus", false)) {
   /**
    * This mapping is used in feeds.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1208,7 +1208,7 @@ if (!class_exists("FeedMappingStatus", false)) {
   }
 }
 
-if (!class_exists("FeedMappingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingErrorReason", false)) {
   /**
    * The given placeholder field does not exist.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1241,7 +1241,7 @@ if (!class_exists("FeedMappingErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1274,7 +1274,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1307,7 +1307,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1340,7 +1340,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1373,7 +1373,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1406,7 +1406,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1439,7 +1439,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1472,7 +1472,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1505,7 +1505,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1539,7 +1539,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1572,7 +1572,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1605,7 +1605,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1638,7 +1638,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1671,7 +1671,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1704,7 +1704,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1737,7 +1737,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1770,7 +1770,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1803,7 +1803,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1836,7 +1836,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1869,7 +1869,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1918,7 +1918,7 @@ if (!class_exists("FeedMappingServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1958,7 +1958,7 @@ if (!class_exists("FeedMappingServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2009,7 +2009,7 @@ if (!class_exists("FeedMappingServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedMappingServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2049,7 +2049,7 @@ if (!class_exists("FeedMappingServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2097,7 +2097,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2137,7 +2137,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2182,7 +2182,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2227,7 +2227,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2272,7 +2272,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2317,7 +2317,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2363,7 +2363,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedMappingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingError", false)) {
   /**
    * Errors caused by invalid usage of FeedMappingService
    * @package Google_Api_Ads_AdWords_v201402
@@ -2408,7 +2408,7 @@ if (!class_exists("FeedMappingError", false)) {
   }
 }
 
-if (!class_exists("FeedMappingOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingOperation", false)) {
   /**
    * Operation used to create a FeedMapping.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2451,7 +2451,7 @@ if (!class_exists("FeedMappingOperation", false)) {
   }
 }
 
-if (!class_exists("FeedMappingReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingReturnValue", false)) {
   /**
    * The result of a call to {@link FeedMappingService#mutate}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2493,7 +2493,7 @@ if (!class_exists("FeedMappingReturnValue", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2538,7 +2538,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2585,7 +2585,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2630,7 +2630,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2666,7 +2666,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2711,7 +2711,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2756,7 +2756,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2808,7 +2808,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2853,7 +2853,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2898,7 +2898,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2964,7 +2964,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3009,7 +3009,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3054,7 +3054,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3100,7 +3100,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3145,7 +3145,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3190,7 +3190,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3235,7 +3235,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3281,7 +3281,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3326,7 +3326,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3369,7 +3369,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedMappingPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedMappingPage", false)) {
   /**
    * The result of a call to {@link FeedMappingService#get}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3416,7 +3416,7 @@ if (!class_exists("FeedMappingService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class FeedMappingService extends AdWordsSoapClient {
+  class FeedMappingService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedMappingService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3433,81 +3433,81 @@ if (!class_exists("FeedMappingService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AttributeFieldMapping" => "AttributeFieldMapping",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedMapping" => "FeedMapping",
-      "FeedMappingError" => "FeedMappingError",
-      "FeedMappingOperation" => "FeedMappingOperation",
-      "FeedMappingPage" => "FeedMappingPage",
-      "FeedMappingReturnValue" => "FeedMappingReturnValue",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "ListReturnValue" => "ListReturnValue",
-      "NotEmptyError" => "NotEmptyError",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "FeedMapping.Status" => "FeedMappingStatus",
-      "FeedMappingError.Reason" => "FeedMappingErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedMappingServiceGet",
-      "getResponse" => "FeedMappingServiceGetResponse",
-      "mutate" => "FeedMappingServiceMutate",
-      "mutateResponse" => "FeedMappingServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AttributeFieldMapping" => "Google_Api_Ads_AdWords_v201402\\AttributeFieldMapping",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedMapping" => "Google_Api_Ads_AdWords_v201402\\FeedMapping",
+      "FeedMappingError" => "Google_Api_Ads_AdWords_v201402\\FeedMappingError",
+      "FeedMappingOperation" => "Google_Api_Ads_AdWords_v201402\\FeedMappingOperation",
+      "FeedMappingPage" => "Google_Api_Ads_AdWords_v201402\\FeedMappingPage",
+      "FeedMappingReturnValue" => "Google_Api_Ads_AdWords_v201402\\FeedMappingReturnValue",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "FeedMapping.Status" => "Google_Api_Ads_AdWords_v201402\\FeedMappingStatus",
+      "FeedMappingError.Reason" => "Google_Api_Ads_AdWords_v201402\\FeedMappingErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\FeedMappingServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\FeedMappingServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\FeedMappingServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\FeedMappingServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -3575,3 +3575,4 @@ if (!class_exists("FeedMappingService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/FeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/FeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("FeedAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedAttribute", false)) {
   /**
    * FeedAttributes define the types of data expected to be present in a Feed. A single FeedAttribute
    * specifies the expected type of the FeedItemAttributes with the same FeedAttributeId. Optionally,
@@ -141,7 +141,7 @@ if (!class_exists("FeedAttribute", false)) {
   }
 }
 
-if (!class_exists("OAuthInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OAuthInfo", false)) {
   /**
    * Data used for authorization using OAuth.
    * For more information about OAuth, see:
@@ -197,7 +197,7 @@ if (!class_exists("OAuthInfo", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -244,7 +244,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -293,7 +293,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -347,7 +347,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -415,7 +415,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -483,7 +483,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("SystemFeedGenerationData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SystemFeedGenerationData", false)) {
   /**
    * Configuration data allowing feed items to be populated for a system feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -555,7 +555,7 @@ if (!class_exists("SystemFeedGenerationData", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -652,7 +652,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -731,7 +731,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Feed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Feed", false)) {
   /**
    * A Feed identifies a source of data and its schema. The data for the Feed can either be
    * user-entered via the FeedItemService or system-generated, in which case the data is provided
@@ -808,7 +808,7 @@ if (!class_exists("Feed", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -880,7 +880,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -960,7 +960,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1039,7 +1039,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1107,7 +1107,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1140,7 +1140,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1173,7 +1173,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1207,7 +1207,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1240,7 +1240,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1273,7 +1273,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1306,7 +1306,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1340,7 +1340,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("FeedOrigin", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedOrigin", false)) {
   /**
    * Used to Specify who manages the {@link FeedAttribute}s for the {@link Feed}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1373,7 +1373,7 @@ if (!class_exists("FeedOrigin", false)) {
   }
 }
 
-if (!class_exists("FeedStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedStatus", false)) {
   /**
    * Status of the Feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1406,7 +1406,7 @@ if (!class_exists("FeedStatus", false)) {
   }
 }
 
-if (!class_exists("FeedAttributeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedAttributeType", false)) {
   /**
    * Possible data types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1439,7 +1439,7 @@ if (!class_exists("FeedAttributeType", false)) {
   }
 }
 
-if (!class_exists("FeedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedErrorReason", false)) {
   /**
    * Error reasons.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1472,7 +1472,7 @@ if (!class_exists("FeedErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1505,7 +1505,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1538,7 +1538,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1571,7 +1571,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1604,7 +1604,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1637,7 +1637,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1670,7 +1670,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1703,7 +1703,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1736,7 +1736,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1769,7 +1769,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1803,7 +1803,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1836,7 +1836,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1869,7 +1869,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1902,7 +1902,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1935,7 +1935,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1968,7 +1968,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2001,7 +2001,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2034,7 +2034,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2067,7 +2067,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2100,7 +2100,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2133,7 +2133,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2182,7 +2182,7 @@ if (!class_exists("FeedServiceGet", false)) {
   }
 }
 
-if (!class_exists("FeedServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2222,7 +2222,7 @@ if (!class_exists("FeedServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("FeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint DistinctIds">Elements in this field must have distinct IDs for following {@link Operator}s : SET, REMOVE.</span>
@@ -2273,7 +2273,7 @@ if (!class_exists("FeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("FeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2313,7 +2313,7 @@ if (!class_exists("FeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2361,7 +2361,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2401,7 +2401,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2446,7 +2446,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2491,7 +2491,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2536,7 +2536,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2581,7 +2581,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2655,7 +2655,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2701,7 +2701,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("FeedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedError", false)) {
   /**
    * An error caused by an invalid Feed in a FeedService request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2746,7 +2746,7 @@ if (!class_exists("FeedError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2791,7 +2791,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2838,7 +2838,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2883,7 +2883,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2928,7 +2928,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2973,7 +2973,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3018,7 +3018,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3070,7 +3070,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3115,7 +3115,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3160,7 +3160,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3226,7 +3226,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3271,7 +3271,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3316,7 +3316,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3362,7 +3362,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3407,7 +3407,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3452,7 +3452,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3497,7 +3497,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3543,7 +3543,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("PlacesLocationFeedData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacesLocationFeedData", false)) {
   /**
    * Data used to configure a location feed populated from
    * Google Places.
@@ -3607,7 +3607,7 @@ if (!class_exists("PlacesLocationFeedData", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3652,7 +3652,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3695,7 +3695,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("FeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedOperation", false)) {
   /**
    * Operation used to create or mutate a Feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3738,7 +3738,7 @@ if (!class_exists("FeedOperation", false)) {
   }
 }
 
-if (!class_exists("FeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedReturnValue", false)) {
   /**
    * The result of a call to FeedService#mutate.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3780,7 +3780,7 @@ if (!class_exists("FeedReturnValue", false)) {
   }
 }
 
-if (!class_exists("NullStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullStatsPage", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3816,7 +3816,7 @@ if (!class_exists("NullStatsPage", false)) {
   }
 }
 
-if (!class_exists("FeedPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedPage", false)) {
   /**
    * The result of a call to FeedService#get.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3863,7 +3863,7 @@ if (!class_exists("FeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class FeedService extends AdWordsSoapClient {
+  class FeedService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "FeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3880,90 +3880,90 @@ if (!class_exists("FeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "FeedAttribute" => "FeedAttribute",
-      "FeedError" => "FeedError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OAuthInfo" => "OAuthInfo",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "PlacesLocationFeedData" => "PlacesLocationFeedData",
-      "DatabaseError" => "DatabaseError",
-      "SystemFeedGenerationData" => "SystemFeedGenerationData",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Feed" => "Feed",
-      "FeedOperation" => "FeedOperation",
-      "FeedPage" => "FeedPage",
-      "FeedReturnValue" => "FeedReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "NullStatsPage" => "NullStatsPage",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "Selector" => "Selector",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "Feed.Origin" => "FeedOrigin",
-      "Feed.Status" => "FeedStatus",
-      "FeedAttribute.Type" => "FeedAttributeType",
-      "FeedError.Reason" => "FeedErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "FeedServiceGet",
-      "getResponse" => "FeedServiceGetResponse",
-      "mutate" => "FeedServiceMutate",
-      "mutateResponse" => "FeedServiceMutateResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "FeedAttribute" => "Google_Api_Ads_AdWords_v201402\\FeedAttribute",
+      "FeedError" => "Google_Api_Ads_AdWords_v201402\\FeedError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OAuthInfo" => "Google_Api_Ads_AdWords_v201402\\OAuthInfo",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "PlacesLocationFeedData" => "Google_Api_Ads_AdWords_v201402\\PlacesLocationFeedData",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "SystemFeedGenerationData" => "Google_Api_Ads_AdWords_v201402\\SystemFeedGenerationData",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Feed" => "Google_Api_Ads_AdWords_v201402\\Feed",
+      "FeedOperation" => "Google_Api_Ads_AdWords_v201402\\FeedOperation",
+      "FeedPage" => "Google_Api_Ads_AdWords_v201402\\FeedPage",
+      "FeedReturnValue" => "Google_Api_Ads_AdWords_v201402\\FeedReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "NullStatsPage" => "Google_Api_Ads_AdWords_v201402\\NullStatsPage",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "Feed.Origin" => "Google_Api_Ads_AdWords_v201402\\FeedOrigin",
+      "Feed.Status" => "Google_Api_Ads_AdWords_v201402\\FeedStatus",
+      "FeedAttribute.Type" => "Google_Api_Ads_AdWords_v201402\\FeedAttributeType",
+      "FeedError.Reason" => "Google_Api_Ads_AdWords_v201402\\FeedErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\FeedServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\FeedServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\FeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\FeedServiceMutateResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -4031,3 +4031,4 @@ if (!class_exists("FeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/GeoLocationService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/GeoLocationService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201402
@@ -112,7 +112,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("GeoLocationSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocationSelector", false)) {
   /**
    * A selector used to fetch geographic coordinates for given addresses.
    * @package Google_Api_Ads_AdWords_v201402
@@ -152,7 +152,7 @@ if (!class_exists("GeoLocationSelector", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201402
@@ -199,7 +199,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -267,7 +267,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -335,7 +335,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("GeoLocation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocation", false)) {
   /**
    * Class representing a location with its geographic coordinates.
    * @package Google_Api_Ads_AdWords_v201402
@@ -428,7 +428,7 @@ if (!class_exists("GeoLocation", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -525,7 +525,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -604,7 +604,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -637,7 +637,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -670,7 +670,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -704,7 +704,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -737,7 +737,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -770,7 +770,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoLocationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocationErrorReason", false)) {
   /**
    * The reasons for the geolocation errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -803,7 +803,7 @@ if (!class_exists("GeoLocationErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -836,7 +836,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -869,7 +869,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -902,7 +902,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -935,7 +935,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -969,7 +969,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1002,7 +1002,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1035,7 +1035,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1068,7 +1068,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1101,7 +1101,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1134,7 +1134,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1167,7 +1167,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1200,7 +1200,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1233,7 +1233,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1266,7 +1266,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("GeoLocationServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocationServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1315,7 +1315,7 @@ if (!class_exists("GeoLocationServiceGet", false)) {
   }
 }
 
-if (!class_exists("GeoLocationServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocationServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1355,7 +1355,7 @@ if (!class_exists("GeoLocationServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1400,7 +1400,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1445,7 +1445,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1490,7 +1490,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1535,7 +1535,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("GeoLocationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoLocationError", false)) {
   /**
    * Errors for {@link GeoLocationService}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1580,7 +1580,7 @@ if (!class_exists("GeoLocationError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1625,7 +1625,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1672,7 +1672,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("InvalidGeoLocation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InvalidGeoLocation", false)) {
   /**
    * Invalid GeoLocation object.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1710,7 +1710,7 @@ if (!class_exists("InvalidGeoLocation", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1755,7 +1755,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1800,7 +1800,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1845,7 +1845,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1890,7 +1890,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1956,7 +1956,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2001,7 +2001,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2046,7 +2046,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2091,7 +2091,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2137,7 +2137,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2182,7 +2182,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2227,7 +2227,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2273,7 +2273,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2318,7 +2318,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2367,7 +2367,7 @@ if (!class_exists("GeoLocationService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class GeoLocationService extends AdWordsSoapClient {
+  class GeoLocationService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "GeoLocationService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -2384,58 +2384,58 @@ if (!class_exists("GeoLocationService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DistinctError" => "DistinctError",
-      "GeoLocationError" => "GeoLocationError",
-      "GeoLocationSelector" => "GeoLocationSelector",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "InvalidGeoLocation" => "InvalidGeoLocation",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "GeoLocation" => "GeoLocation",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "GeoLocationError.Reason" => "GeoLocationErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "get" => "GeoLocationServiceGet",
-      "getResponse" => "GeoLocationServiceGetResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "GeoLocationError" => "Google_Api_Ads_AdWords_v201402\\GeoLocationError",
+      "GeoLocationSelector" => "Google_Api_Ads_AdWords_v201402\\GeoLocationSelector",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "InvalidGeoLocation" => "Google_Api_Ads_AdWords_v201402\\InvalidGeoLocation",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "GeoLocation" => "Google_Api_Ads_AdWords_v201402\\GeoLocation",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "GeoLocationError.Reason" => "Google_Api_Ads_AdWords_v201402\\GeoLocationErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\GeoLocationServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\GeoLocationServiceGetResponse",
     );
 
 
@@ -2468,3 +2468,4 @@ if (!class_exists("GeoLocationService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/LocationCriterionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/LocationCriterionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -127,7 +127,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -206,7 +206,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -251,7 +251,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -296,7 +296,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -341,7 +341,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -428,7 +428,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -473,7 +473,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Date", false)) {
   /**
    * Represents a date.
    * @package Google_Api_Ads_AdWords_v201402
@@ -527,7 +527,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -572,7 +572,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -620,7 +620,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -665,7 +665,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -710,7 +710,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -757,7 +757,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -809,10 +809,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -876,7 +876,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("LocationCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationCriterion", false)) {
   /**
    * Represents data that encapsulates a location criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -951,7 +951,7 @@ if (!class_exists("LocationCriterion", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceError", false)) {
   /**
    * Represents errors thrown by the {@link LocationCriterionService#get} operation.
    * @package Google_Api_Ads_AdWords_v201402
@@ -996,7 +996,7 @@ if (!class_exists("LocationCriterionServiceError", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1050,7 +1050,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1102,7 +1102,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1147,7 +1147,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1192,7 +1192,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1237,7 +1237,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1284,7 +1284,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1333,7 +1333,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1379,7 +1379,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1433,7 +1433,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1488,7 +1488,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1536,7 +1536,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1576,7 +1576,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1628,7 +1628,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1673,7 +1673,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1718,7 +1718,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1784,7 +1784,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1829,7 +1829,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1874,7 +1874,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1920,7 +1920,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1965,7 +1965,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2033,7 +2033,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2078,7 +2078,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2123,7 +2123,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2191,7 +2191,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2259,7 +2259,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2305,7 +2305,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2357,7 +2357,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2416,7 +2416,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2479,7 +2479,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2512,7 +2512,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2545,7 +2545,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2578,7 +2578,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2612,7 +2612,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2645,7 +2645,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2678,7 +2678,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2711,7 +2711,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2744,7 +2744,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2777,7 +2777,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2810,7 +2810,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -2844,7 +2844,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceErrorReason", false)) {
   /**
    * Reasons for error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2877,7 +2877,7 @@ if (!class_exists("LocationCriterionServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2910,7 +2910,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2943,7 +2943,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2976,7 +2976,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3009,7 +3009,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3042,7 +3042,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3075,7 +3075,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3109,7 +3109,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3142,7 +3142,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3175,7 +3175,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3208,7 +3208,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3241,7 +3241,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3274,7 +3274,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3307,7 +3307,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3340,7 +3340,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3373,7 +3373,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3406,7 +3406,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3439,7 +3439,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3472,7 +3472,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3520,7 +3520,7 @@ if (!class_exists("LocationCriterionServiceGet", false)) {
   }
 }
 
-if (!class_exists("LocationCriterionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3560,7 +3560,7 @@ if (!class_exists("LocationCriterionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3608,7 +3608,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3648,7 +3648,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3693,7 +3693,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3742,7 +3742,7 @@ if (!class_exists("LocationCriterionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class LocationCriterionService extends AdWordsSoapClient {
+  class LocationCriterionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "LocationCriterionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3759,88 +3759,88 @@ if (!class_exists("LocationCriterionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Criterion" => "Criterion",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Location" => "Location",
-      "LocationCriterion" => "LocationCriterion",
-      "LocationCriterionServiceError" => "LocationCriterionServiceError",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationCriterionServiceError.Reason" => "LocationCriterionServiceErrorReason",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "get" => "LocationCriterionServiceGet",
-      "getResponse" => "LocationCriterionServiceGetResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201402\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "LocationCriterion" => "Google_Api_Ads_AdWords_v201402\\LocationCriterion",
+      "LocationCriterionServiceError" => "Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceError",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "LocationCriterionServiceError.Reason" => "Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceErrorReason",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "get" => "Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\LocationCriterionServiceGetResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
     );
 
 
@@ -3888,3 +3888,4 @@ if (!class_exists("LocationCriterionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ManagedCustomerService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ManagedCustomerService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -82,7 +82,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -133,7 +133,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -186,7 +186,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -244,7 +244,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -316,7 +316,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -388,7 +388,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -489,7 +489,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -572,7 +572,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -644,7 +644,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -728,7 +728,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -811,7 +811,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -848,7 +848,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -885,7 +885,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -923,7 +923,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -960,7 +960,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -997,7 +997,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1034,7 +1034,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1071,7 +1071,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -1108,7 +1108,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1145,7 +1145,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1182,7 +1182,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -1219,7 +1219,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -1256,7 +1256,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -1293,7 +1293,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1331,7 +1331,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1368,7 +1368,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -1405,7 +1405,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1442,7 +1442,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1479,7 +1479,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -1516,7 +1516,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1553,7 +1553,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1590,7 +1590,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -1627,7 +1627,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -1664,7 +1664,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -1701,7 +1701,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceError", false)) {
   /**
    * Error for {@link ManagedCustomerService}
    * @package Google_Api_Ads_AdWords_v201402
@@ -1753,7 +1753,7 @@ if (!class_exists("ManagedCustomerServiceError", false)) {
   }
 }
 
-if (!class_exists("PendingInvitationSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PendingInvitationSelector", false)) {
   /**
    * Selector for getPendingInvitations method.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1800,7 +1800,7 @@ if (!class_exists("PendingInvitationSelector", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerLink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerLink", false)) {
   /**
    * Represents an AdWords manager-client link.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1861,7 +1861,7 @@ if (!class_exists("ManagedCustomerLink", false)) {
   }
 }
 
-if (!class_exists("LinkOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LinkOperation", false)) {
   /**
    * Operation for modifying ManagedCustomer links. See {@link ManagedCustomerService#mutateLink}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1904,7 +1904,7 @@ if (!class_exists("LinkOperation", false)) {
   }
 }
 
-if (!class_exists("MoveOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MoveOperation", false)) {
   /**
    * Operation for moving ManagedCustomer links. See {@link ManagedCustomerService#mutateManager}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1954,7 +1954,7 @@ if (!class_exists("MoveOperation", false)) {
   }
 }
 
-if (!class_exists("MutateLinkResults", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateLinkResults", false)) {
   /**
    * Results of a {@link ManagedCustomerService#mutateLink} call which changes
    * manager/client links.
@@ -1995,7 +1995,7 @@ if (!class_exists("MutateLinkResults", false)) {
   }
 }
 
-if (!class_exists("MutateManagerResults", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateManagerResults", false)) {
   /**
    * Results of a {@link ManagedCustomerService#mutateManager} call, which moves client customers to
    * new managers.
@@ -2036,7 +2036,7 @@ if (!class_exists("MutateManagerResults", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomer", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomer", false)) {
   /**
    * Data object that represents a managed customer.  Member of {@link ManagedCustomerPage}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2125,7 +2125,7 @@ if (!class_exists("ManagedCustomer", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerOperation", false)) {
   /**
    * An operation on a managed customer.
    * <p class="note"><b>Note:</b> only <code>ADD</code> operator is supported.</p>
@@ -2169,7 +2169,7 @@ if (!class_exists("ManagedCustomerOperation", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerPage", false)) {
   /**
    * Return result of {@link ManagedCustomerService}
    * @package Google_Api_Ads_AdWords_v201402
@@ -2219,7 +2219,7 @@ if (!class_exists("ManagedCustomerPage", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerReturnValue", false)) {
   /**
    * A container for return values from the ManagedCustomerService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2259,7 +2259,7 @@ if (!class_exists("ManagedCustomerReturnValue", false)) {
   }
 }
 
-if (!class_exists("PendingInvitation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PendingInvitation", false)) {
   /**
    * Pending invitation result for the getPendingInvitations method.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2320,7 +2320,7 @@ if (!class_exists("PendingInvitation", false)) {
   }
 }
 
-if (!class_exists("LinkStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LinkStatus", false)) {
   /**
    * These status values match the values in the ServicedAccounts.Status column.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2353,7 +2353,7 @@ if (!class_exists("LinkStatus", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceErrorReason", false)) {
   /**
    * Unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2386,7 +2386,7 @@ if (!class_exists("ManagedCustomerServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2434,7 +2434,7 @@ if (!class_exists("ManagedCustomerServiceGet", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2474,7 +2474,7 @@ if (!class_exists("ManagedCustomerServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetPendingInvitations", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetPendingInvitations", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2520,7 +2520,7 @@ if (!class_exists("GetPendingInvitations", false)) {
   }
 }
 
-if (!class_exists("GetPendingInvitationsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetPendingInvitationsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2560,7 +2560,7 @@ if (!class_exists("GetPendingInvitationsResponse", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2614,7 +2614,7 @@ if (!class_exists("ManagedCustomerServiceMutate", false)) {
   }
 }
 
-if (!class_exists("ManagedCustomerServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2654,7 +2654,7 @@ if (!class_exists("ManagedCustomerServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("MutateLink", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateLink", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: SET, ADD.</span>
@@ -2712,7 +2712,7 @@ if (!class_exists("MutateLink", false)) {
   }
 }
 
-if (!class_exists("MutateLinkResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateLinkResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2752,7 +2752,7 @@ if (!class_exists("MutateLinkResponse", false)) {
   }
 }
 
-if (!class_exists("MutateManager", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateManager", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -2808,7 +2808,7 @@ if (!class_exists("MutateManager", false)) {
   }
 }
 
-if (!class_exists("MutateManagerResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateManagerResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2848,7 +2848,7 @@ if (!class_exists("MutateManagerResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -2897,7 +2897,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -2946,7 +2946,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -2995,7 +2995,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -3044,7 +3044,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -3093,7 +3093,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -3142,7 +3142,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -3193,7 +3193,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -3242,7 +3242,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -3291,7 +3291,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -3340,7 +3340,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -3389,7 +3389,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -3438,7 +3438,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -3508,7 +3508,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -3557,7 +3557,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -3606,7 +3606,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3656,7 +3656,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -3705,7 +3705,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -3754,7 +3754,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -3803,7 +3803,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3853,7 +3853,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -3902,7 +3902,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3955,7 +3955,7 @@ if (!class_exists("ManagedCustomerService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ManagedCustomerService extends AdWordsSoapClient {
+  class ManagedCustomerService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ManagedCustomerService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/mcm/v201402";
@@ -3972,87 +3972,87 @@ if (!class_exists("ManagedCustomerService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Selector" => "Selector",
-      "Operation" => "Operation",
-      "Page" => "Page",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "ManagedCustomerServiceError" => "ManagedCustomerServiceError",
-      "PendingInvitationSelector" => "PendingInvitationSelector",
-      "ManagedCustomerLink" => "ManagedCustomerLink",
-      "LinkOperation" => "LinkOperation",
-      "MoveOperation" => "MoveOperation",
-      "MutateLinkResults" => "MutateLinkResults",
-      "MutateManagerResults" => "MutateManagerResults",
-      "ManagedCustomer" => "ManagedCustomer",
-      "ManagedCustomerOperation" => "ManagedCustomerOperation",
-      "ManagedCustomerPage" => "ManagedCustomerPage",
-      "ManagedCustomerReturnValue" => "ManagedCustomerReturnValue",
-      "PendingInvitation" => "PendingInvitation",
-      "LinkStatus" => "LinkStatus",
-      "ManagedCustomerServiceError.Reason" => "ManagedCustomerServiceErrorReason",
-      "get" => "ManagedCustomerServiceGet",
-      "getResponse" => "ManagedCustomerServiceGetResponse",
-      "getPendingInvitations" => "GetPendingInvitations",
-      "getPendingInvitationsResponse" => "GetPendingInvitationsResponse",
-      "mutate" => "ManagedCustomerServiceMutate",
-      "mutateResponse" => "ManagedCustomerServiceMutateResponse",
-      "mutateLink" => "MutateLink",
-      "mutateLinkResponse" => "MutateLinkResponse",
-      "mutateManager" => "MutateManager",
-      "mutateManagerResponse" => "MutateManagerResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "ManagedCustomerServiceError" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceError",
+      "PendingInvitationSelector" => "Google_Api_Ads_AdWords_v201402\\PendingInvitationSelector",
+      "ManagedCustomerLink" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerLink",
+      "LinkOperation" => "Google_Api_Ads_AdWords_v201402\\LinkOperation",
+      "MoveOperation" => "Google_Api_Ads_AdWords_v201402\\MoveOperation",
+      "MutateLinkResults" => "Google_Api_Ads_AdWords_v201402\\MutateLinkResults",
+      "MutateManagerResults" => "Google_Api_Ads_AdWords_v201402\\MutateManagerResults",
+      "ManagedCustomer" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomer",
+      "ManagedCustomerOperation" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerOperation",
+      "ManagedCustomerPage" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerPage",
+      "ManagedCustomerReturnValue" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerReturnValue",
+      "PendingInvitation" => "Google_Api_Ads_AdWords_v201402\\PendingInvitation",
+      "LinkStatus" => "Google_Api_Ads_AdWords_v201402\\LinkStatus",
+      "ManagedCustomerServiceError.Reason" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceGetResponse",
+      "getPendingInvitations" => "Google_Api_Ads_AdWords_v201402\\GetPendingInvitations",
+      "getPendingInvitationsResponse" => "Google_Api_Ads_AdWords_v201402\\GetPendingInvitationsResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\ManagedCustomerServiceMutateResponse",
+      "mutateLink" => "Google_Api_Ads_AdWords_v201402\\MutateLink",
+      "mutateLinkResponse" => "Google_Api_Ads_AdWords_v201402\\MutateLinkResponse",
+      "mutateManager" => "Google_Api_Ads_AdWords_v201402\\MutateManager",
+      "mutateManagerResponse" => "Google_Api_Ads_AdWords_v201402\\MutateManagerResponse",
     );
 
 
@@ -4170,3 +4170,4 @@ if (!class_exists("ManagedCustomerService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/MediaService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/MediaService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -78,7 +78,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -125,7 +125,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -173,7 +173,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -221,7 +221,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * @package Google_Api_Ads_AdWords_v201402
@@ -268,7 +268,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -317,7 +317,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * @package Google_Api_Ads_AdWords_v201402
@@ -371,7 +371,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -439,7 +439,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -507,7 +507,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -604,7 +604,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -683,7 +683,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201402
@@ -825,7 +825,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaPage", false)) {
   /**
    * Page of media returned by the {@link MediaService} which includes
    * the media.
@@ -873,7 +873,7 @@ if (!class_exists("MediaPage", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * @package Google_Api_Ads_AdWords_v201402
@@ -941,7 +941,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("AudioErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AudioErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -974,7 +974,7 @@ if (!class_exists("AudioErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1007,7 +1007,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1040,7 +1040,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -1074,7 +1074,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1107,7 +1107,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1140,7 +1140,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -1174,7 +1174,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1207,7 +1207,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1240,7 +1240,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1273,7 +1273,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201402
@@ -1306,7 +1306,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201402
@@ -1339,7 +1339,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201402
@@ -1372,7 +1372,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1405,7 +1405,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1438,7 +1438,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1471,7 +1471,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1504,7 +1504,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1537,7 +1537,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1570,7 +1570,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1603,7 +1603,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1637,7 +1637,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1670,7 +1670,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1703,7 +1703,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1736,7 +1736,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1769,7 +1769,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1802,7 +1802,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1835,7 +1835,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1868,7 +1868,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1901,7 +1901,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1934,7 +1934,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1967,7 +1967,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("VideoErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\VideoErrorReason", false)) {
   /**
    * Invalid video.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2000,7 +2000,7 @@ if (!class_exists("VideoErrorReason", false)) {
   }
 }
 
-if (!class_exists("MediaServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2049,7 +2049,7 @@ if (!class_exists("MediaServiceGet", false)) {
   }
 }
 
-if (!class_exists("MediaServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2089,7 +2089,7 @@ if (!class_exists("MediaServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("Query", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Query", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -2137,7 +2137,7 @@ if (!class_exists("Query", false)) {
   }
 }
 
-if (!class_exists("QueryResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2177,7 +2177,7 @@ if (!class_exists("QueryResponse", false)) {
   }
 }
 
-if (!class_exists("Upload", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Upload", false)) {
   /**
    * Uploads new media. Currently, you can only upload {@link Image} files.
    * 
@@ -2221,7 +2221,7 @@ if (!class_exists("Upload", false)) {
   }
 }
 
-if (!class_exists("UploadResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UploadResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -2261,7 +2261,7 @@ if (!class_exists("UploadResponse", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2327,7 +2327,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("AudioError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AudioError", false)) {
   /**
    * Error class for errors associated with parsing audio data.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2372,7 +2372,7 @@ if (!class_exists("AudioError", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2417,7 +2417,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2462,7 +2462,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2507,7 +2507,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2552,7 +2552,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2598,7 +2598,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2643,7 +2643,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -2696,7 +2696,7 @@ if (!class_exists("Image", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2741,7 +2741,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2788,7 +2788,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2833,7 +2833,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2878,7 +2878,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2923,7 +2923,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2968,7 +2968,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3013,7 +3013,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3065,7 +3065,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3110,7 +3110,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3155,7 +3155,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3221,7 +3221,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3266,7 +3266,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3311,7 +3311,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -3357,7 +3357,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3402,7 +3402,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3447,7 +3447,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3492,7 +3492,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3538,7 +3538,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3625,7 +3625,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("VideoError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\VideoError", false)) {
   /**
    * Error class for errors associated with parsing video data.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3670,7 +3670,7 @@ if (!class_exists("VideoError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3715,7 +3715,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3764,7 +3764,7 @@ if (!class_exists("MediaService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class MediaService extends AdWordsSoapClient {
+  class MediaService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "MediaService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3781,89 +3781,89 @@ if (!class_exists("MediaService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Audio" => "Audio",
-      "AudioError" => "AudioError",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "DateRange" => "DateRange",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageError" => "ImageError",
-      "InternalApiError" => "InternalApiError",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OrderBy" => "OrderBy",
-      "Paging" => "Paging",
-      "Predicate" => "Predicate",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "Video" => "Video",
-      "VideoError" => "VideoError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Media" => "Media",
-      "MediaPage" => "MediaPage",
-      "Selector" => "Selector",
-      "AudioError.Reason" => "AudioErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "VideoError.Reason" => "VideoErrorReason",
-      "get" => "MediaServiceGet",
-      "getResponse" => "MediaServiceGetResponse",
-      "query" => "Query",
-      "queryResponse" => "QueryResponse",
-      "upload" => "Upload",
-      "uploadResponse" => "UploadResponse",
+      "Audio" => "Google_Api_Ads_AdWords_v201402\\Audio",
+      "AudioError" => "Google_Api_Ads_AdWords_v201402\\AudioError",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201402\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201402\\Image",
+      "ImageError" => "Google_Api_Ads_AdWords_v201402\\ImageError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "MediaError" => "Google_Api_Ads_AdWords_v201402\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "Video" => "Google_Api_Ads_AdWords_v201402\\Video",
+      "VideoError" => "Google_Api_Ads_AdWords_v201402\\VideoError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Media" => "Google_Api_Ads_AdWords_v201402\\Media",
+      "MediaPage" => "Google_Api_Ads_AdWords_v201402\\MediaPage",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "AudioError.Reason" => "Google_Api_Ads_AdWords_v201402\\AudioErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201402\\ImageErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201402\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201402\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201402\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201402\\MediaErrorReason",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "VideoError.Reason" => "Google_Api_Ads_AdWords_v201402\\VideoErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\MediaServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\MediaServiceGetResponse",
+      "query" => "Google_Api_Ads_AdWords_v201402\\Query",
+      "queryResponse" => "Google_Api_Ads_AdWords_v201402\\QueryResponse",
+      "upload" => "Google_Api_Ads_AdWords_v201402\\Upload",
+      "uploadResponse" => "Google_Api_Ads_AdWords_v201402\\UploadResponse",
     );
 
 
@@ -3924,3 +3924,4 @@ if (!class_exists("MediaService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/MutateJobService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/MutateJobService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Ad", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Ad", false)) {
   /**
    * The base class of all ad types. To update basic ad fields,
    * you can construct an {@code Ad} object (instead of
@@ -133,7 +133,7 @@ if (!class_exists("Ad", false)) {
   }
 }
 
-if (!class_exists("AdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtension", false)) {
   /**
    * Base class for AdExtension objects. An AdExtension is an extension to
    * an existing ad or metadata that will process into an extension.
@@ -213,7 +213,7 @@ if (!class_exists("AdExtension", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverride", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverride", false)) {
   /**
    * Represents an ad level ad extension override. An ad extension override
    * specifies the ad extension that must be used if the ad is served with
@@ -283,7 +283,7 @@ if (!class_exists("AdExtensionOverride", false)) {
   }
 }
 
-if (!class_exists("AdGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroup", false)) {
   /**
    * Represents an ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -386,7 +386,7 @@ if (!class_exists("AdGroup", false)) {
   }
 }
 
-if (!class_exists("AdGroupAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAd", false)) {
   /**
    * Represents an ad in an ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -475,7 +475,7 @@ if (!class_exists("AdGroupAd", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for an AdGroupAd
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -530,7 +530,7 @@ if (!class_exists("AdGroupAdExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifier", false)) {
   /**
    * Represents an adgroup level bid modifier override for campaign level criterion
    * bid modifier values.
@@ -599,7 +599,7 @@ if (!class_exists("AdGroupBidModifier", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterion", false)) {
   /**
    * Represents a criterion in an ad group, used with AdGroupCriterionService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -699,7 +699,7 @@ if (!class_exists("AdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * Bid multiplier used to modify the bid of a criterion while running
    * an experiment.
@@ -773,7 +773,7 @@ if (!class_exists("AdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupExperimentBidMultipliers", false)) {
   /**
    * Bid multiplier used to modify the bid of an adgroup while running
    * an experiment.
@@ -847,7 +847,7 @@ if (!class_exists("AdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("AdGroupExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this adgroup.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -909,7 +909,7 @@ if (!class_exists("AdGroupExperimentData", false)) {
   }
 }
 
-if (!class_exists("AdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdUnionId", false)) {
   /**
    * Represents an id indicating a grouping of Ads under some heuristic.
    * @package Google_Api_Ads_AdWords_v201402
@@ -988,7 +988,7 @@ if (!class_exists("AdUnionId", false)) {
   }
 }
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1070,7 +1070,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -1167,7 +1167,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiErrorReason", false)) {
   /**
    * Interface that has a reason return an associated service error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1606,7 +1606,7 @@ if (!class_exists("ApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1685,7 +1685,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1730,7 +1730,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1775,7 +1775,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("Bid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bid", false)) {
   /**
    * Represents a bid of a certain amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1815,7 +1815,7 @@ if (!class_exists("Bid", false)) {
   }
 }
 
-if (!class_exists("BidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidMultiplier", false)) {
   /**
    * Represents a multiplier to modify a bid. The final value after
    * modification is represented by the multiplied bid value.
@@ -1863,7 +1863,7 @@ if (!class_exists("BidMultiplier", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterion", false)) {
   /**
    * A biddable (positive) criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1979,7 +1979,7 @@ if (!class_exists("BiddableAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterionExperimentData", false)) {
   /**
    * Data associated with an advertiser experiment for this {@link BiddableAdGroupCriterion}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2040,7 +2040,7 @@ if (!class_exists("BiddableAdGroupCriterionExperimentData", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2085,7 +2085,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BiddingErrors", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrors", false)) {
   /**
    * Represents error codes for bidding strategy entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2130,7 +2130,7 @@ if (!class_exists("BiddingErrors", false)) {
   }
 }
 
-if (!class_exists("BiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingScheme", false)) {
   /**
    * Base class for all bidding schemes.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -2203,7 +2203,7 @@ if (!class_exists("BiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyConfiguration", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration", false)) {
   /**
    * Encapsulates the information about bids and bidding strategies.
    * 
@@ -2295,7 +2295,7 @@ if (!class_exists("BiddingStrategyConfiguration", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingTransitionError", false)) {
   /**
    * Bidding transition errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2340,7 +2340,7 @@ if (!class_exists("BiddingTransitionError", false)) {
   }
 }
 
-if (!class_exists("Bids", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Bids", false)) {
   /**
    * Base class for all bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2412,7 +2412,7 @@ if (!class_exists("Bids", false)) {
   }
 }
 
-if (!class_exists("BillingSummary", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BillingSummary", false)) {
   /**
    * Represents the billing summary of the job that provides the overall cost of
    * the job's operations, i.e., for the work done <i>by</i> the job. This
@@ -2462,7 +2462,7 @@ if (!class_exists("BillingSummary", false)) {
   }
 }
 
-if (!class_exists("Budget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Budget", false)) {
   /**
    * Budgets are used for managing the amount of money spent on AdWords.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2551,7 +2551,7 @@ if (!class_exists("Budget", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2596,7 +2596,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme", false)) {
   /**
    * In budget optimizer, Google automatically places bids for the user based on
    * their daily/monthly budget.
@@ -2647,7 +2647,7 @@ if (!class_exists("BudgetOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BulkMutateJobError", false)) {
   /**
    * Bulk mutate job handling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2692,7 +2692,7 @@ if (!class_exists("BulkMutateJobError", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobPolicy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BulkMutateJobPolicy", false)) {
   /**
    * A basic job policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2732,7 +2732,7 @@ if (!class_exists("BulkMutateJobPolicy", false)) {
   }
 }
 
-if (!class_exists("Campaign", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Campaign", false)) {
   /**
    * Data representing an AdWords campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2877,7 +2877,7 @@ if (!class_exists("Campaign", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtension", false)) {
   /**
    * Represents a campaign level ad extension. A campaign ad extension specifies
    * a campaign and an ad extension which can extend any ad under that campaign.
@@ -2939,7 +2939,7 @@ if (!class_exists("CampaignAdExtension", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionError", false)) {
   /**
    * CampaignAdExtension errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2984,7 +2984,7 @@ if (!class_exists("CampaignAdExtensionError", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterion", false)) {
   /**
    * Represents a campaign level criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3091,7 +3091,7 @@ if (!class_exists("CampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionError", false)) {
   /**
    * Base error class for Campaign Criterion Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3136,7 +3136,7 @@ if (!class_exists("CampaignCriterionError", false)) {
   }
 }
 
-if (!class_exists("CampaignError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignError", false)) {
   /**
    * Base error class for Campaign Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3181,7 +3181,7 @@ if (!class_exists("CampaignError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3226,7 +3226,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3298,7 +3298,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme", false)) {
   /**
    * Conversion optimizer bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -3361,7 +3361,7 @@ if (!class_exists("ConversionOptimizerBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibility", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibility", false)) {
   /**
    * Eligibility data for Campaign to transition to Conversion Optimizer
    * @package Google_Api_Ads_AdWords_v201402
@@ -3408,7 +3408,7 @@ if (!class_exists("ConversionOptimizerEligibility", false)) {
   }
 }
 
-if (!class_exists("CpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpaBid", false)) {
   /**
    * CPA Bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3450,7 +3450,7 @@ if (!class_exists("CpaBid", false)) {
   }
 }
 
-if (!class_exists("CpcBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpcBid", false)) {
   /**
    * Manual click based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3506,7 +3506,7 @@ if (!class_exists("CpcBid", false)) {
   }
 }
 
-if (!class_exists("CpmBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CpmBid", false)) {
   /**
    * Manual impression based bids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3555,7 +3555,7 @@ if (!class_exists("CpmBid", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -3642,7 +3642,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3687,7 +3687,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("CriterionParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionParameter", false)) {
   /**
    * Base type of criterion parameters.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3759,7 +3759,7 @@ if (!class_exists("CriterionParameter", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3804,7 +3804,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3849,7 +3849,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DeprecatedAd", false)) {
   /**
    * Represents a deprecated ad.
    * 
@@ -3905,7 +3905,7 @@ if (!class_exists("DeprecatedAd", false)) {
   }
 }
 
-if (!class_exists("Dimensions", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Dimensions", false)) {
   /**
    * Represents a simple height-width dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3952,7 +3952,7 @@ if (!class_exists("Dimensions", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3997,7 +3997,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EnhancedCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme", false)) {
   /**
    * Enhanced CPC is a bidding strategy that raises your bids for clicks that seem more likely to
    * lead to a conversion and lowers them for clicks where they seem less likely.
@@ -4036,7 +4036,7 @@ if (!class_exists("EnhancedCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4081,7 +4081,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -4155,7 +4155,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -4201,7 +4201,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("ExemptionRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExemptionRequest", false)) {
   /**
    * A request to be exempted from a {@link PolicyViolationError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4241,7 +4241,7 @@ if (!class_exists("ExemptionRequest", false)) {
   }
 }
 
-if (!class_exists("ExperimentError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentError", false)) {
   /**
    * The error reason represented by an enum.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4286,7 +4286,7 @@ if (!class_exists("ExperimentError", false)) {
   }
 }
 
-if (!class_exists("FeedItem", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItem", false)) {
   /**
    * Represents an item in a feed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4382,7 +4382,7 @@ if (!class_exists("FeedItem", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemAttributeError", false)) {
   /**
    * Contains validation error details for a set of feed attributes.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4429,7 +4429,7 @@ if (!class_exists("FeedItemAttributeError", false)) {
   }
 }
 
-if (!class_exists("FeedItemAttributeValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemAttributeValue", false)) {
   /**
    * Represents a feed item's value for a particular feed attribute. A feed item's value is
    * composed of a collection of these attribute values.
@@ -4498,7 +4498,7 @@ if (!class_exists("FeedItemAttributeValue", false)) {
   }
 }
 
-if (!class_exists("FeedItemDevicePreference", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemDevicePreference", false)) {
   /**
    * Represents a FeedItem device preference.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4538,7 +4538,7 @@ if (!class_exists("FeedItemDevicePreference", false)) {
   }
 }
 
-if (!class_exists("FeedItemError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemError", false)) {
   /**
    * FeedItemService related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4583,7 +4583,7 @@ if (!class_exists("FeedItemError", false)) {
   }
 }
 
-if (!class_exists("FeedItemSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemSchedule", false)) {
   /**
    * Represents a FeedItem schedule, which specifies a time interval on a given day
    * when the feed item may serve. The FeedItemSchedule times are in the account's time zone.
@@ -4652,7 +4652,7 @@ if (!class_exists("FeedItemSchedule", false)) {
   }
 }
 
-if (!class_exists("FeedItemScheduling", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemScheduling", false)) {
   /**
    * Represents a collection of FeedItem schedules specifying all time intervals for which
    * the feed item may serve. Any time range not covered by the specified FeedItemSchedules will
@@ -4694,7 +4694,7 @@ if (!class_exists("FeedItemScheduling", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetail", false)) {
   /**
    * Contains offline-validation and approval results for a given FeedItem and FeedMapping. Each
    * validation detail indicates any issues found on the feed item when used in the context
@@ -4757,7 +4757,7 @@ if (!class_exists("FeedItemValidationDetail", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError", false)) {
   /**
    * A ForwardComptibilityError represents possible errors when using the forwardCompatibilityMap
    * in some of the common services.
@@ -4803,7 +4803,7 @@ if (!class_exists("ForwardCompatibilityError", false)) {
   }
 }
 
-if (!class_exists("FrequencyCap", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FrequencyCap", false)) {
   /**
    * A frequency cap is the maximum number of times an ad (or some set of ads) can
    * be shown to a user over a particular time period.
@@ -4858,7 +4858,7 @@ if (!class_exists("FrequencyCap", false)) {
   }
 }
 
-if (!class_exists("FeedFunction", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedFunction", false)) {
   /**
    * Represents a function where its operator is applied to its argument operands
    * resulting in a return value. It has the form
@@ -4942,7 +4942,7 @@ if (!class_exists("FeedFunction", false)) {
   }
 }
 
-if (!class_exists("FunctionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionError", false)) {
   /**
    * Errors that indicate issues with the function.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4987,10 +4987,10 @@ if (!class_exists("FunctionError", false)) {
   }
 }
 
-if (!class_exists("Gender", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Gender", false)) {
   /**
    * Represents a Gender criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -5033,7 +5033,7 @@ if (!class_exists("Gender", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5080,7 +5080,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5125,7 +5125,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("ImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageAd", false)) {
   /**
    * Represents an ImageAd.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -5186,7 +5186,7 @@ if (!class_exists("ImageAd", false)) {
   }
 }
 
-if (!class_exists("ImageError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageError", false)) {
   /**
    * Error class for errors associated with parsing image data.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5231,7 +5231,7 @@ if (!class_exists("ImageError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -5278,7 +5278,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("IpBlock", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IpBlock", false)) {
   /**
    * Criterion used for IP exclusions. We allow:
    * 
@@ -5330,7 +5330,7 @@ if (!class_exists("IpBlock", false)) {
   }
 }
 
-if (!class_exists("Job", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Job", false)) {
   /**
    * Represents an asynchronous macro unit of work.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5423,7 +5423,7 @@ if (!class_exists("Job", false)) {
   }
 }
 
-if (!class_exists("JobError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobError", false)) {
   /**
    * Job handling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5468,7 +5468,7 @@ if (!class_exists("JobError", false)) {
   }
 }
 
-if (!class_exists("JobEvent", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobEvent", false)) {
   /**
    * An event defined by a status change of a job.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5547,7 +5547,7 @@ if (!class_exists("JobEvent", false)) {
   }
 }
 
-if (!class_exists("JobResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobResult", false)) {
   /**
    * Represents the result data of a job. This contains both the results of
    * successfully processed operations as well as errors returned by failed
@@ -5589,7 +5589,7 @@ if (!class_exists("JobResult", false)) {
   }
 }
 
-if (!class_exists("JobSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobSelector", false)) {
   /**
    * For selecting jobs whose information will be returned from a get method call
    * of a job service.
@@ -5676,7 +5676,7 @@ if (!class_exists("JobSelector", false)) {
   }
 }
 
-if (!class_exists("JobStats", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobStats", false)) {
   /**
    * Job-handling statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5769,7 +5769,7 @@ if (!class_exists("JobStats", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -5821,10 +5821,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -5874,10 +5874,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -5941,7 +5941,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("LocationExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationExtension", false)) {
   /**
    * Location based ad extension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6033,7 +6033,7 @@ if (!class_exists("LocationExtension", false)) {
   }
 }
 
-if (!class_exists("LocationOverrideInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationOverrideInfo", false)) {
   /**
    * Represents override info for ad level LocationExtension overrides.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6080,7 +6080,7 @@ if (!class_exists("LocationOverrideInfo", false)) {
   }
 }
 
-if (!class_exists("LocationSyncExtension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationSyncExtension", false)) {
   /**
    * Local business center(LBC) sync extension that ties a LBC account with a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6151,7 +6151,7 @@ if (!class_exists("LocationSyncExtension", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   /**
    * AdGroupCriterion level bid multiplier used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6201,7 +6201,7 @@ if (!class_exists("ManualCPCAdGroupCriterionExperimentBidMultiplier", false)) {
   }
 }
 
-if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPC bidding strategies.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6251,7 +6251,7 @@ if (!class_exists("ManualCPCAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCPMAdGroupExperimentBidMultipliers", false)) {
   /**
    * Adgroup level bid multipliers used in manual CPM bidding strategy.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6294,7 +6294,7 @@ if (!class_exists("ManualCPMAdGroupExperimentBidMultipliers", false)) {
   }
 }
 
-if (!class_exists("ManualCpcBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme", false)) {
   /**
    * Manual click based bidding where user pays per click.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -6337,7 +6337,7 @@ if (!class_exists("ManualCpcBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("ManualCpmBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme", false)) {
   /**
    * Manual impression based bidding where user pays per thousand impressions.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -6373,7 +6373,7 @@ if (!class_exists("ManualCpmBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("Media", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media", false)) {
   /**
    * Represents some kind of media.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6515,7 +6515,7 @@ if (!class_exists("Media", false)) {
   }
 }
 
-if (!class_exists("MediaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaError", false)) {
   /**
    * Error class for media related errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6560,7 +6560,7 @@ if (!class_exists("MediaError", false)) {
   }
 }
 
-if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type Dimensions.
@@ -6608,7 +6608,7 @@ if (!class_exists("Media_Size_DimensionsMapEntry", false)) {
   }
 }
 
-if (!class_exists("Media_Size_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Size
    * and value of type String.
@@ -6656,7 +6656,7 @@ if (!class_exists("Media_Size_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("MobileAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAd", false)) {
   /**
    * Represents a mobile ad.
    * 
@@ -6794,7 +6794,7 @@ if (!class_exists("MobileAd", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -6848,7 +6848,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -6900,10 +6900,10 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("MobileDevice", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDevice", false)) {
   /**
    * Represents a Mobile Device Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -6967,7 +6967,7 @@ if (!class_exists("MobileDevice", false)) {
   }
 }
 
-if (!class_exists("MobileImageAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileImageAd", false)) {
   /**
    * Represents a mobile image ad.
    * 
@@ -7032,7 +7032,7 @@ if (!class_exists("MobileImageAd", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7074,7 +7074,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NegativeAdGroupCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeAdGroupCriterion", false)) {
   /**
    * A negative criterion in an adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7113,7 +7113,7 @@ if (!class_exists("NegativeAdGroupCriterion", false)) {
   }
 }
 
-if (!class_exists("NegativeCampaignCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeCampaignCriterion", false)) {
   /**
    * A negative campaign criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7153,7 +7153,7 @@ if (!class_exists("NegativeCampaignCriterion", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7214,7 +7214,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationError", false)) {
   /**
    * Error associated with creation of new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7259,7 +7259,7 @@ if (!class_exists("NewEntityCreationError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7304,7 +7304,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7349,7 +7349,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7384,7 +7384,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OAuthInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OAuthInfo", false)) {
   /**
    * Data used for authorization using OAuth.
    * For more information about OAuth, see:
@@ -7440,7 +7440,7 @@ if (!class_exists("OAuthInfo", false)) {
   }
 }
 
-if (!class_exists("FunctionArgumentOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand", false)) {
   /**
    * An operand that can be used in a function expression.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7512,7 +7512,7 @@ if (!class_exists("FunctionArgumentOperand", false)) {
   }
 }
 
-if (!class_exists("Operand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operand", false)) {
   /**
    * A marker interface for entities that can be operated upon in mutate
    * operations.
@@ -7658,10 +7658,10 @@ if (!class_exists("Operand", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion", false)) {
   /**
    * Represents a Operating System Version Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -7725,7 +7725,7 @@ if (!class_exists("OperatingSystemVersion", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -7805,7 +7805,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7850,7 +7850,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7895,7 +7895,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OverrideInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OverrideInfo", false)) {
   /**
    * Represents additional override info with which to augment the override
    * extension.
@@ -7936,7 +7936,7 @@ if (!class_exists("OverrideInfo", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme", false)) {
   /**
    * Page-One Promoted bidding scheme, which sets max cpc bids to
    * target impressions on page one or page one promoted slots on google.com.
@@ -8015,7 +8015,7 @@ if (!class_exists("PageOnePromotedBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -8061,7 +8061,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBid", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBid", false)) {
   /**
    * Percentage CPA based bidding where user pays a percent of conversions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8110,7 +8110,7 @@ if (!class_exists("PercentCpaBid", false)) {
   }
 }
 
-if (!class_exists("PercentCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme", false)) {
   /**
    * Percentage CPA based bidding scheme attributes where user pays a percent of conversions.
    * This bidding strategy is available only to some advertisers.
@@ -8151,7 +8151,7 @@ if (!class_exists("PercentCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("PlaceHolder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlaceHolder", false)) {
   /**
    * A place holder for a result which is not available.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8184,7 +8184,7 @@ if (!class_exists("PlaceHolder", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -8230,7 +8230,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("PlacesOfInterestOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperand", false)) {
   /**
    * This operand specifies a place of interest category for semantic targeting.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8272,10 +8272,10 @@ if (!class_exists("PlacesOfInterestOperand", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -8318,7 +8318,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -8409,7 +8409,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8456,7 +8456,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -8504,7 +8504,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -8559,7 +8559,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAd", false)) {
   /**
    * Represents a product ad (known as a <a href=
    * "//support.google.com/adwords/bin/answer.py?answer=2456103">product
@@ -8618,7 +8618,7 @@ if (!class_exists("ProductAd", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -8666,7 +8666,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8706,7 +8706,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("ProductDimension", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimension", false)) {
   /**
    * Dimension by which to subdivide or filter products.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8778,7 +8778,7 @@ if (!class_exists("ProductDimension", false)) {
   }
 }
 
-if (!class_exists("ProductOfferId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductOfferId", false)) {
   /**
    * An offer ID as specified by the merchant.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8820,7 +8820,7 @@ if (!class_exists("ProductOfferId", false)) {
   }
 }
 
-if (!class_exists("ProductPartition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductPartition", false)) {
   /**
    * Product partition (product group) in a shopping campaign. Depending on its type, a product
    * partition subdivides products along some product dimension, specifies a bid for products, or
@@ -8892,7 +8892,7 @@ if (!class_exists("ProductPartition", false)) {
   }
 }
 
-if (!class_exists("ProductSalesChannel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductSalesChannel", false)) {
   /**
    * Defines the sales channel of the shopping products to be advertised.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -8930,7 +8930,7 @@ if (!class_exists("ProductSalesChannel", false)) {
   }
 }
 
-if (!class_exists("ProductScope", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductScope", false)) {
   /**
    * Scope of products. Contains a set of product dimensions, all of which a product has to match to
    * be included in the campaign. These product dimensions must have a value; the "everything else"
@@ -8981,7 +8981,7 @@ if (!class_exists("ProductScope", false)) {
   }
 }
 
-if (!class_exists("ProductType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductType", false)) {
   /**
    * One element of a product type string at a certain level. Top-level product types are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -9033,7 +9033,7 @@ if (!class_exists("ProductType", false)) {
   }
 }
 
-if (!class_exists("ProductTypeFull", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductTypeFull", false)) {
   /**
    * A full product type string. Category of the product according to the merchant's own
    * classification. Example:
@@ -9080,7 +9080,7 @@ if (!class_exists("ProductTypeFull", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -9088,7 +9088,7 @@ if (!class_exists("Proximity", false)) {
    * by a lat/long pair. The caller may also alternatively provide address fields which will be
    * geocoded into a lat/long pair. Note: If a geoPoint value is provided, the address is not
    * used for calculating the lat/long to target.
-   * <p> A criterion of this type is only targetable.
+   * <p>
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -9152,7 +9152,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QualityInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QualityInfo", false)) {
   /**
    * Container for criterion quality information.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9213,7 +9213,7 @@ if (!class_exists("QualityInfo", false)) {
   }
 }
 
-if (!class_exists("QueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryError", false)) {
   /**
    * A QueryError represents possible errors for query parsing and execution.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9265,7 +9265,7 @@ if (!class_exists("QueryError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9310,7 +9310,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("QuotaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaError", false)) {
   /**
    * Errors that are thrown if a quota limit is exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9362,7 +9362,7 @@ if (!class_exists("QuotaError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9407,7 +9407,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9473,7 +9473,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9518,7 +9518,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9563,7 +9563,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9608,7 +9608,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -9654,7 +9654,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9699,7 +9699,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("RichMediaAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAd", false)) {
   /**
    * Data associated with a rich media ad.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -9802,7 +9802,7 @@ if (!class_exists("RichMediaAd", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9847,10 +9847,10 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("LocationGroups", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationGroups", false)) {
   /**
    * Represents a criterion containing a function that when evaluated specifies how to target
-   * based on the type of the location. These ???location groups??? are custom, dynamic bundles of
+   * based on the type of the location. These "location groups" are custom, dynamic bundles of
    * locations (for instance "High income areas in California" or "Airports in France").
    * 
    * <p>Examples:</p>
@@ -9919,7 +9919,7 @@ if (!class_exists("LocationGroups", false)) {
   }
 }
 
-if (!class_exists("Setting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Setting", false)) {
   /**
    * Base type for AdWords campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -9991,7 +9991,7 @@ if (!class_exists("Setting", false)) {
   }
 }
 
-if (!class_exists("SettingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingError", false)) {
   /**
    * Indicates a problem with campaign settings.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10036,7 +10036,7 @@ if (!class_exists("SettingError", false)) {
   }
 }
 
-if (!class_exists("ShoppingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ShoppingSetting", false)) {
   /**
    * Setting for shopping campaigns. Defines the universe of products covered by the campaign.
    * Encapsulates a merchant ID, sales country, and campaign priority.
@@ -10093,7 +10093,7 @@ if (!class_exists("ShoppingSetting", false)) {
   }
 }
 
-if (!class_exists("SimpleMutateJob", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SimpleMutateJob", false)) {
   /**
    * A mutation job, which was submitted using
    * {@link MutateJobService#mutate}, and will execute asynchronously
@@ -10154,7 +10154,7 @@ if (!class_exists("SimpleMutateJob", false)) {
   }
 }
 
-if (!class_exists("SimpleMutateResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SimpleMutateResult", false)) {
   /**
    * The results of a simple mutation job.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10201,7 +10201,7 @@ if (!class_exists("SimpleMutateResult", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10246,7 +10246,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10314,7 +10314,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10382,7 +10382,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10427,7 +10427,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -10473,7 +10473,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("String_StringMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\String_StringMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type String
    * and value of type String.
@@ -10521,7 +10521,7 @@ if (!class_exists("String_StringMapEntry", false)) {
   }
 }
 
-if (!class_exists("Target", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Target", false)) {
   /**
    * Target abstract class.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10593,7 +10593,7 @@ if (!class_exists("Target", false)) {
   }
 }
 
-if (!class_exists("TargetCpaBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme", false)) {
   /**
    * Target Cpa bidding strategy helps you maximize your return on investment
    * (ROI) by automatically getting you the most possible conversions for your budget.
@@ -10660,7 +10660,7 @@ if (!class_exists("TargetCpaBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * @package Google_Api_Ads_AdWords_v201402
@@ -10705,7 +10705,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("TargetList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetList", false)) {
   /**
    * Targets list abstract class (a list of a given type of targets along with their campaign ID).
    * @package Google_Api_Ads_AdWords_v201402
@@ -10784,7 +10784,7 @@ if (!class_exists("TargetList", false)) {
   }
 }
 
-if (!class_exists("TargetingSettingDetail", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingSettingDetail", false)) {
   /**
    * Specifies if criteria of this type group should be used to restrict
    * targeting, or if ads can serve anywhere and criteria are only used in
@@ -10833,7 +10833,7 @@ if (!class_exists("TargetingSettingDetail", false)) {
   }
 }
 
-if (!class_exists("TargetRoasBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme", false)) {
   /**
    * Target Roas bidding strategy helps you maximize revenue while averaging a specific target
    * Return On Average Spend (ROAS).
@@ -10899,7 +10899,7 @@ if (!class_exists("TargetRoasBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetSpendBiddingScheme", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme", false)) {
   /**
    * Target Spend bidding scheme, in which Google automatically places
    * bids for the user based on their daily/monthly budget or optional
@@ -10951,7 +10951,7 @@ if (!class_exists("TargetSpendBiddingScheme", false)) {
   }
 }
 
-if (!class_exists("TargetingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingSetting", false)) {
   /**
    * Setting for targeting related features.
    * This is applicable at Campaign and AdGroup level.
@@ -10994,7 +10994,7 @@ if (!class_exists("TargetingSetting", false)) {
   }
 }
 
-if (!class_exists("TempAdUnionId", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TempAdUnionId", false)) {
   /**
    * Represents the temporary id for an ad union id, which the user can specify.
    * The temporary id can be used to group ads together during ad creation.
@@ -11031,7 +11031,7 @@ if (!class_exists("TempAdUnionId", false)) {
   }
 }
 
-if (!class_exists("TemplateAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateAd", false)) {
   /**
    * Represents a <a href=
    * "//www.google.com/adwords/displaynetwork/plan-creative-campaigns/display-ad-builder.html"
@@ -11132,7 +11132,7 @@ if (!class_exists("TemplateAd", false)) {
   }
 }
 
-if (!class_exists("TemplateElement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElement", false)) {
   /**
    * Represents an element in a template. Each template element is composed
    * of a list of fields (actual value data).
@@ -11180,7 +11180,7 @@ if (!class_exists("TemplateElement", false)) {
   }
 }
 
-if (!class_exists("TemplateElementField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElementField", false)) {
   /**
    * Represents a field in a template element.
    * @package Google_Api_Ads_AdWords_v201402
@@ -11241,7 +11241,7 @@ if (!class_exists("TemplateElementField", false)) {
   }
 }
 
-if (!class_exists("TextAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TextAd", false)) {
   /**
    * Represents a TextAd.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -11302,7 +11302,7 @@ if (!class_exists("TextAd", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAd", false)) {
   /**
    * Data associated with rich media extension attributes.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11381,7 +11381,7 @@ if (!class_exists("ThirdPartyRedirectAd", false)) {
   }
 }
 
-if (!class_exists("TrackingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrackingSetting", false)) {
   /**
    * Campaign level settings for tracking information.
    * @package Google_Api_Ads_AdWords_v201402
@@ -11423,7 +11423,7 @@ if (!class_exists("TrackingSetting", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11475,7 +11475,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -11534,7 +11534,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -11597,7 +11597,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("Video", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Video", false)) {
   /**
    * Encapsulates a Video media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -11684,7 +11684,7 @@ if (!class_exists("Video", false)) {
   }
 }
 
-if (!class_exists("Webpage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Webpage", false)) {
   /**
    * Criterion for targeting webpages of an advertiser's website. The
    * website domain name is specified at the campaign level.
@@ -11744,7 +11744,7 @@ if (!class_exists("Webpage", false)) {
   }
 }
 
-if (!class_exists("WebpageCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageCondition", false)) {
   /**
    * Logical expression for targeting webpages of an advertiser's website.
    * 
@@ -11796,7 +11796,7 @@ if (!class_exists("WebpageCondition", false)) {
   }
 }
 
-if (!class_exists("WebpageParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageParameter", false)) {
   /**
    * Parameter of Webpage criterion, expressed as a list of conditions, or
    * logical expressions, for targeting webpages of an advertiser's website.
@@ -11846,7 +11846,7 @@ if (!class_exists("WebpageParameter", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAd", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DynamicSearchAd", false)) {
   /**
    * Represents a dynamic search ad. This ad will have its headline and
    * destination URL auto-generated at serving time according to domain name
@@ -11930,7 +11930,7 @@ if (!class_exists("DynamicSearchAd", false)) {
   }
 }
 
-if (!class_exists("AdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -11963,7 +11963,7 @@ if (!class_exists("AdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionErrorReason", false)) {
   /**
    * Account has been deleted
    * @package Google_Api_Ads_AdWords_v201402
@@ -11996,7 +11996,7 @@ if (!class_exists("AdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideApprovalStatus", false)) {
   /**
    * Approval status for the AdExtensionOverride
    * @package Google_Api_Ads_AdWords_v201402
@@ -12029,7 +12029,7 @@ if (!class_exists("AdExtensionOverrideApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideStatus", false)) {
   /**
    * Status of the AdExtensionOverride
    * @package Google_Api_Ads_AdWords_v201402
@@ -12062,7 +12062,7 @@ if (!class_exists("AdExtensionOverrideStatus", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideErrorReason", false)) {
   /**
    * Cannot override an ad that is already overriden with an adextension
    * @package Google_Api_Ads_AdWords_v201402
@@ -12095,7 +12095,7 @@ if (!class_exists("AdExtensionOverrideErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdApprovalStatus", false)) {
   /**
    * Represents the possible approval statuses.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12128,7 +12128,7 @@ if (!class_exists("AdGroupAdApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdStatus", false)) {
   /**
    * The current status of an Ad.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12161,7 +12161,7 @@ if (!class_exists("AdGroupAdStatus", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12194,7 +12194,7 @@ if (!class_exists("AdGroupAdErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12227,7 +12227,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12260,7 +12260,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceErrorReason", false)) {
   /**
    * The reasons for the adgroup service error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12293,7 +12293,7 @@ if (!class_exists("AdGroupServiceErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupStatus", false)) {
   /**
    * Status of this ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12326,7 +12326,7 @@ if (!class_exists("AdGroupStatus", false)) {
   }
 }
 
-if (!class_exists("AdServingOptimizationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdServingOptimizationStatus", false)) {
   /**
    * Ad serving status of campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12359,7 +12359,7 @@ if (!class_exists("AdServingOptimizationStatus", false)) {
   }
 }
 
-if (!class_exists("AdvertisingChannelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdvertisingChannelType", false)) {
   /**
    * The channel type a campaign may target to serve on.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12392,7 +12392,7 @@ if (!class_exists("AdvertisingChannelType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12425,7 +12425,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AgeRangeAgeRangeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType", false)) {
   /**
    * <span class="constraint Rejected">Used for return value only. An enumeration could not be processed, typically due to incompatibility with your WSDL version.</span>
    * @package Google_Api_Ads_AdWords_v201402
@@ -12458,7 +12458,7 @@ if (!class_exists("AgeRangeAgeRangeType", false)) {
   }
 }
 
-if (!class_exists("ApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApprovalStatus", false)) {
   /**
    * Approval status for the criterion.
    * Note: there are more states involved but we only expose two to users.
@@ -12492,7 +12492,7 @@ if (!class_exists("ApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12525,7 +12525,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12558,7 +12558,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BasicJobStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BasicJobStatus", false)) {
   /**
    * A basic set of job statuses.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12591,7 +12591,7 @@ if (!class_exists("BasicJobStatus", false)) {
   }
 }
 
-if (!class_exists("BetaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BetaErrorReason", false)) {
   /**
    * The reasons for the beta error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12624,7 +12624,7 @@ if (!class_exists("BetaErrorReason", false)) {
   }
 }
 
-if (!class_exists("BidModifierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidModifierSource", false)) {
   /**
    * Enumerates possible sources for bid modifier.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12657,7 +12657,7 @@ if (!class_exists("BidModifierSource", false)) {
   }
 }
 
-if (!class_exists("BidSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidSource", false)) {
   /**
    * Indicate where a criterion's bid came from: criterion or the adgroup it
    * belongs to.
@@ -12691,7 +12691,7 @@ if (!class_exists("BidSource", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12724,7 +12724,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorsReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason", false)) {
   /**
    * Bidding strategy cannot override ad group or campaign bidding strategy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12757,7 +12757,7 @@ if (!class_exists("BiddingErrorsReason", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategySource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategySource", false)) {
   /**
    * Indicates where bidding strategy came from: campaign, adgroup or criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12790,7 +12790,7 @@ if (!class_exists("BiddingStrategySource", false)) {
   }
 }
 
-if (!class_exists("BiddingStrategyType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingStrategyType", false)) {
   /**
    * The bidding strategy type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12823,7 +12823,7 @@ if (!class_exists("BiddingStrategyType", false)) {
   }
 }
 
-if (!class_exists("BiddingTransitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingTransitionErrorReason", false)) {
   /**
    * Reason for bidding transition error.
    * It is used by capability service as denial reasons, for bidding transition
@@ -12858,7 +12858,7 @@ if (!class_exists("BiddingTransitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod", false)) {
   /**
    * Budget delivery methods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12891,7 +12891,7 @@ if (!class_exists("BudgetBudgetDeliveryMethod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetPeriod", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod", false)) {
   /**
    * Budget periods.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12924,7 +12924,7 @@ if (!class_exists("BudgetBudgetPeriod", false)) {
   }
 }
 
-if (!class_exists("BudgetBudgetStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -12957,7 +12957,7 @@ if (!class_exists("BudgetBudgetStatus", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -12990,7 +12990,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BulkMutateJobErrorReason", false)) {
   /**
    * The reasons for the bulk mutate job handling error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13023,7 +13023,7 @@ if (!class_exists("BulkMutateJobErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionApprovalStatus", false)) {
   /**
    * Approval status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13056,7 +13056,7 @@ if (!class_exists("CampaignAdExtensionApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionStatus", false)) {
   /**
    * Status of the CampaignAdExtension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13089,7 +13089,7 @@ if (!class_exists("CampaignAdExtensionStatus", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionErrorReason", false)) {
   /**
    * Cannot operate on an adextensions under the wrong campaign
    * @package Google_Api_Ads_AdWords_v201402
@@ -13122,7 +13122,7 @@ if (!class_exists("CampaignAdExtensionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13155,7 +13155,7 @@ if (!class_exists("CampaignCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13188,7 +13188,7 @@ if (!class_exists("CampaignErrorReason", false)) {
   }
 }
 
-if (!class_exists("CampaignStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignStatus", false)) {
   /**
    * Campaign status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13221,7 +13221,7 @@ if (!class_exists("CampaignStatus", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -13255,7 +13255,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("ContentLabelType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ContentLabelType", false)) {
   /**
    * Content label type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13288,7 +13288,7 @@ if (!class_exists("ContentLabelType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType", false)) {
   /**
    * Average cost-per-acquisition (targetCPA) bid type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13321,7 +13321,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemeBidType", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -13354,7 +13354,7 @@ if (!class_exists("ConversionOptimizerBiddingSchemePricingMode", false)) {
   }
 }
 
-if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibilityRejectionReason", false)) {
   /**
    * Campaign is not active
    * @package Google_Api_Ads_AdWords_v201402
@@ -13387,7 +13387,7 @@ if (!class_exists("ConversionOptimizerEligibilityRejectionReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13420,7 +13420,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13453,7 +13453,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionTypeGroup", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionTypeGroup", false)) {
   /**
    * The list of groupings of criteria types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13486,7 +13486,7 @@ if (!class_exists("CriterionTypeGroup", false)) {
   }
 }
 
-if (!class_exists("CriterionUse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUse", false)) {
   /**
    * The way a criterion is used - biddable or negative.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13519,7 +13519,7 @@ if (!class_exists("CriterionUse", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13552,7 +13552,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13585,7 +13585,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DayOfWeek", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DayOfWeek", false)) {
   /**
    * Days of the week.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13618,7 +13618,7 @@ if (!class_exists("DayOfWeek", false)) {
   }
 }
 
-if (!class_exists("DeprecatedAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DeprecatedAdType", false)) {
   /**
    * Video ad.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13651,7 +13651,7 @@ if (!class_exists("DeprecatedAdType", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13684,7 +13684,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13717,7 +13717,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13750,7 +13750,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -13784,7 +13784,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("ExperimentDataStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus", false)) {
   /**
    * Status of the experimental change associated with an entity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13817,7 +13817,7 @@ if (!class_exists("ExperimentDataStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentDeltaStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus", false)) {
   /**
    * Status of an entity denoting its type of experimental change in a campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13850,7 +13850,7 @@ if (!class_exists("ExperimentDeltaStatus", false)) {
   }
 }
 
-if (!class_exists("ExperimentErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13883,7 +13883,7 @@ if (!class_exists("ExperimentErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemStatus", false)) {
   /**
    * Feed item is active
    * @package Google_Api_Ads_AdWords_v201402
@@ -13916,7 +13916,7 @@ if (!class_exists("FeedItemStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemErrorReason", false)) {
   /**
    * The reasons for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13949,7 +13949,7 @@ if (!class_exists("FeedItemErrorReason", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailApprovalStatus", false)) {
   /**
    * Feed item approval status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -13982,7 +13982,7 @@ if (!class_exists("FeedItemValidationDetailApprovalStatus", false)) {
   }
 }
 
-if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailValidationStatus", false)) {
   /**
    * Feed item validation status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14015,7 +14015,7 @@ if (!class_exists("FeedItemValidationDetailValidationStatus", false)) {
   }
 }
 
-if (!class_exists("ForwardCompatibilityErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason", false)) {
   /**
    * The reason for the error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14048,7 +14048,7 @@ if (!class_exists("ForwardCompatibilityErrorReason", false)) {
   }
 }
 
-if (!class_exists("FunctionOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionOperator", false)) {
   /**
    * Operators that can be used in functions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14081,7 +14081,7 @@ if (!class_exists("FunctionOperator", false)) {
   }
 }
 
-if (!class_exists("FunctionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FunctionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14114,7 +14114,7 @@ if (!class_exists("FunctionErrorReason", false)) {
   }
 }
 
-if (!class_exists("GenderGenderType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GenderGenderType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -14147,7 +14147,7 @@ if (!class_exists("GenderGenderType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   /**
    * The various signals a negative location target may use.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14180,7 +14180,7 @@ if (!class_exists("GeoTargetTypeSettingNegativeGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   /**
    * The various signals a positive location target may use.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14213,7 +14213,7 @@ if (!class_exists("GeoTargetTypeSettingPositiveGeoTargetType", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14246,7 +14246,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("ImageErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageErrorReason", false)) {
   /**
    * The image is not valid.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14279,7 +14279,7 @@ if (!class_exists("ImageErrorReason", false)) {
   }
 }
 
-if (!class_exists("IncomeTier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IncomeTier", false)) {
   /**
    * Income tiers that specify the income bracket a household falls under. TIER_1
    * belongs to the highest income bracket. The income bracket range associated with
@@ -14314,7 +14314,7 @@ if (!class_exists("IncomeTier", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14347,7 +14347,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("JobErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\JobErrorReason", false)) {
   /**
    * The reasons for the job handling error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14380,7 +14380,7 @@ if (!class_exists("JobErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -14414,7 +14414,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("Level", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Level", false)) {
   /**
    * The level on which the cap is to be applied.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14447,7 +14447,7 @@ if (!class_exists("Level", false)) {
   }
 }
 
-if (!class_exists("LocationExtensionSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationExtensionSource", false)) {
   /**
    * From manual entry in adwords frontend
    * @package Google_Api_Ads_AdWords_v201402
@@ -14480,7 +14480,7 @@ if (!class_exists("LocationExtensionSource", false)) {
   }
 }
 
-if (!class_exists("LocationOverrideInfoRadiusUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationOverrideInfoRadiusUnits", false)) {
   /**
    * Radius units
    * @package Google_Api_Ads_AdWords_v201402
@@ -14513,7 +14513,7 @@ if (!class_exists("LocationOverrideInfoRadiusUnits", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14546,7 +14546,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("MarkupLanguageType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MarkupLanguageType", false)) {
   /**
    * Markup languages to use for mobile ads.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14579,7 +14579,7 @@ if (!class_exists("MarkupLanguageType", false)) {
   }
 }
 
-if (!class_exists("MediaMediaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMediaType", false)) {
   /**
    * Media types
    * @package Google_Api_Ads_AdWords_v201402
@@ -14612,7 +14612,7 @@ if (!class_exists("MediaMediaType", false)) {
   }
 }
 
-if (!class_exists("MediaMimeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaMimeType", false)) {
   /**
    * Mime types
    * @package Google_Api_Ads_AdWords_v201402
@@ -14645,7 +14645,7 @@ if (!class_exists("MediaMimeType", false)) {
   }
 }
 
-if (!class_exists("MediaSize", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaSize", false)) {
   /**
    * Sizes for retrieving the original media
    * @package Google_Api_Ads_AdWords_v201402
@@ -14678,7 +14678,7 @@ if (!class_exists("MediaSize", false)) {
   }
 }
 
-if (!class_exists("MediaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MediaErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14711,7 +14711,7 @@ if (!class_exists("MediaErrorReason", false)) {
   }
 }
 
-if (!class_exists("MinuteOfHour", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MinuteOfHour", false)) {
   /**
    * Minutes in an hour.  Currently only 0, 15, 30, and 45 are supported
    * @package Google_Api_Ads_AdWords_v201402
@@ -14744,7 +14744,7 @@ if (!class_exists("MinuteOfHour", false)) {
   }
 }
 
-if (!class_exists("MobileDeviceDeviceType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -14777,7 +14777,7 @@ if (!class_exists("MobileDeviceDeviceType", false)) {
   }
 }
 
-if (!class_exists("MultiplierSource", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MultiplierSource", false)) {
   /**
    * Denotes whether the bid multiplier is derived from the adgroup
    * or the criterion
@@ -14811,7 +14811,7 @@ if (!class_exists("MultiplierSource", false)) {
   }
 }
 
-if (!class_exists("NewEntityCreationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason", false)) {
   /**
    * Do not set the id field while creating new entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14844,7 +14844,7 @@ if (!class_exists("NewEntityCreationErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14877,7 +14877,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14910,7 +14910,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatingSystemVersionOperatorType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType", false)) {
   /**
    * The operator type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14943,7 +14943,7 @@ if (!class_exists("OperatingSystemVersionOperatorType", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -14976,7 +14976,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15009,7 +15009,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15042,9 +15042,9 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   /**
-   * 
+   * First page on google.com.
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -15075,7 +15075,7 @@ if (!class_exists("PageOnePromotedBiddingSchemeStrategyGoal", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15108,7 +15108,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("PlacesOfInterestOperandCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperandCategory", false)) {
   /**
    * Categories to identify places of interest.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15141,7 +15141,7 @@ if (!class_exists("PlacesOfInterestOperandCategory", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorReason", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -15174,7 +15174,7 @@ if (!class_exists("PolicyViolationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalConditionCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition", false)) {
   /**
    * A canonical product condition.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15207,7 +15207,7 @@ if (!class_exists("ProductCanonicalConditionCondition", false)) {
   }
 }
 
-if (!class_exists("ProductDimensionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductDimensionType", false)) {
   /**
    * Type of product dimension.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15240,7 +15240,7 @@ if (!class_exists("ProductDimensionType", false)) {
   }
 }
 
-if (!class_exists("ProductPartitionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductPartitionType", false)) {
   /**
    * Type of a product partition in a shopping campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15273,7 +15273,7 @@ if (!class_exists("ProductPartitionType", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15306,7 +15306,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QueryErrorReason", false)) {
   /**
    * The reason for the query error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15339,7 +15339,7 @@ if (!class_exists("QueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -15373,7 +15373,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaErrorReason", false)) {
   /**
    * The reasons for the quota error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15406,7 +15406,7 @@ if (!class_exists("QuotaErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15439,7 +15439,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15472,7 +15472,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15505,7 +15505,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15538,7 +15538,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15571,7 +15571,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15604,7 +15604,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15637,7 +15637,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdAdAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAdAdAttribute", false)) {
   /**
    * A set of attributes that describe the rich media ad capabilities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15670,7 +15670,7 @@ if (!class_exists("RichMediaAdAdAttribute", false)) {
   }
 }
 
-if (!class_exists("RichMediaAdRichMediaAdType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RichMediaAdRichMediaAdType", false)) {
   /**
    * Different types of rich media ad that are available to customers.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15703,7 +15703,7 @@ if (!class_exists("RichMediaAdRichMediaAdType", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15736,7 +15736,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("ServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ServingStatus", false)) {
   /**
    * Campaign serving status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15769,7 +15769,7 @@ if (!class_exists("ServingStatus", false)) {
   }
 }
 
-if (!class_exists("SettingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SettingErrorReason", false)) {
   /**
    * The reasons for the setting error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15802,7 +15802,7 @@ if (!class_exists("SettingErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15835,7 +15835,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15868,7 +15868,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15901,7 +15901,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("SystemServingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SystemServingStatus", false)) {
   /**
    * Reported by system to reflect the criterion's serving status.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15934,7 +15934,7 @@ if (!class_exists("SystemServingStatus", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -15967,7 +15967,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("TemplateElementFieldType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TemplateElementFieldType", false)) {
   /**
    * Possible field types of template element fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16000,7 +16000,7 @@ if (!class_exists("TemplateElementFieldType", false)) {
   }
 }
 
-if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAdExpandingDirection", false)) {
   /**
    * Allowed expanding directions for ads that are expandable.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16033,7 +16033,7 @@ if (!class_exists("ThirdPartyRedirectAdExpandingDirection", false)) {
   }
 }
 
-if (!class_exists("TimeUnit", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TimeUnit", false)) {
   /**
    * Unit of time the cap is defined at.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16066,7 +16066,7 @@ if (!class_exists("TimeUnit", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16099,7 +16099,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("UserStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\UserStatus", false)) {
   /**
    * Specified by user to pause or unpause a criterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16132,7 +16132,7 @@ if (!class_exists("UserStatus", false)) {
   }
 }
 
-if (!class_exists("VideoType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\VideoType", false)) {
   /**
    * VideoType enum values that are permitted for video filterable
    * creative attribute IDs.
@@ -16166,7 +16166,7 @@ if (!class_exists("VideoType", false)) {
   }
 }
 
-if (!class_exists("WebpageConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageConditionOperand", false)) {
   /**
    * Operand value of {@link WebpageCondition}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16199,7 +16199,7 @@ if (!class_exists("WebpageConditionOperand", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateJobServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -16245,7 +16245,7 @@ if (!class_exists("MutateJobServiceGet", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateJobServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -16285,7 +16285,7 @@ if (!class_exists("MutateJobServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetResult", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -16332,7 +16332,7 @@ if (!class_exists("GetResult", false)) {
   }
 }
 
-if (!class_exists("GetResultResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetResultResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -16372,7 +16372,7 @@ if (!class_exists("GetResultResponse", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateJobServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -16432,7 +16432,7 @@ if (!class_exists("MutateJobServiceMutate", false)) {
   }
 }
 
-if (!class_exists("MutateJobServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MutateJobServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -16472,7 +16472,7 @@ if (!class_exists("MutateJobServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdError", false)) {
   /**
    * Base error class for Ad Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16517,7 +16517,7 @@ if (!class_exists("AdError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionError", false)) {
   /**
    * AdExtension errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16562,7 +16562,7 @@ if (!class_exists("AdExtensionError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideError", false)) {
   /**
    * AdExtensionOverride errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16607,7 +16607,7 @@ if (!class_exists("AdExtensionOverrideError", false)) {
   }
 }
 
-if (!class_exists("AdExtensionOverrideOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideOperation", false)) {
   /**
    * AdExtensionOverride service operation.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16650,7 +16650,7 @@ if (!class_exists("AdExtensionOverrideOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdCountLimitExceeded", false)) {
   /**
    * Indicates too many ads were added/enabled under the specified adgroup.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16689,7 +16689,7 @@ if (!class_exists("AdGroupAdCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdError", false)) {
   /**
    * Error information for AdGroupAdService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16734,7 +16734,7 @@ if (!class_exists("AdGroupAdError", false)) {
   }
 }
 
-if (!class_exists("AdGroupAdOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupAdOperation", false)) {
   /**
    * AdGroupAd service operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16784,7 +16784,7 @@ if (!class_exists("AdGroupAdOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidModifierOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierOperation", false)) {
   /**
    * Operation used to create or mutate a AdGroupBidModifier.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16827,7 +16827,7 @@ if (!class_exists("AdGroupBidModifierOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16872,7 +16872,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16918,7 +16918,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionOperation", false)) {
   /**
    * Operation (add, remove and set) on adgroup criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -16968,7 +16968,7 @@ if (!class_exists("AdGroupCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupOperation", false)) {
   /**
    * AdGroup operations for adding/updating/removing adgroups.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17011,7 +17011,7 @@ if (!class_exists("AdGroupOperation", false)) {
   }
 }
 
-if (!class_exists("AdGroupServiceError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupServiceError", false)) {
   /**
    * Represents possible error codes in AdGroupService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17063,7 +17063,7 @@ if (!class_exists("AdGroupServiceError", false)) {
   }
 }
 
-if (!class_exists("AdSchedule", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdSchedule", false)) {
   /**
    * Represents an AdSchedule Criterion.
    * AdSchedule is specified as day and time of the week criteria to target
@@ -17140,7 +17140,7 @@ if (!class_exists("AdSchedule", false)) {
   }
 }
 
-if (!class_exists("AdScheduleTarget", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdScheduleTarget", false)) {
   /**
    * Immutable structure to hold an ad schedule target.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17217,7 +17217,7 @@ if (!class_exists("AdScheduleTarget", false)) {
   }
 }
 
-if (!class_exists("AdScheduleTargetList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdScheduleTargetList", false)) {
   /**
    * List of ad schedule targets.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17260,7 +17260,7 @@ if (!class_exists("AdScheduleTargetList", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17305,10 +17305,10 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("AgeRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AgeRange", false)) {
   /**
    * Represents an Age Range criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only excludable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -17351,7 +17351,7 @@ if (!class_exists("AgeRange", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17394,7 +17394,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("Audio", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Audio", false)) {
   /**
    * Encapsulates an Audio media identified by a MediaId.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17460,7 +17460,7 @@ if (!class_exists("Audio", false)) {
   }
 }
 
-if (!class_exists("BudgetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetOperation", false)) {
   /**
    * Operations for adding/updating Budget entities.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17503,7 +17503,7 @@ if (!class_exists("BudgetOperation", false)) {
   }
 }
 
-if (!class_exists("BulkMutateJobSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BulkMutateJobSelector", false)) {
   /**
    * Specifies additional criteria for selecting bulk mutate jobs.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17554,7 +17554,7 @@ if (!class_exists("BulkMutateJobSelector", false)) {
   }
 }
 
-if (!class_exists("CampaignAdExtensionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionOperation", false)) {
   /**
    * CampaignAdExtension service operation. <b>Note:</b> The {@code SET} operator
    * is not supported.
@@ -17598,7 +17598,7 @@ if (!class_exists("CampaignAdExtensionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignCriterionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignCriterionOperation", false)) {
   /**
    * Generic operation (add, remove and set) for campaign criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17641,7 +17641,7 @@ if (!class_exists("CampaignCriterionOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignOperation", false)) {
   /**
    * An operation on an AdWords campaign.
    * <p class="note"><b>Note:</b> The <code>REMOVE</code> operator is not
@@ -17687,7 +17687,7 @@ if (!class_exists("CampaignOperation", false)) {
   }
 }
 
-if (!class_exists("CampaignTargetOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignTargetOperation", false)) {
   /**
    * Sets a list of targets on a specified campaign.
    * <p class="note"><b>Note:</b> Only the <code>SET</code> operator is supported.</p>
@@ -17731,10 +17731,10 @@ if (!class_exists("CampaignTargetOperation", false)) {
   }
 }
 
-if (!class_exists("Carrier", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Carrier", false)) {
   /**
    * Represents a Carrier Criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
@@ -17784,7 +17784,7 @@ if (!class_exists("Carrier", false)) {
   }
 }
 
-if (!class_exists("ContentLabel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ContentLabel", false)) {
   /**
    * Content Label for category exclusion.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -17829,7 +17829,7 @@ if (!class_exists("ContentLabel", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17869,7 +17869,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -17910,7 +17910,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("DynamicSearchAdsSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DynamicSearchAdsSetting", false)) {
   /**
    * Setting for controlling Dynamic Search Ads (DSA). Contains the domain name and the language
    * used by the DSA system to automatically generate landing pages and keywords for a campaign.
@@ -17960,7 +17960,7 @@ if (!class_exists("DynamicSearchAdsSetting", false)) {
   }
 }
 
-if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExplorerAutoOptimizerSetting", false)) {
   /**
    * Settings for Explorer (GDN Auto Optimizer).
    * @package Google_Api_Ads_AdWords_v201402
@@ -18002,7 +18002,7 @@ if (!class_exists("ExplorerAutoOptimizerSetting", false)) {
   }
 }
 
-if (!class_exists("FeedItemOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FeedItemOperation", false)) {
   /**
    * FeedItem service mutate operation.
    * @package Google_Api_Ads_AdWords_v201402
@@ -18045,7 +18045,7 @@ if (!class_exists("FeedItemOperation", false)) {
   }
 }
 
-if (!class_exists("GeoTargetOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetOperand", false)) {
   /**
    * Represents an operand containing geo information, specifying the scope of the
    * geographical area.
@@ -18088,7 +18088,7 @@ if (!class_exists("GeoTargetOperand", false)) {
   }
 }
 
-if (!class_exists("GeoTargetTypeSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSetting", false)) {
   /**
    * Represents a collection of settings related to ads geotargeting.
    * 
@@ -18162,7 +18162,7 @@ if (!class_exists("GeoTargetTypeSetting", false)) {
   }
 }
 
-if (!class_exists("Image", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Image", false)) {
   /**
    * Encapsulates an Image media. For {@code SET},{@code REMOVE} operations in
    * MediaService, use {@code mediaId}.
@@ -18215,7 +18215,7 @@ if (!class_exists("Image", false)) {
   }
 }
 
-if (!class_exists("IncomeOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IncomeOperand", false)) {
   /**
    * This operand specifies the income bracket a household falls under.
    * @package Google_Api_Ads_AdWords_v201402
@@ -18257,7 +18257,7 @@ if (!class_exists("IncomeOperand", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchSetting", false)) {
   /**
    * Improved exact and phrase match option includes misspellings, plurals,
    * and other close variants of your keywords.
@@ -18307,7 +18307,7 @@ if (!class_exists("KeywordMatchSetting", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -18348,7 +18348,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsGrouping", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping", false)) {
   /**
    * An {@code adwords grouping} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -18391,7 +18391,7 @@ if (!class_exists("ProductAdwordsGrouping", false)) {
   }
 }
 
-if (!class_exists("ProductAdwordsLabels", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels", false)) {
   /**
    * An {@code adwords labels} string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -18434,7 +18434,7 @@ if (!class_exists("ProductAdwordsLabels", false)) {
   }
 }
 
-if (!class_exists("ProductBiddingCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory", false)) {
   /**
    * One element of a bidding category at a certain level. Top-level categories are at level 1,
    * their children at level 2, and so on. We currently support up to 5 levels. The user must specify
@@ -18486,7 +18486,7 @@ if (!class_exists("ProductBiddingCategory", false)) {
   }
 }
 
-if (!class_exists("ProductBrand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductBrand", false)) {
   /**
    * A brand string.
    * @package Google_Api_Ads_AdWords_v201402
@@ -18528,7 +18528,7 @@ if (!class_exists("ProductBrand", false)) {
   }
 }
 
-if (!class_exists("ProductCanonicalCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition", false)) {
   /**
    * A canonical condition. Only supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -18571,7 +18571,7 @@ if (!class_exists("ProductCanonicalCondition", false)) {
   }
 }
 
-if (!class_exists("ProductLegacyCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition", false)) {
   /**
    * A plain condition string. Not supported by campaigns of
    * {@link AdvertisingChannelType#SHOPPING}.
@@ -18614,7 +18614,7 @@ if (!class_exists("ProductLegacyCondition", false)) {
   }
 }
 
-if (!class_exists("ProductCustomAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute", false)) {
   /**
    * A custom attribute value. As a product can have multiple custom attributes, the user must specify
    * a dimension type that indicates the index of the attribute by which to subdivide. All cases of
@@ -18665,7 +18665,7 @@ if (!class_exists("ProductCustomAttribute", false)) {
   }
 }
 
-if (!class_exists("RealTimeBiddingSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RealTimeBiddingSetting", false)) {
   /**
    * Settings for Real-Time Bidding, a feature only available for campaigns
    * targeting the Ad Exchange network.
@@ -18714,7 +18714,7 @@ if (!class_exists("MutateJobService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class MutateJobService extends AdWordsSoapClient {
+  class MutateJobService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "MutateJobService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -18731,381 +18731,381 @@ if (!class_exists("MutateJobService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Ad" => "Ad",
-      "AdError" => "AdError",
-      "AdExtension" => "AdExtension",
-      "AdExtensionError" => "AdExtensionError",
-      "AdExtensionOverride" => "AdExtensionOverride",
-      "AdExtensionOverrideError" => "AdExtensionOverrideError",
-      "AdExtensionOverrideOperation" => "AdExtensionOverrideOperation",
-      "AdGroup" => "AdGroup",
-      "AdGroupAd" => "AdGroupAd",
-      "AdGroupAdCountLimitExceeded" => "AdGroupAdCountLimitExceeded",
-      "AdGroupAdError" => "AdGroupAdError",
-      "AdGroupAdExperimentData" => "AdGroupAdExperimentData",
-      "AdGroupAdOperation" => "AdGroupAdOperation",
-      "AdGroupBidModifier" => "AdGroupBidModifier",
-      "AdGroupBidModifierOperation" => "AdGroupBidModifierOperation",
-      "AdGroupCriterion" => "AdGroupCriterion",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionExperimentBidMultiplier" => "AdGroupCriterionExperimentBidMultiplier",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdGroupCriterionOperation" => "AdGroupCriterionOperation",
-      "AdGroupExperimentBidMultipliers" => "AdGroupExperimentBidMultipliers",
-      "AdGroupExperimentData" => "AdGroupExperimentData",
-      "AdGroupOperation" => "AdGroupOperation",
-      "AdGroupServiceError" => "AdGroupServiceError",
-      "AdSchedule" => "AdSchedule",
-      "AdScheduleTarget" => "AdScheduleTarget",
-      "AdScheduleTargetList" => "AdScheduleTargetList",
-      "AdUnionId" => "AdUnionId",
-      "Address" => "Address",
-      "AdxError" => "AdxError",
-      "AgeRange" => "AgeRange",
-      "ApiError" => "ApiError",
-      "ApiErrorReason" => "ApiErrorReason",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "Audio" => "Audio",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "Bid" => "Bid",
-      "BidMultiplier" => "BidMultiplier",
-      "BiddableAdGroupCriterion" => "BiddableAdGroupCriterion",
-      "BiddableAdGroupCriterionExperimentData" => "BiddableAdGroupCriterionExperimentData",
-      "BiddingError" => "BiddingError",
-      "BiddingErrors" => "BiddingErrors",
-      "BiddingScheme" => "BiddingScheme",
-      "BiddingStrategyConfiguration" => "BiddingStrategyConfiguration",
-      "BiddingTransitionError" => "BiddingTransitionError",
-      "Bids" => "Bids",
-      "BillingSummary" => "BillingSummary",
-      "Budget" => "Budget",
-      "BudgetError" => "BudgetError",
-      "BudgetOperation" => "BudgetOperation",
-      "BudgetOptimizerBiddingScheme" => "BudgetOptimizerBiddingScheme",
-      "BulkMutateJobError" => "BulkMutateJobError",
-      "BulkMutateJobPolicy" => "BulkMutateJobPolicy",
-      "BulkMutateJobSelector" => "BulkMutateJobSelector",
-      "Campaign" => "Campaign",
-      "CampaignAdExtension" => "CampaignAdExtension",
-      "CampaignAdExtensionError" => "CampaignAdExtensionError",
-      "CampaignAdExtensionOperation" => "CampaignAdExtensionOperation",
-      "CampaignCriterion" => "CampaignCriterion",
-      "CampaignCriterionError" => "CampaignCriterionError",
-      "CampaignCriterionOperation" => "CampaignCriterionOperation",
-      "CampaignError" => "CampaignError",
-      "CampaignOperation" => "CampaignOperation",
-      "CampaignTargetOperation" => "CampaignTargetOperation",
-      "Carrier" => "Carrier",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "ContentLabel" => "ContentLabel",
-      "ConversionOptimizerBiddingScheme" => "ConversionOptimizerBiddingScheme",
-      "ConversionOptimizerEligibility" => "ConversionOptimizerEligibility",
-      "CpaBid" => "CpaBid",
-      "CpcBid" => "CpcBid",
-      "CpmBid" => "CpmBid",
-      "Criterion" => "Criterion",
-      "CriterionError" => "CriterionError",
-      "CriterionParameter" => "CriterionParameter",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DeprecatedAd" => "DeprecatedAd",
-      "Dimensions" => "Dimensions",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "DynamicSearchAdsSetting" => "DynamicSearchAdsSetting",
-      "EnhancedCpcBiddingScheme" => "EnhancedCpcBiddingScheme",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "ExemptionRequest" => "ExemptionRequest",
-      "ExperimentError" => "ExperimentError",
-      "ExplorerAutoOptimizerSetting" => "ExplorerAutoOptimizerSetting",
-      "FeedItem" => "FeedItem",
-      "FeedItemAttributeError" => "FeedItemAttributeError",
-      "FeedItemAttributeValue" => "FeedItemAttributeValue",
-      "FeedItemDevicePreference" => "FeedItemDevicePreference",
-      "FeedItemError" => "FeedItemError",
-      "FeedItemOperation" => "FeedItemOperation",
-      "FeedItemSchedule" => "FeedItemSchedule",
-      "FeedItemScheduling" => "FeedItemScheduling",
-      "FeedItemValidationDetail" => "FeedItemValidationDetail",
-      "ForwardCompatibilityError" => "ForwardCompatibilityError",
-      "FrequencyCap" => "FrequencyCap",
-      "Function" => "FeedFunction",
-      "FunctionError" => "FunctionError",
-      "Gender" => "Gender",
-      "GeoPoint" => "GeoPoint",
-      "GeoTargetOperand" => "GeoTargetOperand",
-      "GeoTargetTypeSetting" => "GeoTargetTypeSetting",
-      "IdError" => "IdError",
-      "Image" => "Image",
-      "ImageAd" => "ImageAd",
-      "ImageError" => "ImageError",
-      "IncomeOperand" => "IncomeOperand",
-      "InternalApiError" => "InternalApiError",
-      "IpBlock" => "IpBlock",
-      "Job" => "Job",
-      "JobError" => "JobError",
-      "JobEvent" => "JobEvent",
-      "JobResult" => "JobResult",
-      "JobSelector" => "JobSelector",
-      "JobStats" => "JobStats",
-      "Keyword" => "Keyword",
-      "KeywordMatchSetting" => "KeywordMatchSetting",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LocationExtension" => "LocationExtension",
-      "LocationOverrideInfo" => "LocationOverrideInfo",
-      "LocationSyncExtension" => "LocationSyncExtension",
-      "LongValue" => "LongValue",
-      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "ManualCPCAdGroupCriterionExperimentBidMultiplier",
-      "ManualCPCAdGroupExperimentBidMultipliers" => "ManualCPCAdGroupExperimentBidMultipliers",
-      "ManualCPMAdGroupExperimentBidMultipliers" => "ManualCPMAdGroupExperimentBidMultipliers",
-      "ManualCpcBiddingScheme" => "ManualCpcBiddingScheme",
-      "ManualCpmBiddingScheme" => "ManualCpmBiddingScheme",
-      "Media" => "Media",
-      "MediaError" => "MediaError",
-      "Media_Size_DimensionsMapEntry" => "Media_Size_DimensionsMapEntry",
-      "Media_Size_StringMapEntry" => "Media_Size_StringMapEntry",
-      "MobileAd" => "MobileAd",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "MobileDevice" => "MobileDevice",
-      "MobileImageAd" => "MobileImageAd",
-      "Money" => "Money",
-      "NegativeAdGroupCriterion" => "NegativeAdGroupCriterion",
-      "NegativeCampaignCriterion" => "NegativeCampaignCriterion",
-      "NetworkSetting" => "NetworkSetting",
-      "NewEntityCreationError" => "NewEntityCreationError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OAuthInfo" => "OAuthInfo",
-      "FunctionArgumentOperand" => "FunctionArgumentOperand",
-      "Operand" => "Operand",
-      "OperatingSystemVersion" => "OperatingSystemVersion",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OverrideInfo" => "OverrideInfo",
-      "PageOnePromotedBiddingScheme" => "PageOnePromotedBiddingScheme",
-      "PagingError" => "PagingError",
-      "PercentCpaBid" => "PercentCpaBid",
-      "PercentCpaBiddingScheme" => "PercentCpaBiddingScheme",
-      "PlaceHolder" => "PlaceHolder",
-      "Placement" => "Placement",
-      "PlacesOfInterestOperand" => "PlacesOfInterestOperand",
-      "Platform" => "Platform",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Product" => "Product",
-      "ProductAd" => "ProductAd",
-      "ProductAdwordsGrouping" => "ProductAdwordsGrouping",
-      "ProductAdwordsLabels" => "ProductAdwordsLabels",
-      "ProductBiddingCategory" => "ProductBiddingCategory",
-      "ProductBrand" => "ProductBrand",
-      "ProductCanonicalCondition" => "ProductCanonicalCondition",
-      "ProductLegacyCondition" => "ProductLegacyCondition",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "ProductCustomAttribute" => "ProductCustomAttribute",
-      "ProductDimension" => "ProductDimension",
-      "ProductOfferId" => "ProductOfferId",
-      "ProductPartition" => "ProductPartition",
-      "ProductSalesChannel" => "ProductSalesChannel",
-      "ProductScope" => "ProductScope",
-      "ProductType" => "ProductType",
-      "ProductTypeFull" => "ProductTypeFull",
-      "Proximity" => "Proximity",
-      "QualityInfo" => "QualityInfo",
-      "QueryError" => "QueryError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "QuotaError" => "QuotaError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RealTimeBiddingSetting" => "RealTimeBiddingSetting",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "RichMediaAd" => "RichMediaAd",
-      "SelectorError" => "SelectorError",
-      "LocationGroups" => "LocationGroups",
-      "Setting" => "Setting",
-      "SettingError" => "SettingError",
-      "ShoppingSetting" => "ShoppingSetting",
-      "SimpleMutateJob" => "SimpleMutateJob",
-      "SimpleMutateResult" => "SimpleMutateResult",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "String_StringMapEntry" => "String_StringMapEntry",
-      "Target" => "Target",
-      "TargetCpaBiddingScheme" => "TargetCpaBiddingScheme",
-      "TargetError" => "TargetError",
-      "TargetList" => "TargetList",
-      "TargetingSettingDetail" => "TargetingSettingDetail",
-      "TargetRoasBiddingScheme" => "TargetRoasBiddingScheme",
-      "TargetSpendBiddingScheme" => "TargetSpendBiddingScheme",
-      "TargetingSetting" => "TargetingSetting",
-      "TempAdUnionId" => "TempAdUnionId",
-      "TemplateAd" => "TemplateAd",
-      "TemplateElement" => "TemplateElement",
-      "TemplateElementField" => "TemplateElementField",
-      "TextAd" => "TextAd",
-      "ThirdPartyRedirectAd" => "ThirdPartyRedirectAd",
-      "TrackingSetting" => "TrackingSetting",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "Video" => "Video",
-      "Webpage" => "Webpage",
-      "WebpageCondition" => "WebpageCondition",
-      "WebpageParameter" => "WebpageParameter",
-      "DynamicSearchAd" => "DynamicSearchAd",
-      "AdError.Reason" => "AdErrorReason",
-      "AdExtensionError.Reason" => "AdExtensionErrorReason",
-      "AdExtensionOverride.ApprovalStatus" => "AdExtensionOverrideApprovalStatus",
-      "AdExtensionOverride.Status" => "AdExtensionOverrideStatus",
-      "AdExtensionOverrideError.Reason" => "AdExtensionOverrideErrorReason",
-      "AdGroupAd.ApprovalStatus" => "AdGroupAdApprovalStatus",
-      "AdGroupAd.Status" => "AdGroupAdStatus",
-      "AdGroupAdError.Reason" => "AdGroupAdErrorReason",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdGroupServiceError.Reason" => "AdGroupServiceErrorReason",
-      "AdGroup.Status" => "AdGroupStatus",
-      "AdServingOptimizationStatus" => "AdServingOptimizationStatus",
-      "AdvertisingChannelType" => "AdvertisingChannelType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AgeRange.AgeRangeType" => "AgeRangeAgeRangeType",
-      "ApprovalStatus" => "ApprovalStatus",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BasicJobStatus" => "BasicJobStatus",
-      "BetaError.Reason" => "BetaErrorReason",
-      "BidModifierSource" => "BidModifierSource",
-      "BidSource" => "BidSource",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BiddingErrors.Reason" => "BiddingErrorsReason",
-      "BiddingStrategySource" => "BiddingStrategySource",
-      "BiddingStrategyType" => "BiddingStrategyType",
-      "BiddingTransitionError.Reason" => "BiddingTransitionErrorReason",
-      "Budget.BudgetDeliveryMethod" => "BudgetBudgetDeliveryMethod",
-      "Budget.BudgetPeriod" => "BudgetBudgetPeriod",
-      "Budget.BudgetStatus" => "BudgetBudgetStatus",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "BulkMutateJobError.Reason" => "BulkMutateJobErrorReason",
-      "CampaignAdExtension.ApprovalStatus" => "CampaignAdExtensionApprovalStatus",
-      "CampaignAdExtension.Status" => "CampaignAdExtensionStatus",
-      "CampaignAdExtensionError.Reason" => "CampaignAdExtensionErrorReason",
-      "CampaignCriterionError.Reason" => "CampaignCriterionErrorReason",
-      "CampaignError.Reason" => "CampaignErrorReason",
-      "CampaignStatus" => "CampaignStatus",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "ContentLabelType" => "ContentLabelType",
-      "ConversionOptimizerBiddingScheme.BidType" => "ConversionOptimizerBiddingSchemeBidType",
-      "ConversionOptimizerBiddingScheme.PricingMode" => "ConversionOptimizerBiddingSchemePricingMode",
-      "ConversionOptimizerEligibility.RejectionReason" => "ConversionOptimizerEligibilityRejectionReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "CriterionTypeGroup" => "CriterionTypeGroup",
-      "CriterionUse" => "CriterionUse",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DayOfWeek" => "DayOfWeek",
-      "DeprecatedAd.Type" => "DeprecatedAdType",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "ExperimentDataStatus" => "ExperimentDataStatus",
-      "ExperimentDeltaStatus" => "ExperimentDeltaStatus",
-      "ExperimentError.Reason" => "ExperimentErrorReason",
-      "FeedItem.Status" => "FeedItemStatus",
-      "FeedItemError.Reason" => "FeedItemErrorReason",
-      "FeedItemValidationDetail.ApprovalStatus" => "FeedItemValidationDetailApprovalStatus",
-      "FeedItemValidationDetail.ValidationStatus" => "FeedItemValidationDetailValidationStatus",
-      "ForwardCompatibilityError.Reason" => "ForwardCompatibilityErrorReason",
-      "Function.Operator" => "FunctionOperator",
-      "FunctionError.Reason" => "FunctionErrorReason",
-      "Gender.GenderType" => "GenderGenderType",
-      "GeoTargetTypeSetting.NegativeGeoTargetType" => "GeoTargetTypeSettingNegativeGeoTargetType",
-      "GeoTargetTypeSetting.PositiveGeoTargetType" => "GeoTargetTypeSettingPositiveGeoTargetType",
-      "IdError.Reason" => "IdErrorReason",
-      "ImageError.Reason" => "ImageErrorReason",
-      "IncomeTier" => "IncomeTier",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "JobError.Reason" => "JobErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "Level" => "Level",
-      "LocationExtension.Source" => "LocationExtensionSource",
-      "LocationOverrideInfo.RadiusUnits" => "LocationOverrideInfoRadiusUnits",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "MarkupLanguageType" => "MarkupLanguageType",
-      "Media.MediaType" => "MediaMediaType",
-      "Media.MimeType" => "MediaMimeType",
-      "Media.Size" => "MediaSize",
-      "MediaError.Reason" => "MediaErrorReason",
-      "MinuteOfHour" => "MinuteOfHour",
-      "MobileDevice.DeviceType" => "MobileDeviceDeviceType",
-      "MultiplierSource" => "MultiplierSource",
-      "NewEntityCreationError.Reason" => "NewEntityCreationErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatingSystemVersion.OperatorType" => "OperatingSystemVersionOperatorType",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PageOnePromotedBiddingScheme.StrategyGoal" => "PageOnePromotedBiddingSchemeStrategyGoal",
-      "PagingError.Reason" => "PagingErrorReason",
-      "PlacesOfInterestOperand.Category" => "PlacesOfInterestOperandCategory",
-      "PolicyViolationError.Reason" => "PolicyViolationErrorReason",
-      "ProductCanonicalCondition.Condition" => "ProductCanonicalConditionCondition",
-      "ProductDimensionType" => "ProductDimensionType",
-      "ProductPartitionType" => "ProductPartitionType",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QueryError.Reason" => "QueryErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "QuotaError.Reason" => "QuotaErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "RichMediaAd.AdAttribute" => "RichMediaAdAdAttribute",
-      "RichMediaAd.RichMediaAdType" => "RichMediaAdRichMediaAdType",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "ServingStatus" => "ServingStatus",
-      "SettingError.Reason" => "SettingErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "SystemServingStatus" => "SystemServingStatus",
-      "TargetError.Reason" => "TargetErrorReason",
-      "TemplateElementField.Type" => "TemplateElementFieldType",
-      "ThirdPartyRedirectAd.ExpandingDirection" => "ThirdPartyRedirectAdExpandingDirection",
-      "TimeUnit" => "TimeUnit",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "UserStatus" => "UserStatus",
-      "VideoType" => "VideoType",
-      "WebpageConditionOperand" => "WebpageConditionOperand",
-      "get" => "MutateJobServiceGet",
-      "getResponse" => "MutateJobServiceGetResponse",
-      "getResult" => "GetResult",
-      "getResultResponse" => "GetResultResponse",
-      "mutate" => "MutateJobServiceMutate",
-      "mutateResponse" => "MutateJobServiceMutateResponse",
+      "Ad" => "Google_Api_Ads_AdWords_v201402\\Ad",
+      "AdError" => "Google_Api_Ads_AdWords_v201402\\AdError",
+      "AdExtension" => "Google_Api_Ads_AdWords_v201402\\AdExtension",
+      "AdExtensionError" => "Google_Api_Ads_AdWords_v201402\\AdExtensionError",
+      "AdExtensionOverride" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverride",
+      "AdExtensionOverrideError" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideError",
+      "AdExtensionOverrideOperation" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideOperation",
+      "AdGroup" => "Google_Api_Ads_AdWords_v201402\\AdGroup",
+      "AdGroupAd" => "Google_Api_Ads_AdWords_v201402\\AdGroupAd",
+      "AdGroupAdCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdCountLimitExceeded",
+      "AdGroupAdError" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdError",
+      "AdGroupAdExperimentData" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdExperimentData",
+      "AdGroupAdOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdOperation",
+      "AdGroupBidModifier" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifier",
+      "AdGroupBidModifierOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidModifierOperation",
+      "AdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterion",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError",
+      "AdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionExperimentBidMultiplier",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded",
+      "AdGroupCriterionOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionOperation",
+      "AdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\AdGroupExperimentBidMultipliers",
+      "AdGroupExperimentData" => "Google_Api_Ads_AdWords_v201402\\AdGroupExperimentData",
+      "AdGroupOperation" => "Google_Api_Ads_AdWords_v201402\\AdGroupOperation",
+      "AdGroupServiceError" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceError",
+      "AdSchedule" => "Google_Api_Ads_AdWords_v201402\\AdSchedule",
+      "AdScheduleTarget" => "Google_Api_Ads_AdWords_v201402\\AdScheduleTarget",
+      "AdScheduleTargetList" => "Google_Api_Ads_AdWords_v201402\\AdScheduleTargetList",
+      "AdUnionId" => "Google_Api_Ads_AdWords_v201402\\AdUnionId",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "AgeRange" => "Google_Api_Ads_AdWords_v201402\\AgeRange",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiErrorReason" => "Google_Api_Ads_AdWords_v201402\\ApiErrorReason",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "Audio" => "Google_Api_Ads_AdWords_v201402\\Audio",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "Bid" => "Google_Api_Ads_AdWords_v201402\\Bid",
+      "BidMultiplier" => "Google_Api_Ads_AdWords_v201402\\BidMultiplier",
+      "BiddableAdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterion",
+      "BiddableAdGroupCriterionExperimentData" => "Google_Api_Ads_AdWords_v201402\\BiddableAdGroupCriterionExperimentData",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201402\\BiddingError",
+      "BiddingErrors" => "Google_Api_Ads_AdWords_v201402\\BiddingErrors",
+      "BiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BiddingScheme",
+      "BiddingStrategyConfiguration" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyConfiguration",
+      "BiddingTransitionError" => "Google_Api_Ads_AdWords_v201402\\BiddingTransitionError",
+      "Bids" => "Google_Api_Ads_AdWords_v201402\\Bids",
+      "BillingSummary" => "Google_Api_Ads_AdWords_v201402\\BillingSummary",
+      "Budget" => "Google_Api_Ads_AdWords_v201402\\Budget",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201402\\BudgetError",
+      "BudgetOperation" => "Google_Api_Ads_AdWords_v201402\\BudgetOperation",
+      "BudgetOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\BudgetOptimizerBiddingScheme",
+      "BulkMutateJobError" => "Google_Api_Ads_AdWords_v201402\\BulkMutateJobError",
+      "BulkMutateJobPolicy" => "Google_Api_Ads_AdWords_v201402\\BulkMutateJobPolicy",
+      "BulkMutateJobSelector" => "Google_Api_Ads_AdWords_v201402\\BulkMutateJobSelector",
+      "Campaign" => "Google_Api_Ads_AdWords_v201402\\Campaign",
+      "CampaignAdExtension" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtension",
+      "CampaignAdExtensionError" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionError",
+      "CampaignAdExtensionOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionOperation",
+      "CampaignCriterion" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterion",
+      "CampaignCriterionError" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionError",
+      "CampaignCriterionOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionOperation",
+      "CampaignError" => "Google_Api_Ads_AdWords_v201402\\CampaignError",
+      "CampaignOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignOperation",
+      "CampaignTargetOperation" => "Google_Api_Ads_AdWords_v201402\\CampaignTargetOperation",
+      "Carrier" => "Google_Api_Ads_AdWords_v201402\\Carrier",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "ContentLabel" => "Google_Api_Ads_AdWords_v201402\\ContentLabel",
+      "ConversionOptimizerBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingScheme",
+      "ConversionOptimizerEligibility" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibility",
+      "CpaBid" => "Google_Api_Ads_AdWords_v201402\\CpaBid",
+      "CpcBid" => "Google_Api_Ads_AdWords_v201402\\CpcBid",
+      "CpmBid" => "Google_Api_Ads_AdWords_v201402\\CpmBid",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201402\\CriterionError",
+      "CriterionParameter" => "Google_Api_Ads_AdWords_v201402\\CriterionParameter",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201402\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DeprecatedAd" => "Google_Api_Ads_AdWords_v201402\\DeprecatedAd",
+      "Dimensions" => "Google_Api_Ads_AdWords_v201402\\Dimensions",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "DynamicSearchAdsSetting" => "Google_Api_Ads_AdWords_v201402\\DynamicSearchAdsSetting",
+      "EnhancedCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\EnhancedCpcBiddingScheme",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDenied",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "ExemptionRequest" => "Google_Api_Ads_AdWords_v201402\\ExemptionRequest",
+      "ExperimentError" => "Google_Api_Ads_AdWords_v201402\\ExperimentError",
+      "ExplorerAutoOptimizerSetting" => "Google_Api_Ads_AdWords_v201402\\ExplorerAutoOptimizerSetting",
+      "FeedItem" => "Google_Api_Ads_AdWords_v201402\\FeedItem",
+      "FeedItemAttributeError" => "Google_Api_Ads_AdWords_v201402\\FeedItemAttributeError",
+      "FeedItemAttributeValue" => "Google_Api_Ads_AdWords_v201402\\FeedItemAttributeValue",
+      "FeedItemDevicePreference" => "Google_Api_Ads_AdWords_v201402\\FeedItemDevicePreference",
+      "FeedItemError" => "Google_Api_Ads_AdWords_v201402\\FeedItemError",
+      "FeedItemOperation" => "Google_Api_Ads_AdWords_v201402\\FeedItemOperation",
+      "FeedItemSchedule" => "Google_Api_Ads_AdWords_v201402\\FeedItemSchedule",
+      "FeedItemScheduling" => "Google_Api_Ads_AdWords_v201402\\FeedItemScheduling",
+      "FeedItemValidationDetail" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetail",
+      "ForwardCompatibilityError" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityError",
+      "FrequencyCap" => "Google_Api_Ads_AdWords_v201402\\FrequencyCap",
+      "Function" => "Google_Api_Ads_AdWords_v201402\\FeedFunction",
+      "FunctionError" => "Google_Api_Ads_AdWords_v201402\\FunctionError",
+      "Gender" => "Google_Api_Ads_AdWords_v201402\\Gender",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "GeoTargetOperand" => "Google_Api_Ads_AdWords_v201402\\GeoTargetOperand",
+      "GeoTargetTypeSetting" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSetting",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "Image" => "Google_Api_Ads_AdWords_v201402\\Image",
+      "ImageAd" => "Google_Api_Ads_AdWords_v201402\\ImageAd",
+      "ImageError" => "Google_Api_Ads_AdWords_v201402\\ImageError",
+      "IncomeOperand" => "Google_Api_Ads_AdWords_v201402\\IncomeOperand",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "IpBlock" => "Google_Api_Ads_AdWords_v201402\\IpBlock",
+      "Job" => "Google_Api_Ads_AdWords_v201402\\Job",
+      "JobError" => "Google_Api_Ads_AdWords_v201402\\JobError",
+      "JobEvent" => "Google_Api_Ads_AdWords_v201402\\JobEvent",
+      "JobResult" => "Google_Api_Ads_AdWords_v201402\\JobResult",
+      "JobSelector" => "Google_Api_Ads_AdWords_v201402\\JobSelector",
+      "JobStats" => "Google_Api_Ads_AdWords_v201402\\JobStats",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "KeywordMatchSetting" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchSetting",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "LocationExtension" => "Google_Api_Ads_AdWords_v201402\\LocationExtension",
+      "LocationOverrideInfo" => "Google_Api_Ads_AdWords_v201402\\LocationOverrideInfo",
+      "LocationSyncExtension" => "Google_Api_Ads_AdWords_v201402\\LocationSyncExtension",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "ManualCPCAdGroupCriterionExperimentBidMultiplier" => "Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupCriterionExperimentBidMultiplier",
+      "ManualCPCAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\ManualCPCAdGroupExperimentBidMultipliers",
+      "ManualCPMAdGroupExperimentBidMultipliers" => "Google_Api_Ads_AdWords_v201402\\ManualCPMAdGroupExperimentBidMultipliers",
+      "ManualCpcBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpcBiddingScheme",
+      "ManualCpmBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\ManualCpmBiddingScheme",
+      "Media" => "Google_Api_Ads_AdWords_v201402\\Media",
+      "MediaError" => "Google_Api_Ads_AdWords_v201402\\MediaError",
+      "Media_Size_DimensionsMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_DimensionsMapEntry",
+      "Media_Size_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\Media_Size_StringMapEntry",
+      "MobileAd" => "Google_Api_Ads_AdWords_v201402\\MobileAd",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "MobileDevice" => "Google_Api_Ads_AdWords_v201402\\MobileDevice",
+      "MobileImageAd" => "Google_Api_Ads_AdWords_v201402\\MobileImageAd",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NegativeAdGroupCriterion" => "Google_Api_Ads_AdWords_v201402\\NegativeAdGroupCriterion",
+      "NegativeCampaignCriterion" => "Google_Api_Ads_AdWords_v201402\\NegativeCampaignCriterion",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201402\\NetworkSetting",
+      "NewEntityCreationError" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OAuthInfo" => "Google_Api_Ads_AdWords_v201402\\OAuthInfo",
+      "FunctionArgumentOperand" => "Google_Api_Ads_AdWords_v201402\\FunctionArgumentOperand",
+      "Operand" => "Google_Api_Ads_AdWords_v201402\\Operand",
+      "OperatingSystemVersion" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersion",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OverrideInfo" => "Google_Api_Ads_AdWords_v201402\\OverrideInfo",
+      "PageOnePromotedBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingScheme",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "PercentCpaBid" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBid",
+      "PercentCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\PercentCpaBiddingScheme",
+      "PlaceHolder" => "Google_Api_Ads_AdWords_v201402\\PlaceHolder",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "PlacesOfInterestOperand" => "Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperand",
+      "Platform" => "Google_Api_Ads_AdWords_v201402\\Platform",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationKey",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductAd" => "Google_Api_Ads_AdWords_v201402\\ProductAd",
+      "ProductAdwordsGrouping" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsGrouping",
+      "ProductAdwordsLabels" => "Google_Api_Ads_AdWords_v201402\\ProductAdwordsLabels",
+      "ProductBiddingCategory" => "Google_Api_Ads_AdWords_v201402\\ProductBiddingCategory",
+      "ProductBrand" => "Google_Api_Ads_AdWords_v201402\\ProductBrand",
+      "ProductCanonicalCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalCondition",
+      "ProductLegacyCondition" => "Google_Api_Ads_AdWords_v201402\\ProductLegacyCondition",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "ProductCustomAttribute" => "Google_Api_Ads_AdWords_v201402\\ProductCustomAttribute",
+      "ProductDimension" => "Google_Api_Ads_AdWords_v201402\\ProductDimension",
+      "ProductOfferId" => "Google_Api_Ads_AdWords_v201402\\ProductOfferId",
+      "ProductPartition" => "Google_Api_Ads_AdWords_v201402\\ProductPartition",
+      "ProductSalesChannel" => "Google_Api_Ads_AdWords_v201402\\ProductSalesChannel",
+      "ProductScope" => "Google_Api_Ads_AdWords_v201402\\ProductScope",
+      "ProductType" => "Google_Api_Ads_AdWords_v201402\\ProductType",
+      "ProductTypeFull" => "Google_Api_Ads_AdWords_v201402\\ProductTypeFull",
+      "Proximity" => "Google_Api_Ads_AdWords_v201402\\Proximity",
+      "QualityInfo" => "Google_Api_Ads_AdWords_v201402\\QualityInfo",
+      "QueryError" => "Google_Api_Ads_AdWords_v201402\\QueryError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "QuotaError" => "Google_Api_Ads_AdWords_v201402\\QuotaError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RealTimeBiddingSetting" => "Google_Api_Ads_AdWords_v201402\\RealTimeBiddingSetting",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "RichMediaAd" => "Google_Api_Ads_AdWords_v201402\\RichMediaAd",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "LocationGroups" => "Google_Api_Ads_AdWords_v201402\\LocationGroups",
+      "Setting" => "Google_Api_Ads_AdWords_v201402\\Setting",
+      "SettingError" => "Google_Api_Ads_AdWords_v201402\\SettingError",
+      "ShoppingSetting" => "Google_Api_Ads_AdWords_v201402\\ShoppingSetting",
+      "SimpleMutateJob" => "Google_Api_Ads_AdWords_v201402\\SimpleMutateJob",
+      "SimpleMutateResult" => "Google_Api_Ads_AdWords_v201402\\SimpleMutateResult",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "String_StringMapEntry" => "Google_Api_Ads_AdWords_v201402\\String_StringMapEntry",
+      "Target" => "Google_Api_Ads_AdWords_v201402\\Target",
+      "TargetCpaBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetCpaBiddingScheme",
+      "TargetError" => "Google_Api_Ads_AdWords_v201402\\TargetError",
+      "TargetList" => "Google_Api_Ads_AdWords_v201402\\TargetList",
+      "TargetingSettingDetail" => "Google_Api_Ads_AdWords_v201402\\TargetingSettingDetail",
+      "TargetRoasBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetRoasBiddingScheme",
+      "TargetSpendBiddingScheme" => "Google_Api_Ads_AdWords_v201402\\TargetSpendBiddingScheme",
+      "TargetingSetting" => "Google_Api_Ads_AdWords_v201402\\TargetingSetting",
+      "TempAdUnionId" => "Google_Api_Ads_AdWords_v201402\\TempAdUnionId",
+      "TemplateAd" => "Google_Api_Ads_AdWords_v201402\\TemplateAd",
+      "TemplateElement" => "Google_Api_Ads_AdWords_v201402\\TemplateElement",
+      "TemplateElementField" => "Google_Api_Ads_AdWords_v201402\\TemplateElementField",
+      "TextAd" => "Google_Api_Ads_AdWords_v201402\\TextAd",
+      "ThirdPartyRedirectAd" => "Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAd",
+      "TrackingSetting" => "Google_Api_Ads_AdWords_v201402\\TrackingSetting",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "Video" => "Google_Api_Ads_AdWords_v201402\\Video",
+      "Webpage" => "Google_Api_Ads_AdWords_v201402\\Webpage",
+      "WebpageCondition" => "Google_Api_Ads_AdWords_v201402\\WebpageCondition",
+      "WebpageParameter" => "Google_Api_Ads_AdWords_v201402\\WebpageParameter",
+      "DynamicSearchAd" => "Google_Api_Ads_AdWords_v201402\\DynamicSearchAd",
+      "AdError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdErrorReason",
+      "AdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdExtensionErrorReason",
+      "AdExtensionOverride.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideApprovalStatus",
+      "AdExtensionOverride.Status" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideStatus",
+      "AdExtensionOverrideError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdExtensionOverrideErrorReason",
+      "AdGroupAd.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdApprovalStatus",
+      "AdGroupAd.Status" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdStatus",
+      "AdGroupAdError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupAdErrorReason",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdGroupServiceError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupServiceErrorReason",
+      "AdGroup.Status" => "Google_Api_Ads_AdWords_v201402\\AdGroupStatus",
+      "AdServingOptimizationStatus" => "Google_Api_Ads_AdWords_v201402\\AdServingOptimizationStatus",
+      "AdvertisingChannelType" => "Google_Api_Ads_AdWords_v201402\\AdvertisingChannelType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AgeRange.AgeRangeType" => "Google_Api_Ads_AdWords_v201402\\AgeRangeAgeRangeType",
+      "ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\ApprovalStatus",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BasicJobStatus" => "Google_Api_Ads_AdWords_v201402\\BasicJobStatus",
+      "BetaError.Reason" => "Google_Api_Ads_AdWords_v201402\\BetaErrorReason",
+      "BidModifierSource" => "Google_Api_Ads_AdWords_v201402\\BidModifierSource",
+      "BidSource" => "Google_Api_Ads_AdWords_v201402\\BidSource",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorReason",
+      "BiddingErrors.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorsReason",
+      "BiddingStrategySource" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategySource",
+      "BiddingStrategyType" => "Google_Api_Ads_AdWords_v201402\\BiddingStrategyType",
+      "BiddingTransitionError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingTransitionErrorReason",
+      "Budget.BudgetDeliveryMethod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetDeliveryMethod",
+      "Budget.BudgetPeriod" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetPeriod",
+      "Budget.BudgetStatus" => "Google_Api_Ads_AdWords_v201402\\BudgetBudgetStatus",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetErrorReason",
+      "BulkMutateJobError.Reason" => "Google_Api_Ads_AdWords_v201402\\BulkMutateJobErrorReason",
+      "CampaignAdExtension.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionApprovalStatus",
+      "CampaignAdExtension.Status" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionStatus",
+      "CampaignAdExtensionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignAdExtensionErrorReason",
+      "CampaignCriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignCriterionErrorReason",
+      "CampaignError.Reason" => "Google_Api_Ads_AdWords_v201402\\CampaignErrorReason",
+      "CampaignStatus" => "Google_Api_Ads_AdWords_v201402\\CampaignStatus",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "ContentLabelType" => "Google_Api_Ads_AdWords_v201402\\ContentLabelType",
+      "ConversionOptimizerBiddingScheme.BidType" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemeBidType",
+      "ConversionOptimizerBiddingScheme.PricingMode" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerBiddingSchemePricingMode",
+      "ConversionOptimizerEligibility.RejectionReason" => "Google_Api_Ads_AdWords_v201402\\ConversionOptimizerEligibilityRejectionReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CriterionErrorReason",
+      "CriterionTypeGroup" => "Google_Api_Ads_AdWords_v201402\\CriterionTypeGroup",
+      "CriterionUse" => "Google_Api_Ads_AdWords_v201402\\CriterionUse",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DayOfWeek" => "Google_Api_Ads_AdWords_v201402\\DayOfWeek",
+      "DeprecatedAd.Type" => "Google_Api_Ads_AdWords_v201402\\DeprecatedAdType",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "ExperimentDataStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDataStatus",
+      "ExperimentDeltaStatus" => "Google_Api_Ads_AdWords_v201402\\ExperimentDeltaStatus",
+      "ExperimentError.Reason" => "Google_Api_Ads_AdWords_v201402\\ExperimentErrorReason",
+      "FeedItem.Status" => "Google_Api_Ads_AdWords_v201402\\FeedItemStatus",
+      "FeedItemError.Reason" => "Google_Api_Ads_AdWords_v201402\\FeedItemErrorReason",
+      "FeedItemValidationDetail.ApprovalStatus" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailApprovalStatus",
+      "FeedItemValidationDetail.ValidationStatus" => "Google_Api_Ads_AdWords_v201402\\FeedItemValidationDetailValidationStatus",
+      "ForwardCompatibilityError.Reason" => "Google_Api_Ads_AdWords_v201402\\ForwardCompatibilityErrorReason",
+      "Function.Operator" => "Google_Api_Ads_AdWords_v201402\\FunctionOperator",
+      "FunctionError.Reason" => "Google_Api_Ads_AdWords_v201402\\FunctionErrorReason",
+      "Gender.GenderType" => "Google_Api_Ads_AdWords_v201402\\GenderGenderType",
+      "GeoTargetTypeSetting.NegativeGeoTargetType" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingNegativeGeoTargetType",
+      "GeoTargetTypeSetting.PositiveGeoTargetType" => "Google_Api_Ads_AdWords_v201402\\GeoTargetTypeSettingPositiveGeoTargetType",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "ImageError.Reason" => "Google_Api_Ads_AdWords_v201402\\ImageErrorReason",
+      "IncomeTier" => "Google_Api_Ads_AdWords_v201402\\IncomeTier",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "JobError.Reason" => "Google_Api_Ads_AdWords_v201402\\JobErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "Level" => "Google_Api_Ads_AdWords_v201402\\Level",
+      "LocationExtension.Source" => "Google_Api_Ads_AdWords_v201402\\LocationExtensionSource",
+      "LocationOverrideInfo.RadiusUnits" => "Google_Api_Ads_AdWords_v201402\\LocationOverrideInfoRadiusUnits",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "MarkupLanguageType" => "Google_Api_Ads_AdWords_v201402\\MarkupLanguageType",
+      "Media.MediaType" => "Google_Api_Ads_AdWords_v201402\\MediaMediaType",
+      "Media.MimeType" => "Google_Api_Ads_AdWords_v201402\\MediaMimeType",
+      "Media.Size" => "Google_Api_Ads_AdWords_v201402\\MediaSize",
+      "MediaError.Reason" => "Google_Api_Ads_AdWords_v201402\\MediaErrorReason",
+      "MinuteOfHour" => "Google_Api_Ads_AdWords_v201402\\MinuteOfHour",
+      "MobileDevice.DeviceType" => "Google_Api_Ads_AdWords_v201402\\MobileDeviceDeviceType",
+      "MultiplierSource" => "Google_Api_Ads_AdWords_v201402\\MultiplierSource",
+      "NewEntityCreationError.Reason" => "Google_Api_Ads_AdWords_v201402\\NewEntityCreationErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperatingSystemVersion.OperatorType" => "Google_Api_Ads_AdWords_v201402\\OperatingSystemVersionOperatorType",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PageOnePromotedBiddingScheme.StrategyGoal" => "Google_Api_Ads_AdWords_v201402\\PageOnePromotedBiddingSchemeStrategyGoal",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "PlacesOfInterestOperand.Category" => "Google_Api_Ads_AdWords_v201402\\PlacesOfInterestOperandCategory",
+      "PolicyViolationError.Reason" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorReason",
+      "ProductCanonicalCondition.Condition" => "Google_Api_Ads_AdWords_v201402\\ProductCanonicalConditionCondition",
+      "ProductDimensionType" => "Google_Api_Ads_AdWords_v201402\\ProductDimensionType",
+      "ProductPartitionType" => "Google_Api_Ads_AdWords_v201402\\ProductPartitionType",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits",
+      "QueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\QueryErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "QuotaError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "RichMediaAd.AdAttribute" => "Google_Api_Ads_AdWords_v201402\\RichMediaAdAdAttribute",
+      "RichMediaAd.RichMediaAdType" => "Google_Api_Ads_AdWords_v201402\\RichMediaAdRichMediaAdType",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "ServingStatus" => "Google_Api_Ads_AdWords_v201402\\ServingStatus",
+      "SettingError.Reason" => "Google_Api_Ads_AdWords_v201402\\SettingErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "SystemServingStatus" => "Google_Api_Ads_AdWords_v201402\\SystemServingStatus",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201402\\TargetErrorReason",
+      "TemplateElementField.Type" => "Google_Api_Ads_AdWords_v201402\\TemplateElementFieldType",
+      "ThirdPartyRedirectAd.ExpandingDirection" => "Google_Api_Ads_AdWords_v201402\\ThirdPartyRedirectAdExpandingDirection",
+      "TimeUnit" => "Google_Api_Ads_AdWords_v201402\\TimeUnit",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "UserStatus" => "Google_Api_Ads_AdWords_v201402\\UserStatus",
+      "VideoType" => "Google_Api_Ads_AdWords_v201402\\VideoType",
+      "WebpageConditionOperand" => "Google_Api_Ads_AdWords_v201402\\WebpageConditionOperand",
+      "get" => "Google_Api_Ads_AdWords_v201402\\MutateJobServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\MutateJobServiceGetResponse",
+      "getResult" => "Google_Api_Ads_AdWords_v201402\\GetResult",
+      "getResultResponse" => "Google_Api_Ads_AdWords_v201402\\GetResultResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\MutateJobServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\MutateJobServiceMutateResponse",
     );
 
 
@@ -19171,3 +19171,4 @@ if (!class_exists("MutateJobService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/OfflineConversionFeedService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/OfflineConversionFeedService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("OfflineConversionFeed", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionFeed", false)) {
   /**
    * Represents an entire record in the offline conversions feed that the advertiser uploads.
    * @package Google_Api_Ads_AdWords_v201402
@@ -91,7 +91,7 @@ if (!class_exists("OfflineConversionFeed", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -171,7 +171,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -239,7 +239,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -307,7 +307,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -404,7 +404,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -483,7 +483,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("ListReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ListReturnValue", false)) {
   /**
    * Base list return value type.
    * @package Google_Api_Ads_AdWords_v201402
@@ -555,7 +555,7 @@ if (!class_exists("ListReturnValue", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -588,7 +588,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -621,7 +621,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -655,7 +655,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -688,7 +688,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -721,7 +721,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -754,7 +754,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -787,7 +787,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -820,7 +820,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * @package Google_Api_Ads_AdWords_v201402
@@ -853,7 +853,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -887,7 +887,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -920,7 +920,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -953,7 +953,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -986,7 +986,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1019,7 +1019,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1052,7 +1052,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionErrorReason", false)) {
   /**
    * The reasons for an OfflineConversionError.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1085,7 +1085,7 @@ if (!class_exists("OfflineConversionErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1118,7 +1118,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1151,7 +1151,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1184,7 +1184,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PagingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingErrorReason", false)) {
   /**
    * The reasons for errors when using pagination.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1217,7 +1217,7 @@ if (!class_exists("PagingErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -1251,7 +1251,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1284,7 +1284,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1317,7 +1317,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1350,7 +1350,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1383,7 +1383,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1416,7 +1416,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1449,7 +1449,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1482,7 +1482,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1515,7 +1515,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1548,7 +1548,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedServiceMutate", false)) {
   /**
    * <span class="constraint ContentsNotNull">This field must not contain {@code null} elements.</span>
    * <span class="constraint NotEmpty">This field must contain at least one element.</span>
@@ -1602,7 +1602,7 @@ if (!class_exists("OfflineConversionFeedServiceMutate", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1642,7 +1642,7 @@ if (!class_exists("OfflineConversionFeedServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1687,7 +1687,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1732,7 +1732,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1777,7 +1777,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1823,7 +1823,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1868,7 +1868,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1913,7 +1913,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1958,7 +1958,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -2032,7 +2032,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -2078,7 +2078,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2123,7 +2123,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -2170,7 +2170,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -2216,7 +2216,7 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2261,7 +2261,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2306,7 +2306,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionError", false)) {
   /**
    * Errors that the {@link OfflineConversionFeedService} can throw.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2351,7 +2351,7 @@ if (!class_exists("OfflineConversionError", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedOperation", false)) {
   /**
    * Operation for uploading {@link OfflineConversionFeed}.
    * See {@link OfflineConversionFeedService#mutate}
@@ -2395,7 +2395,7 @@ if (!class_exists("OfflineConversionFeedOperation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2440,7 +2440,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2485,7 +2485,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("PagingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PagingError", false)) {
   /**
    * Error codes for pagination.
    * See {@link com.google.ads.api.services.common.pagination.Paging}.
@@ -2531,7 +2531,7 @@ if (!class_exists("PagingError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2576,7 +2576,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2621,7 +2621,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2687,7 +2687,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2732,7 +2732,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2777,7 +2777,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2822,7 +2822,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2868,7 +2868,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2913,7 +2913,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2958,7 +2958,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -3004,7 +3004,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3049,7 +3049,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3092,7 +3092,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("OfflineConversionFeedReturnValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedReturnValue", false)) {
   /**
    * A container for return values from the OfflineConversionFeedService.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3147,7 +3147,7 @@ if (!class_exists("OfflineConversionFeedService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class OfflineConversionFeedService extends AdWordsSoapClient {
+  class OfflineConversionFeedService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "OfflineConversionFeedService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -3164,77 +3164,77 @@ if (!class_exists("OfflineConversionFeedService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "MatchesRegexError" => "MatchesRegexError",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OfflineConversionError" => "OfflineConversionError",
-      "OfflineConversionFeed" => "OfflineConversionFeed",
-      "OfflineConversionFeedOperation" => "OfflineConversionFeedOperation",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "PagingError" => "PagingError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "OfflineConversionFeedReturnValue" => "OfflineConversionFeedReturnValue",
-      "ListReturnValue" => "ListReturnValue",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OfflineConversionError.Reason" => "OfflineConversionErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "PagingError.Reason" => "PagingErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "mutate" => "OfflineConversionFeedServiceMutate",
-      "mutateResponse" => "OfflineConversionFeedServiceMutateResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OfflineConversionError" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionError",
+      "OfflineConversionFeed" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionFeed",
+      "OfflineConversionFeedOperation" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedOperation",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "PagingError" => "Google_Api_Ads_AdWords_v201402\\PagingError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "OfflineConversionFeedReturnValue" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedReturnValue",
+      "ListReturnValue" => "Google_Api_Ads_AdWords_v201402\\ListReturnValue",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OfflineConversionError.Reason" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "PagingError.Reason" => "Google_Api_Ads_AdWords_v201402\\PagingErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\OfflineConversionFeedServiceMutateResponse",
     );
 
 
@@ -3272,3 +3272,4 @@ if (!class_exists("OfflineConversionFeedService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ProductServiceService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ProductServiceService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -135,7 +135,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -222,7 +222,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -275,7 +275,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -328,7 +328,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -381,7 +381,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -476,7 +476,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -529,7 +529,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -591,7 +591,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -644,7 +644,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -700,7 +700,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -753,7 +753,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -806,7 +806,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -861,7 +861,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -921,7 +921,7 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -983,7 +983,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1043,7 +1043,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1096,7 +1096,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1149,7 +1149,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1204,7 +1204,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1291,7 +1291,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1348,7 +1348,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1402,7 +1402,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -1464,7 +1464,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1527,7 +1527,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1583,7 +1583,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -1631,7 +1631,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1684,7 +1684,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1737,7 +1737,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1811,7 +1811,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -1864,7 +1864,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -1917,7 +1917,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -1971,7 +1971,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2024,7 +2024,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2100,7 +2100,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2153,7 +2153,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2206,7 +2206,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2282,7 +2282,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2358,7 +2358,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2412,7 +2412,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2472,7 +2472,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2539,7 +2539,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2610,7 +2610,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -2651,7 +2651,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2692,7 +2692,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2734,7 +2734,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -2775,7 +2775,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2816,7 +2816,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2857,7 +2857,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -2898,7 +2898,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2939,7 +2939,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -2980,7 +2980,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3022,7 +3022,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3063,7 +3063,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3104,7 +3104,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -3145,7 +3145,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3187,7 +3187,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3228,7 +3228,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3269,7 +3269,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3310,7 +3310,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3351,7 +3351,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3392,7 +3392,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3433,7 +3433,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3474,7 +3474,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -3515,7 +3515,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -3556,7 +3556,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3597,7 +3597,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -3638,7 +3638,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("ProductService", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductService", false)) {
   /**
    * A {@link Criterion} which describes the product or service an Ad is targeting. A product and
    * service criterion can be used to derive a group of {@link KeywordSet} by AdWords Express.
@@ -3691,7 +3691,7 @@ if (!class_exists("ProductService", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3727,7 +3727,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ProductServiceServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductServiceServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -3775,7 +3775,7 @@ if (!class_exists("ProductServiceServiceGet", false)) {
   }
 }
 
-if (!class_exists("ProductServiceServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductServiceServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -3815,7 +3815,7 @@ if (!class_exists("ProductServiceServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -3866,7 +3866,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("ProductServicePage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductServicePage", false)) {
   /**
    * Contains a page of {@link ProductService}s with no stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3913,7 +3913,7 @@ if (!class_exists("ProductServiceService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ProductServiceService extends AdWordsSoapClient {
+  class ProductServiceService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ProductServiceService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201402";
@@ -3930,79 +3930,79 @@ if (!class_exists("ProductServiceService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "Criterion" => "Criterion",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "ProductService" => "ProductService",
-      "ProductServicePage" => "ProductServicePage",
-      "NoStatsPage" => "NoStatsPage",
-      "get" => "ProductServiceServiceGet",
-      "getResponse" => "ProductServiceServiceGetResponse",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201402\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "ProductService" => "Google_Api_Ads_AdWords_v201402\\ProductService",
+      "ProductServicePage" => "Google_Api_Ads_AdWords_v201402\\ProductServicePage",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "get" => "Google_Api_Ads_AdWords_v201402\\ProductServiceServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\ProductServiceServiceGetResponse",
     );
 
 
@@ -4034,3 +4034,4 @@ if (!class_exists("ProductServiceService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/PromotionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/PromotionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("Address", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Address", false)) {
   /**
    * Structure to specify an address location.
    * 
@@ -116,7 +116,7 @@ if (!class_exists("Address", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -217,7 +217,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -300,7 +300,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -349,7 +349,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -398,7 +398,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -447,7 +447,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -523,7 +523,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -614,7 +614,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -663,7 +663,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("Date", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Date", false)) {
   /**
    * Represents a date.
    * 
@@ -721,7 +721,7 @@ if (!class_exists("Date", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -770,7 +770,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DateRange", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateRange", false)) {
   /**
    * Represents a range of dates that has either an upper or a lower bound.
    * The format for the date is YYYYMMDD.
@@ -822,7 +822,7 @@ if (!class_exists("DateRange", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -871,7 +871,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("GeoPoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GeoPoint", false)) {
   /**
    * Specifies a geo location with the supplied latitude/longitude.
    * 
@@ -922,7 +922,7 @@ if (!class_exists("GeoPoint", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -971,7 +971,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1022,7 +1022,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1078,10 +1078,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1135,10 +1135,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1206,7 +1206,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1264,7 +1264,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1320,7 +1320,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1366,7 +1366,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1415,7 +1415,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1464,7 +1464,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1503,7 +1503,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("Operation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operation", false)) {
   /**
    * This represents an operation that includes an operator and an operand
    * specified type.
@@ -1587,7 +1587,7 @@ if (!class_exists("Operation", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1636,7 +1636,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1685,7 +1685,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("OrderBy", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OrderBy", false)) {
   /**
    * Specifies how the resulting information should be sorted.
    * 
@@ -1736,7 +1736,7 @@ if (!class_exists("OrderBy", false)) {
   }
 }
 
-if (!class_exists("Page", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Page", false)) {
   /**
    * Contains the results from a get call.
    * 
@@ -1819,7 +1819,7 @@ if (!class_exists("Page", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1872,7 +1872,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1922,7 +1922,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Predicate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Predicate", false)) {
   /**
    * Specifies how an entity (eg. adgroup, campaign, criterion, ad) should be filtered.
    * 
@@ -1980,7 +1980,7 @@ if (!class_exists("Predicate", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2039,7 +2039,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2091,7 +2091,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -2135,7 +2135,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("Proximity", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Proximity", false)) {
   /**
    * Represents a Proximity Criterion.
    * 
@@ -2143,7 +2143,7 @@ if (!class_exists("Proximity", false)) {
    * by a lat/long pair. The caller may also alternatively provide address fields which will be
    * geocoded into a lat/long pair. Note: If a geoPoint value is provided, the address is not
    * used for calculating the lat/long to target.
-   * <p> A criterion of this type is only targetable.
+   * <p>
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -2211,7 +2211,7 @@ if (!class_exists("Proximity", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2260,7 +2260,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2309,7 +2309,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2379,7 +2379,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2428,7 +2428,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2477,7 +2477,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2527,7 +2527,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2576,7 +2576,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("Selector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Selector", false)) {
   /**
    * A generic selector to specify the type of information to return.
    * 
@@ -2648,7 +2648,7 @@ if (!class_exists("Selector", false)) {
   }
 }
 
-if (!class_exists("SelectorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorError", false)) {
   /**
    * Represents possible error codes for {@link Selector}.
    * 
@@ -2697,7 +2697,7 @@ if (!class_exists("SelectorError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2746,7 +2746,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2818,7 +2818,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2890,7 +2890,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2940,7 +2940,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2996,7 +2996,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3059,7 +3059,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -3126,7 +3126,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -3163,7 +3163,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3200,7 +3200,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3238,7 +3238,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3275,7 +3275,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3312,7 +3312,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3349,7 +3349,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3386,7 +3386,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3423,7 +3423,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3460,7 +3460,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3498,7 +3498,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -3535,7 +3535,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3572,7 +3572,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3609,7 +3609,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3646,7 +3646,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("Operator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Operator", false)) {
   /**
    * This represents an operator that may be presented to an adsapi service.
    * 
@@ -3683,7 +3683,7 @@ if (!class_exists("Operator", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3720,7 +3720,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("PredicateOperator", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PredicateOperator", false)) {
   /**
    * Defines the valid set of operators.
    * 
@@ -3757,7 +3757,7 @@ if (!class_exists("PredicateOperator", false)) {
   }
 }
 
-if (!class_exists("ProximityDistanceUnits", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits", false)) {
   /**
    * The radius distance is expressed in either kilometers or miles.
    * 
@@ -3794,7 +3794,7 @@ if (!class_exists("ProximityDistanceUnits", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3832,7 +3832,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3869,7 +3869,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3906,7 +3906,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3943,7 +3943,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3980,7 +3980,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -4017,7 +4017,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4054,7 +4054,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SelectorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SelectorErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4091,7 +4091,7 @@ if (!class_exists("SelectorErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -4128,7 +4128,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("SortOrder", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SortOrder", false)) {
   /**
    * Possible orders of sorting.
    * 
@@ -4165,7 +4165,7 @@ if (!class_exists("SortOrder", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4202,7 +4202,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4239,7 +4239,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("Creative", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Creative", false)) {
   /**
    * Creative for a text ad.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4293,7 +4293,7 @@ if (!class_exists("Creative", false)) {
   }
 }
 
-if (!class_exists("ExpressSoapHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExpressSoapHeader", false)) {
   /**
    * {@link SoapHeader} for AdWords Express services.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4339,7 +4339,7 @@ if (!class_exists("ExpressSoapHeader", false)) {
   }
 }
 
-if (!class_exists("KeywordSet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordSet", false)) {
   /**
    * A keyword set based {@link Criterion}.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -4398,7 +4398,7 @@ if (!class_exists("KeywordSet", false)) {
   }
 }
 
-if (!class_exists("NegativeCriterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeCriterion", false)) {
   /**
    * A negative criterion. It wraps a {@link Criterion} and will be associated with an ad group as a
    * {@link com.google.ads.api.services.campaignmgmt.criterion.adgroupcriterion.NegativeAdGroupCriterion}
@@ -4445,7 +4445,7 @@ if (!class_exists("NegativeCriterion", false)) {
   }
 }
 
-if (!class_exists("NegativeKeyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NegativeKeyword", false)) {
   /**
    * Criterion to mark a keyword is negative keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -4482,7 +4482,7 @@ if (!class_exists("NegativeKeyword", false)) {
   }
 }
 
-if (!class_exists("NoStatsPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NoStatsPage", false)) {
   /**
    * Base class for Get results for a page of entities that do not use statistics.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4518,7 +4518,7 @@ if (!class_exists("NoStatsPage", false)) {
   }
 }
 
-if (!class_exists("ProductService", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductService", false)) {
   /**
    * A {@link Criterion} which describes the product or service an Ad is targeting. A product and
    * service criterion can be used to derive a group of {@link KeywordSet} by AdWords Express.
@@ -4571,7 +4571,7 @@ if (!class_exists("ProductService", false)) {
   }
 }
 
-if (!class_exists("Promotion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Promotion", false)) {
   /**
    * A promotion for a business. It contains all the user specified data as needed by AdWords Express
    * to generate AdWords campaigns.
@@ -4682,7 +4682,7 @@ if (!class_exists("Promotion", false)) {
   }
 }
 
-if (!class_exists("PromotionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionError", false)) {
   /**
    * Promotion related errors for AdWords Express.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4727,7 +4727,7 @@ if (!class_exists("PromotionError", false)) {
   }
 }
 
-if (!class_exists("PromotionOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionOperation", false)) {
   /**
    * A typed {@link Operation} class that uses an instance of {@link Promotion} as its operand.
    * 
@@ -4774,7 +4774,7 @@ if (!class_exists("PromotionOperation", false)) {
   }
 }
 
-if (!class_exists("PromotionPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionPage", false)) {
   /**
    * Contains a page of {@link Promotion}s with no stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4815,7 +4815,7 @@ if (!class_exists("PromotionPage", false)) {
   }
 }
 
-if (!class_exists("PromotionStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionStatus", false)) {
   /**
    * Statuses of a promotion.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4848,7 +4848,7 @@ if (!class_exists("PromotionStatus", false)) {
   }
 }
 
-if (!class_exists("PromotionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionErrorReason", false)) {
   /**
    * Reason behind the {@code PromotionError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4881,7 +4881,7 @@ if (!class_exists("PromotionErrorReason", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4927,7 +4927,7 @@ if (!class_exists("PromotionServiceGet", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4967,7 +4967,7 @@ if (!class_exists("PromotionServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceMutate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionServiceMutate", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * <span class="constraint SupportedOperators">The following {@link Operator}s are supported: ADD, SET.</span>
@@ -5015,7 +5015,7 @@ if (!class_exists("PromotionServiceMutate", false)) {
   }
 }
 
-if (!class_exists("PromotionServiceMutateResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PromotionServiceMutateResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -5055,7 +5055,7 @@ if (!class_exists("PromotionServiceMutateResponse", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -5102,7 +5102,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -5147,7 +5147,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -5198,7 +5198,7 @@ if (!class_exists("PromotionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class PromotionService extends AdWordsSoapClient {
+  class PromotionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "PromotionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/express/v201402";
@@ -5215,109 +5215,109 @@ if (!class_exists("PromotionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "Address" => "Address",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "DatabaseError" => "DatabaseError",
-      "Date" => "Date",
-      "DateError" => "DateError",
-      "DateRange" => "DateRange",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "GeoPoint" => "GeoPoint",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "Operation" => "Operation",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "OrderBy" => "OrderBy",
-      "Page" => "Page",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Predicate" => "Predicate",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "Proximity" => "Proximity",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "Selector" => "Selector",
-      "SelectorError" => "SelectorError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "Operator" => "Operator",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "Predicate.Operator" => "PredicateOperator",
-      "Proximity.DistanceUnits" => "ProximityDistanceUnits",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SelectorError.Reason" => "SelectorErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "SortOrder" => "SortOrder",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "Creative" => "Creative",
-      "ExpressSoapHeader" => "ExpressSoapHeader",
-      "KeywordSet" => "KeywordSet",
-      "NegativeCriterion" => "NegativeCriterion",
-      "NegativeKeyword" => "NegativeKeyword",
-      "NoStatsPage" => "NoStatsPage",
-      "ProductService" => "ProductService",
-      "Promotion" => "Promotion",
-      "PromotionError" => "PromotionError",
-      "PromotionOperation" => "PromotionOperation",
-      "PromotionPage" => "PromotionPage",
-      "Promotion.Status" => "PromotionStatus",
-      "PromotionError.Reason" => "PromotionErrorReason",
-      "get" => "PromotionServiceGet",
-      "getResponse" => "PromotionServiceGetResponse",
-      "mutate" => "PromotionServiceMutate",
-      "mutateResponse" => "PromotionServiceMutateResponse",
+      "Address" => "Google_Api_Ads_AdWords_v201402\\Address",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "Date" => "Google_Api_Ads_AdWords_v201402\\Date",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DateRange" => "Google_Api_Ads_AdWords_v201402\\DateRange",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "GeoPoint" => "Google_Api_Ads_AdWords_v201402\\GeoPoint",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "Operation" => "Google_Api_Ads_AdWords_v201402\\Operation",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "OrderBy" => "Google_Api_Ads_AdWords_v201402\\OrderBy",
+      "Page" => "Google_Api_Ads_AdWords_v201402\\Page",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Predicate" => "Google_Api_Ads_AdWords_v201402\\Predicate",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "Proximity" => "Google_Api_Ads_AdWords_v201402\\Proximity",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "Selector" => "Google_Api_Ads_AdWords_v201402\\Selector",
+      "SelectorError" => "Google_Api_Ads_AdWords_v201402\\SelectorError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "Operator" => "Google_Api_Ads_AdWords_v201402\\Operator",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "Predicate.Operator" => "Google_Api_Ads_AdWords_v201402\\PredicateOperator",
+      "Proximity.DistanceUnits" => "Google_Api_Ads_AdWords_v201402\\ProximityDistanceUnits",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SelectorError.Reason" => "Google_Api_Ads_AdWords_v201402\\SelectorErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "SortOrder" => "Google_Api_Ads_AdWords_v201402\\SortOrder",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "Creative" => "Google_Api_Ads_AdWords_v201402\\Creative",
+      "ExpressSoapHeader" => "Google_Api_Ads_AdWords_v201402\\ExpressSoapHeader",
+      "KeywordSet" => "Google_Api_Ads_AdWords_v201402\\KeywordSet",
+      "NegativeCriterion" => "Google_Api_Ads_AdWords_v201402\\NegativeCriterion",
+      "NegativeKeyword" => "Google_Api_Ads_AdWords_v201402\\NegativeKeyword",
+      "NoStatsPage" => "Google_Api_Ads_AdWords_v201402\\NoStatsPage",
+      "ProductService" => "Google_Api_Ads_AdWords_v201402\\ProductService",
+      "Promotion" => "Google_Api_Ads_AdWords_v201402\\Promotion",
+      "PromotionError" => "Google_Api_Ads_AdWords_v201402\\PromotionError",
+      "PromotionOperation" => "Google_Api_Ads_AdWords_v201402\\PromotionOperation",
+      "PromotionPage" => "Google_Api_Ads_AdWords_v201402\\PromotionPage",
+      "Promotion.Status" => "Google_Api_Ads_AdWords_v201402\\PromotionStatus",
+      "PromotionError.Reason" => "Google_Api_Ads_AdWords_v201402\\PromotionErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\PromotionServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\PromotionServiceGetResponse",
+      "mutate" => "Google_Api_Ads_AdWords_v201402\\PromotionServiceMutate",
+      "mutateResponse" => "Google_Api_Ads_AdWords_v201402\\PromotionServiceMutateResponse",
     );
 
 
@@ -5363,3 +5363,4 @@ if (!class_exists("PromotionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/ReportDefinitionService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/ReportDefinitionService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("EnumValuePair", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EnumValuePair", false)) {
   /**
    * Represents information about enum values.
    * @package Google_Api_Ads_AdWords_v201402
@@ -77,7 +77,7 @@ if (!class_exists("EnumValuePair", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionField", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReportDefinitionField", false)) {
   /**
    * Represents the fields that can be used to create a ReportDefinition.
    * This class allows the user to query the list of fields applicable to a
@@ -184,7 +184,7 @@ if (!class_exists("ReportDefinitionField", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -252,7 +252,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * @package Google_Api_Ads_AdWords_v201402
@@ -320,7 +320,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -417,7 +417,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * @package Google_Api_Ads_AdWords_v201402
@@ -496,7 +496,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * @package Google_Api_Ads_AdWords_v201402
@@ -529,7 +529,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -562,7 +562,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -596,7 +596,7 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -629,7 +629,7 @@ if (!class_exists("CollectionSizeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -662,7 +662,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -695,7 +695,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -728,7 +728,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -761,7 +761,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -794,7 +794,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -827,7 +827,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotWhitelistedErrorReason", false)) {
   /**
    * The single reason for the whitelist error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -860,7 +860,7 @@ if (!class_exists("NotWhitelistedErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -893,7 +893,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -926,7 +926,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -960,7 +960,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -993,7 +993,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1026,7 +1026,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1059,7 +1059,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1092,7 +1092,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionReportType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReportDefinitionReportType", false)) {
   /**
    * Enums for report types.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1125,7 +1125,7 @@ if (!class_exists("ReportDefinitionReportType", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReportDefinitionErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * a {@link ReportDefinitionService#mutate(java.util.List)} operation.
@@ -1159,7 +1159,7 @@ if (!class_exists("ReportDefinitionErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1192,7 +1192,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1225,7 +1225,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1258,7 +1258,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1291,7 +1291,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("GetReportFields", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetReportFields", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -1343,7 +1343,7 @@ if (!class_exists("GetReportFields", false)) {
   }
 }
 
-if (!class_exists("GetReportFieldsResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetReportFieldsResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -1383,7 +1383,7 @@ if (!class_exists("GetReportFieldsResponse", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1428,7 +1428,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1473,7 +1473,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1518,7 +1518,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -1564,7 +1564,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1609,7 +1609,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1654,7 +1654,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1699,7 +1699,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1746,7 +1746,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1791,7 +1791,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NotWhitelistedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotWhitelistedError", false)) {
   /**
    * Indicates that the customer is not whitelisted for accessing the API.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1836,7 +1836,7 @@ if (!class_exists("NotWhitelistedError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1881,7 +1881,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1926,7 +1926,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * @package Google_Api_Ads_AdWords_v201402
@@ -1971,7 +1971,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2016,7 +2016,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2082,7 +2082,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2127,7 +2127,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2172,7 +2172,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("ReportDefinitionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReportDefinitionError", false)) {
   /**
    * Encapsulates the errors that can be thrown during {@link ReportDefinition}
    * mutate operation.
@@ -2218,7 +2218,7 @@ if (!class_exists("ReportDefinitionError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2264,7 +2264,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2309,7 +2309,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2354,7 +2354,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2400,7 +2400,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2445,7 +2445,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * @package Google_Api_Ads_AdWords_v201402
@@ -2494,7 +2494,7 @@ if (!class_exists("ReportDefinitionService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class ReportDefinitionService extends AdWordsSoapClient {
+  class ReportDefinitionService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "ReportDefinitionService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
@@ -2511,62 +2511,62 @@ if (!class_exists("ReportDefinitionService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "EnumValuePair" => "EnumValuePair",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "NotEmptyError" => "NotEmptyError",
-      "NotWhitelistedError" => "NotWhitelistedError",
-      "NullError" => "NullError",
-      "OperatorError" => "OperatorError",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RejectedError" => "RejectedError",
-      "ReportDefinitionError" => "ReportDefinitionError",
-      "ReportDefinitionField" => "ReportDefinitionField",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "DatabaseError" => "DatabaseError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "CollectionSizeError.Reason" => "CollectionSizeErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NotWhitelistedError.Reason" => "NotWhitelistedErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "ReportDefinition.ReportType" => "ReportDefinitionReportType",
-      "ReportDefinitionError.Reason" => "ReportDefinitionErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "getReportFields" => "GetReportFields",
-      "getReportFieldsResponse" => "GetReportFieldsResponse",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "EnumValuePair" => "Google_Api_Ads_AdWords_v201402\\EnumValuePair",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NotWhitelistedError" => "Google_Api_Ads_AdWords_v201402\\NotWhitelistedError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "ReportDefinitionError" => "Google_Api_Ads_AdWords_v201402\\ReportDefinitionError",
+      "ReportDefinitionField" => "Google_Api_Ads_AdWords_v201402\\ReportDefinitionField",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NotWhitelistedError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotWhitelistedErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "ReportDefinition.ReportType" => "Google_Api_Ads_AdWords_v201402\\ReportDefinitionReportType",
+      "ReportDefinitionError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReportDefinitionErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "getReportFields" => "Google_Api_Ads_AdWords_v201402\\GetReportFields",
+      "getReportFieldsResponse" => "Google_Api_Ads_AdWords_v201402\\GetReportFieldsResponse",
     );
 
 
@@ -2602,3 +2602,4 @@ if (!class_exists("ReportDefinitionService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/TargetingIdeaService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/TargetingIdeaService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -131,7 +131,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -214,7 +214,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -263,7 +263,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -312,7 +312,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeLandscapePoint", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidLandscapeLandscapePoint", false)) {
   /**
    * A set of estimates for a criterion's performance for a specific bid
    * amount.
@@ -392,7 +392,7 @@ if (!class_exists("BidLandscapeLandscapePoint", false)) {
   }
 }
 
-if (!class_exists("BiddingError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingError", false)) {
   /**
    * Represents bidding errors.
    * 
@@ -441,7 +441,7 @@ if (!class_exists("BiddingError", false)) {
   }
 }
 
-if (!class_exists("BudgetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetError", false)) {
   /**
    * A list of all the error codes being used by the common budget domain package.
    * 
@@ -490,7 +490,7 @@ if (!class_exists("BudgetError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -539,7 +539,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -554,6 +554,12 @@ if (!class_exists("CollectionSizeError", false)) {
 
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
     const XSI_TYPE = "CollectionSizeError";
+
+    /**
+     * @access public
+     * @var tnsCollectionSizeErrorReason
+     */
+    public $reason;
 
     /**
      * Gets the namesapce of this class
@@ -571,8 +577,9 @@ if (!class_exists("CollectionSizeError", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
+    public function __construct($reason = null, $fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
       parent::__construct();
+      $this->reason = $reason;
       $this->fieldPath = $fieldPath;
       $this->trigger = $trigger;
       $this->errorString = $errorString;
@@ -582,7 +589,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -658,7 +665,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -749,7 +756,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("CriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionError", false)) {
   /**
    * Error class used for reporting criteria related errors.
    * 
@@ -798,7 +805,7 @@ if (!class_exists("CriterionError", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -847,7 +854,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -896,7 +903,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -945,7 +952,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded", false)) {
   /**
    * Signals that an entity count limit was exceeded for some level.
    * For example, too many criteria for a campaign.
@@ -1023,7 +1030,7 @@ if (!class_exists("EntityCountLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -1073,7 +1080,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -1122,7 +1129,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -1173,7 +1180,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -1229,10 +1236,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1286,10 +1293,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1357,7 +1364,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1415,7 +1422,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1471,7 +1478,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1517,7 +1524,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * 
@@ -1582,7 +1589,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1631,7 +1638,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1680,7 +1687,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1719,7 +1726,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1768,7 +1775,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("Paging", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Paging", false)) {
   /**
    * Specifies the page of results to return in the response. A page is specified
    * by the result position to start at and the maximum number of results to
@@ -1821,7 +1828,7 @@ if (!class_exists("Paging", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1871,10 +1878,10 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Platform", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Platform", false)) {
   /**
    * Represents Platform criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1921,7 +1928,7 @@ if (!class_exists("Platform", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationError", false)) {
   /**
    * Represents violations of a single policy by some text in a field.
    * 
@@ -2016,7 +2023,7 @@ if (!class_exists("PolicyViolationError", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationErrorPart", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart", false)) {
   /**
    * Points to a substring within an ad field or criterion.
    * 
@@ -2067,7 +2074,7 @@ if (!class_exists("PolicyViolationErrorPart", false)) {
   }
 }
 
-if (!class_exists("PolicyViolationKey", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PolicyViolationKey", false)) {
   /**
    * Key of the violation. The key is used for referring to a violation when
    * filing an exemption request.
@@ -2119,7 +2126,7 @@ if (!class_exists("PolicyViolationKey", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -2178,7 +2185,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -2230,7 +2237,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -2274,7 +2281,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -2323,7 +2330,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -2372,7 +2379,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -2442,7 +2449,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -2491,7 +2498,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * 
@@ -2540,7 +2547,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2589,7 +2596,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2639,7 +2646,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2688,7 +2695,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2737,7 +2744,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2809,7 +2816,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2881,7 +2888,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StatsQueryError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryError", false)) {
   /**
    * Represents possible error codes when querying for stats.
    * 
@@ -2930,7 +2937,7 @@ if (!class_exists("StatsQueryError", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2980,7 +2987,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("DataEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DataEntry", false)) {
   /**
    * The base class of all return types of the table service.
    * 
@@ -3056,7 +3063,7 @@ if (!class_exists("DataEntry", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * 
@@ -3105,7 +3112,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3161,7 +3168,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -3224,7 +3231,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -3291,7 +3298,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscapeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapeType", false)) {
   /**
    * Used to specify the type of {@code AdGroupLandscape}
    * 
@@ -3328,7 +3335,7 @@ if (!class_exists("AdGroupBidLandscapeType", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3365,7 +3372,7 @@ if (!class_exists("AdGroupCriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   /**
    * The entity type that exceeded the limit.
    * 
@@ -3402,7 +3409,7 @@ if (!class_exists("AdGroupCriterionLimitExceededCriteriaLimitType", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * 
@@ -3439,7 +3446,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -3476,7 +3483,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3513,7 +3520,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("BiddingErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BiddingErrorReason", false)) {
   /**
    * Reason for bidding error.
    * 
@@ -3550,7 +3557,7 @@ if (!class_exists("BiddingErrorReason", false)) {
   }
 }
 
-if (!class_exists("BudgetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BudgetErrorReason", false)) {
   /**
    * The reasons for the budget error.
    * 
@@ -3587,7 +3594,7 @@ if (!class_exists("BudgetErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -3625,7 +3632,44 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
+  /**
+   * The reasons for the target error.
+   * 
+   * 
+   * 
+   * Represents data about a bidlandscape for an adgroup.
+   * @package Google_Api_Ads_AdWords_v201402
+   * @subpackage v201402
+   */
+  class CollectionSizeErrorReason {
+
+    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
+    const XSI_TYPE = "CollectionSizeError.Reason";
+
+    /**
+     * Gets the namesapce of this class
+     * @return the namespace of this class
+     */
+    public function getNamespace() {
+      return self::WSDL_NAMESPACE;
+    }
+
+    /**
+     * Gets the xsi:type name of this class
+     * @return the xsi:type name of this class
+     */
+    public function getXsiTypeName() {
+      return self::XSI_TYPE;
+    }
+
+    public function __construct() {
+    }
+
+  }
+}
+
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -3662,7 +3706,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("CriterionErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionErrorReason", false)) {
   /**
    * Concrete type of criterion is required for ADD and SET operations.
    * 
@@ -3699,7 +3743,7 @@ if (!class_exists("CriterionErrorReason", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -3736,7 +3780,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3773,7 +3817,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3810,7 +3854,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityCountLimitExceededReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason", false)) {
   /**
    * Limits at various levels of the account.
    * 
@@ -3847,7 +3891,7 @@ if (!class_exists("EntityCountLimitExceededReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -3885,7 +3929,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3922,7 +3966,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3959,7 +4003,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3997,7 +4041,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -4034,7 +4078,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4071,7 +4115,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4108,7 +4152,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -4145,7 +4189,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -4183,7 +4227,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4220,7 +4264,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -4257,7 +4301,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4294,7 +4338,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -4331,7 +4375,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4368,7 +4412,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -4405,7 +4449,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4442,7 +4486,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -4479,7 +4523,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StatsQueryErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason", false)) {
   /**
    * The reasons for errors when querying for stats.
    * 
@@ -4516,7 +4560,7 @@ if (!class_exists("StatsQueryErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4553,7 +4597,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -4590,7 +4634,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -4627,7 +4671,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("AdFormatSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdFormatSpec", false)) {
   /**
    * A placement response object which provides information about one of the ad formats
    * supported by a placement.
@@ -4668,7 +4712,7 @@ if (!class_exists("AdFormatSpec", false)) {
   }
 }
 
-if (!class_exists("AdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdSpec", false)) {
   /**
    * Interface for ad specifications to implement. See individual spec
    * documentation for more details on how to use each type, and
@@ -4724,7 +4768,7 @@ if (!class_exists("AdSpec", false)) {
   }
 }
 
-if (!class_exists("Attribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Attribute", false)) {
   /**
    * {@link Attribute}s encompass the core information about a particular
    * {@link com.google.ads.api.services.targetingideas.TargetingIdea}. Some
@@ -4803,7 +4847,7 @@ if (!class_exists("Attribute", false)) {
   }
 }
 
-if (!class_exists("BidLandscapeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidLandscapeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link BidLandscape} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4845,7 +4889,7 @@ if (!class_exists("BidLandscapeAttribute", false)) {
   }
 }
 
-if (!class_exists("BooleanAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BooleanAttribute", false)) {
   /**
    * {@link Attribute} type that contains a boolean value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4887,7 +4931,7 @@ if (!class_exists("BooleanAttribute", false)) {
   }
 }
 
-if (!class_exists("CriterionAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Criterion} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4929,7 +4973,7 @@ if (!class_exists("CriterionAttribute", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4974,7 +5018,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DisplayAdSpec", false)) {
   /**
    * Placement request/response object which provides details about display
    * ad types, options, and other available configuration variables.
@@ -5029,7 +5073,7 @@ if (!class_exists("DisplayAdSpec", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpecAdSizeSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DisplayAdSpecAdSizeSpec", false)) {
   /**
    * Specification for an ad size. This specification allows customization by
    * display options for more fine-grained control over returns, so that
@@ -5092,7 +5136,7 @@ if (!class_exists("DisplayAdSpecAdSizeSpec", false)) {
   }
 }
 
-if (!class_exists("DisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DisplayType", false)) {
   /**
    * Base interface for types of display ads.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5146,7 +5190,7 @@ if (!class_exists("DisplayType", false)) {
   }
 }
 
-if (!class_exists("DoubleAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleAttribute", false)) {
   /**
    * {@link Attribute} type that contains a double value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5188,58 +5232,7 @@ if (!class_exists("DoubleAttribute", false)) {
   }
 }
 
-if (!class_exists("DoubleComparisonOperation", false)) {
-  /**
-   * Object representing double comparison operations. This is usually used within
-   * a particular
-   * {@link com.google.ads.api.services.targetingideas.search.SearchParameter} to
-   * specify the valid values requested for the specific
-   * {@link com.google.ads.api.services.common.optimization.attributes.Attribute}.
-   * @package Google_Api_Ads_AdWords_v201402
-   * @subpackage v201402
-   */
-  class DoubleComparisonOperation {
-
-    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201402";
-    const XSI_TYPE = "DoubleComparisonOperation";
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $minimum;
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $maximum;
-
-    /**
-     * Gets the namesapce of this class
-     * @return the namespace of this class
-     */
-    public function getNamespace() {
-      return self::WSDL_NAMESPACE;
-    }
-
-    /**
-     * Gets the xsi:type name of this class
-     * @return the xsi:type name of this class
-     */
-    public function getXsiTypeName() {
-      return self::XSI_TYPE;
-    }
-
-    public function __construct($minimum = null, $maximum = null) {
-      $this->minimum = $minimum;
-      $this->maximum = $maximum;
-    }
-
-  }
-}
-
-if (!class_exists("FlashDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\FlashDisplayType", false)) {
   /**
    * {@link DisplayType} implementation for Flash display ads.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5272,7 +5265,7 @@ if (!class_exists("FlashDisplayType", false)) {
   }
 }
 
-if (!class_exists("HtmlDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\HtmlDisplayType", false)) {
   /**
    * HTML-specific options for display ads are contained within
    * this class.
@@ -5313,7 +5306,7 @@ if (!class_exists("HtmlDisplayType", false)) {
   }
 }
 
-if (!class_exists("IdeaTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdeaTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link IdeaType} value. For example,
    * if a {@link com.google.ads.api.services.targetingideas.TargetingIdea}
@@ -5358,7 +5351,7 @@ if (!class_exists("IdeaTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("ImageDisplayType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ImageDisplayType", false)) {
   /**
    * {@link DisplayType} implementation for images.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5391,7 +5384,7 @@ if (!class_exists("ImageDisplayType", false)) {
   }
 }
 
-if (!class_exists("InStreamAdInfo", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InStreamAdInfo", false)) {
   /**
    * Information specific to the instream ad format. Instream ads are video ads
    * which play as part of the delivery of video content, either before, during,
@@ -5468,7 +5461,7 @@ if (!class_exists("InStreamAdInfo", false)) {
   }
 }
 
-if (!class_exists("InStreamAdInfoAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InStreamAdInfoAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link InStreamAdInfo} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5510,7 +5503,7 @@ if (!class_exists("InStreamAdInfoAttribute", false)) {
   }
 }
 
-if (!class_exists("InStreamAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InStreamAdSpec", false)) {
   /**
    * Placement request/response object which provides details about instream
    * ad types, options, and other available configuration variables.
@@ -5558,7 +5551,7 @@ if (!class_exists("InStreamAdSpec", false)) {
   }
 }
 
-if (!class_exists("IntegerAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IntegerAttribute", false)) {
   /**
    * {@link Attribute} type that contains an integer value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5600,7 +5593,7 @@ if (!class_exists("IntegerAttribute", false)) {
   }
 }
 
-if (!class_exists("IntegerSetAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IntegerSetAttribute", false)) {
   /**
    * {@link Attribute} type that contains a Set of integer values.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5642,7 +5635,7 @@ if (!class_exists("IntegerSetAttribute", false)) {
   }
 }
 
-if (!class_exists("KeywordAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Keyword} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5684,7 +5677,7 @@ if (!class_exists("KeywordAttribute", false)) {
   }
 }
 
-if (!class_exists("LongAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongAttribute", false)) {
   /**
    * {@link Attribute} type that contains a long value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5726,7 +5719,7 @@ if (!class_exists("LongAttribute", false)) {
   }
 }
 
-if (!class_exists("LongComparisonOperation", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongComparisonOperation", false)) {
   /**
    * Object representing integer comparison operations. This is usually used within
    * a particular
@@ -5777,7 +5770,7 @@ if (!class_exists("LongComparisonOperation", false)) {
   }
 }
 
-if (!class_exists("LongRangeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongRangeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Range} of {@link LongValue}
    * values.
@@ -5820,7 +5813,7 @@ if (!class_exists("LongRangeAttribute", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -5866,7 +5859,7 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("MoneyAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MoneyAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Money} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -5908,7 +5901,7 @@ if (!class_exists("MoneyAttribute", false)) {
   }
 }
 
-if (!class_exists("MonthlySearchVolume", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MonthlySearchVolume", false)) {
   /**
    * A keyword response value representing search volume for a single month. An
    * instance with a {@code null} count is valid, indicating that the information
@@ -5964,7 +5957,7 @@ if (!class_exists("MonthlySearchVolume", false)) {
   }
 }
 
-if (!class_exists("MonthlySearchVolumeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MonthlySearchVolumeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link MonthlySearchVolume}
    * values. The list contains the past 12 {@link MonthlySearchVolume}s
@@ -6009,7 +6002,7 @@ if (!class_exists("MonthlySearchVolumeAttribute", false)) {
   }
 }
 
-if (!class_exists("OpportunityIdeaTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OpportunityIdeaTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains an {@link OpportunityIdeaType} value.
    * For example, if a
@@ -6055,7 +6048,7 @@ if (!class_exists("OpportunityIdeaTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("PlacementAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacementAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link Placement} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6097,7 +6090,7 @@ if (!class_exists("PlacementAttribute", false)) {
   }
 }
 
-if (!class_exists("PlacementTypeAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacementTypeAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link PlacementType} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6139,7 +6132,7 @@ if (!class_exists("PlacementTypeAttribute", false)) {
   }
 }
 
-if (!class_exists("Range", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Range", false)) {
   /**
    * Represents a range of values that has either an upper or a lower bound.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6186,7 +6179,7 @@ if (!class_exists("Range", false)) {
   }
 }
 
-if (!class_exists("SearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SearchParameter", false)) {
   /**
    * A set of {@link SearchParameter}s are supplied to the
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaSelector}
@@ -6206,7 +6199,10 @@ if (!class_exists("SearchParameter", false)) {
    * related information (eg. {@link CompetitionSearchParameter}, etc.).</li>
    * </ul><p>
    * 
-   * A request should only contain one instance of each {@link SearchParameter}
+   * A request should only contain one instance of each {@link SearchParameter}.
+   * 
+   * NOTICE: Starting with version v201406, requests containing multiple
+   * instances of the same search parameter will be rejected.
    * <p>One or more of the following {@link SearchParameter}s are required:<br/>
    * <ul><li>{@link CategoryProductsAndServicesSearchParameter}</li>
    * <li>{@link LocationSearchParameter}</li>
@@ -6226,7 +6222,6 @@ if (!class_exists("SearchParameter", false)) {
    * <li>{@link NetworkSearchParameter}</li>
    * <li>{@link RelatedToQuerySearchParameter}</li>
    * <li>{@link RelatedToUrlSearchParameter}</li>
-   * <li>{@link SearchVolumeDeltaSearchParameter}</li>
    * <li>{@link SearchVolumeSearchParameter}</li>
    * <li>{@link SeedAdGroupIdSearchParameter}</li>
    * </ul><p>
@@ -6308,63 +6303,7 @@ if (!class_exists("SearchParameter", false)) {
   }
 }
 
-if (!class_exists("SearchVolumeDeltaSearchParameter", false)) {
-  /**
-   * A {@link SearchParameter} that specifies the level of search volume delta expected in results,
-   * and it is directly related to
-   * {@link com.google.ads.api.services.targetingideas.external.AttributeType#SEARCH_VOLUME_DELTA}.
-   * Absence of a {@link SearchVolumeDeltaSearchParameter} in a
-   * {@link com.google.ads.api.services.targetingideas.TargetingIdeaSelector} is
-   * equivalent to having no constraint on search volume delta specified.
-   * <p>This element is supported by following {@link IdeaType}s: KEYWORD.
-   * <p>This element is supported by following {@link RequestType}s: STATS, IDEAS.
-   * @package Google_Api_Ads_AdWords_v201402
-   * @subpackage v201402
-   */
-  class SearchVolumeDeltaSearchParameter extends SearchParameter {
-
-    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201402";
-    const XSI_TYPE = "SearchVolumeDeltaSearchParameter";
-
-    /**
-     * @access public
-     * @var DoubleComparisonOperation
-     */
-    public $relative;
-
-    /**
-     * @access public
-     * @var LongComparisonOperation
-     */
-    public $absolute;
-
-    /**
-     * Gets the namesapce of this class
-     * @return the namespace of this class
-     */
-    public function getNamespace() {
-      return self::WSDL_NAMESPACE;
-    }
-
-    /**
-     * Gets the xsi:type name of this class
-     * @return the xsi:type name of this class
-     */
-    public function getXsiTypeName() {
-      return self::XSI_TYPE;
-    }
-
-    public function __construct($relative = null, $absolute = null, $SearchParameterType = null) {
-      parent::__construct();
-      $this->relative = $relative;
-      $this->absolute = $absolute;
-      $this->SearchParameterType = $SearchParameterType;
-    }
-
-  }
-}
-
-if (!class_exists("SearchVolumeSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SearchVolumeSearchParameter", false)) {
   /**
    * A {@link SearchParameter} that specifies the level of search volume expected in results,
    * and it has a direct relationship to
@@ -6413,7 +6352,7 @@ if (!class_exists("SearchVolumeSearchParameter", false)) {
   }
 }
 
-if (!class_exists("SeedAdGroupIdSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SeedAdGroupIdSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s
    * that specifies that the supplied AdGroup should be used as a seed
@@ -6460,7 +6399,7 @@ if (!class_exists("SeedAdGroupIdSearchParameter", false)) {
   }
 }
 
-if (!class_exists("StringAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringAttribute", false)) {
   /**
    * {@link Attribute} type that contains a string value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6502,7 +6441,7 @@ if (!class_exists("StringAttribute", false)) {
   }
 }
 
-if (!class_exists("TargetingIdea", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdea", false)) {
   /**
    * Represents a {@link TargetingIdea} returned by search criteria specified in
    * the {@link TargetingIdeaSelector}. Targeting ideas are keywords or placements
@@ -6544,7 +6483,7 @@ if (!class_exists("TargetingIdea", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaError", false)) {
   /**
    * Base error class for the
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaService}.
@@ -6590,7 +6529,7 @@ if (!class_exists("TargetingIdeaError", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaPage", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaPage", false)) {
   /**
    * Contains a subset of {@link TargetingIdea}s from the search criteria
    * specified by a {@link TargetingIdeaSelector}.
@@ -6638,7 +6577,7 @@ if (!class_exists("TargetingIdeaPage", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaSelector", false)) {
   /**
    * A descriptor for finding {@link TargetingIdea}s that match the specified criteria.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6720,10 +6659,9 @@ if (!class_exists("TargetingIdeaSelector", false)) {
   }
 }
 
-if (!class_exists("TextAdSpec", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TextAdSpec", false)) {
   /**
-   * Specification for a text ad. Currently there are no customizable
-   * options on text ads, but the presence of a {@code TextAdSpec} in a
+   * Specification for a text ad. The presence of a {@code TextAdSpec} in a
    * request indicates that text ads are a desired result, and the presence
    * of a {@code TextAdSpec} in a response indicates that there are text
    * ads available in the requested inventory.
@@ -6757,7 +6695,7 @@ if (!class_exists("TextAdSpec", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorError", false)) {
   /**
    * Base error class for
    * {@link com.google.ads.api.services.trafficestimator.TrafficEstimatorService}.
@@ -6803,7 +6741,7 @@ if (!class_exists("TrafficEstimatorError", false)) {
   }
 }
 
-if (!class_exists("Type_AttributeMapEntry", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Type_AttributeMapEntry", false)) {
   /**
    * This represents an entry in a map with a key of type Type
    * and value of type Attribute.
@@ -6851,7 +6789,7 @@ if (!class_exists("Type_AttributeMapEntry", false)) {
   }
 }
 
-if (!class_exists("WebpageDescriptor", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageDescriptor", false)) {
   /**
    * Basic information about a webpage.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6898,7 +6836,7 @@ if (!class_exists("WebpageDescriptor", false)) {
   }
 }
 
-if (!class_exists("WebpageDescriptorAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\WebpageDescriptorAttribute", false)) {
   /**
    * {@link Attribute} type that contains a {@link WebpageDescriptor} value.
    * @package Google_Api_Ads_AdWords_v201402
@@ -6940,7 +6878,7 @@ if (!class_exists("WebpageDescriptorAttribute", false)) {
   }
 }
 
-if (!class_exists("AttributeType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AttributeType", false)) {
   /**
    * Represents the type of
    * {@link com.google.ads.api.services.common.optimization.attributes.Attribute}.
@@ -6996,7 +6934,7 @@ if (!class_exists("AttributeType", false)) {
   }
 }
 
-if (!class_exists("CompetitionSearchParameterLevel", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CompetitionSearchParameterLevel", false)) {
   /**
    * An enumeration of possible values to be used in conjunction with the
    * {@link CompetitionSearchParameter} to specify the granularity of
@@ -7031,7 +6969,7 @@ if (!class_exists("CompetitionSearchParameterLevel", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7064,7 +7002,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("DisplayAdSpecActivationOption", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DisplayAdSpecActivationOption", false)) {
   /**
    * Activation options. Describes the ad's activated mode.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7097,7 +7035,7 @@ if (!class_exists("DisplayAdSpecActivationOption", false)) {
   }
 }
 
-if (!class_exists("HtmlDisplayTypeHtmlOption", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\HtmlDisplayTypeHtmlOption", false)) {
   /**
    * Served by a third party.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7130,7 +7068,7 @@ if (!class_exists("HtmlDisplayTypeHtmlOption", false)) {
   }
 }
 
-if (!class_exists("IdeaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdeaType", false)) {
   /**
    * Represents the type of idea.
    * <span class="constraint AdxEnabled">This is disabled for AdX.</span>
@@ -7164,7 +7102,7 @@ if (!class_exists("IdeaType", false)) {
   }
 }
 
-if (!class_exists("InStreamAdSpecInStreamType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InStreamAdSpecInStreamType", false)) {
   /**
    * Display subtype.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7197,7 +7135,7 @@ if (!class_exists("InStreamAdSpecInStreamType", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7230,7 +7168,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("OpportunityIdeaType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OpportunityIdeaType", false)) {
   /**
    * Represents the type of opportunity.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7263,7 +7201,7 @@ if (!class_exists("OpportunityIdeaType", false)) {
   }
 }
 
-if (!class_exists("RequestType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestType", false)) {
   /**
    * Represents the type of the request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7296,7 +7234,7 @@ if (!class_exists("RequestType", false)) {
   }
 }
 
-if (!class_exists("SiteConstantsAdFormat", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SiteConstantsAdFormat", false)) {
   /**
    * Enumerates the ad formats which can be reported in search results.
    * @package Google_Api_Ads_AdWords_v201402
@@ -7329,7 +7267,7 @@ if (!class_exists("SiteConstantsAdFormat", false)) {
   }
 }
 
-if (!class_exists("SiteConstantsPlacementType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SiteConstantsPlacementType", false)) {
   /**
    * A placement request and response value indicating the type of site or other medium
    * (for example, a web page, in a feed, in a video) where ads will appear.
@@ -7363,7 +7301,7 @@ if (!class_exists("SiteConstantsPlacementType", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaErrorReason", false)) {
   /**
    * An enumeration of
    * {@link com.google.ads.api.services.targetingideas.TargetingIdeaService}
@@ -7398,7 +7336,7 @@ if (!class_exists("TargetingIdeaErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorErrorReason", false)) {
   /**
    * When the request with {@code null} campaign ID in
    * {@link com.google.ads.api.services.trafficestimator.CampaignEstimateRequest}
@@ -7435,7 +7373,7 @@ if (!class_exists("TrafficEstimatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7496,7 +7434,7 @@ if (!class_exists("TargetingIdeaServiceGet", false)) {
   }
 }
 
-if (!class_exists("TargetingIdeaServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetingIdeaServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -7536,7 +7474,7 @@ if (!class_exists("TargetingIdeaServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("GetBulkKeywordIdeas", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetBulkKeywordIdeas", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -7609,7 +7547,7 @@ if (!class_exists("GetBulkKeywordIdeas", false)) {
   }
 }
 
-if (!class_exists("GetBulkKeywordIdeasResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\GetBulkKeywordIdeasResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -7649,7 +7587,7 @@ if (!class_exists("GetBulkKeywordIdeasResponse", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError", false)) {
   /**
    * Base error class for Ad Group Criterion Service.
    * 
@@ -7698,7 +7636,7 @@ if (!class_exists("AdGroupCriterionError", false)) {
   }
 }
 
-if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded", false)) {
   /**
    * Signals that too many criteria were added to some ad group.
    * 
@@ -7748,7 +7686,7 @@ if (!class_exists("AdGroupCriterionLimitExceeded", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * 
@@ -7797,7 +7735,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -7844,7 +7782,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("BidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\BidLandscape", false)) {
   /**
    * Represents data about a bid landscape for an ad group or criterion.
    * 
@@ -7918,7 +7856,7 @@ if (!class_exists("BidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionBidLandscape", false)) {
   /**
    * The bid landscape for a criterion.  A bid landscape estimates how a
    * a criterion will perform based on different bid amounts.
@@ -7969,7 +7907,7 @@ if (!class_exists("CriterionBidLandscape", false)) {
   }
 }
 
-if (!class_exists("CriterionPolicyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionPolicyError", false)) {
   /**
    * Contains the policy violations for a single BiddableAdGroupCriterion.
    * 
@@ -8013,7 +7951,7 @@ if (!class_exists("CriterionPolicyError", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -8058,7 +7996,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -8103,7 +8041,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdFormatSpecListAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdFormatSpecListAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link AdFormatSpec} values.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8145,7 +8083,7 @@ if (!class_exists("AdFormatSpecListAttribute", false)) {
   }
 }
 
-if (!class_exists("AdSpecListAttribute", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdSpecListAttribute", false)) {
   /**
    * {@link Attribute} type that contains a list of {@link AdSpec} values.
    * @package Google_Api_Ads_AdWords_v201402
@@ -8187,7 +8125,7 @@ if (!class_exists("AdSpecListAttribute", false)) {
   }
 }
 
-if (!class_exists("AdSpecListSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdSpecListSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code PLACEMENT} {@link IdeaType}s used to
    * filter the results by the list of {@link AdSpec}s. See {@link AdSpec}
@@ -8233,7 +8171,7 @@ if (!class_exists("AdSpecListSearchParameter", false)) {
   }
 }
 
-if (!class_exists("CategoryProductsAndServicesSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CategoryProductsAndServicesSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * sets a keyword category that all search results should belong to.
@@ -8280,7 +8218,7 @@ if (!class_exists("CategoryProductsAndServicesSearchParameter", false)) {
   }
 }
 
-if (!class_exists("CompetitionSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CompetitionSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s used to
    * filter the results by the amount of competition (eg: LOW, MEDIUM, HIGH).
@@ -8325,7 +8263,7 @@ if (!class_exists("CompetitionSearchParameter", false)) {
   }
 }
 
-if (!class_exists("ExcludedKeywordSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ExcludedKeywordSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * specifies {@link Keyword}s that should be excluded from the results.<p>
@@ -8408,7 +8346,7 @@ if (!class_exists("ExcludedKeywordSearchParameter", false)) {
   }
 }
 
-if (!class_exists("IdeaTextFilterSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdeaTextFilterSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} {@link IdeaType}s that
    * specifies a collection of strings by which the results should be
@@ -8467,7 +8405,7 @@ if (!class_exists("IdeaTextFilterSearchParameter", false)) {
   }
 }
 
-if (!class_exists("IncludeAdultContentSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IncludeAdultContentSearchParameter", false)) {
   /**
    * {@link SearchParameter} that specifies whether adult content should be
    * returned.<p>
@@ -8508,7 +8446,7 @@ if (!class_exists("IncludeAdultContentSearchParameter", false)) {
   }
 }
 
-if (!class_exists("LanguageSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LanguageSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for both {@code PLACEMENT} and {@code KEYWORD}
    * {@link IdeaType}s used to indicate multiple language being targeted. This can
@@ -8563,7 +8501,7 @@ if (!class_exists("LanguageSearchParameter", false)) {
   }
 }
 
-if (!class_exists("LocationSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for both {@code PLACEMENT} and {@code KEYWORD}
    * {@link IdeaType}s used to indicate the locations being targeted. This can
@@ -8618,7 +8556,7 @@ if (!class_exists("LocationSearchParameter", false)) {
   }
 }
 
-if (!class_exists("NetworkSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NetworkSearchParameter", false)) {
   /**
    * <p>A {@link SearchParameter} for setting the search network. Currently we
    * support two network setting options:
@@ -8667,7 +8605,7 @@ if (!class_exists("NetworkSearchParameter", false)) {
   }
 }
 
-if (!class_exists("PlacementTypeSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\PlacementTypeSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code PLACEMENT} {@link IdeaType}s
    * used to filter results based on the type of website, known as
@@ -8715,7 +8653,7 @@ if (!class_exists("PlacementTypeSearchParameter", false)) {
   }
 }
 
-if (!class_exists("RelatedToQuerySearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RelatedToQuerySearchParameter", false)) {
   /**
    * A {@link SearchParameter} for a query of {@code String}s.
    * <p>This search parameter can be used in bulk keyword requests through the {@link com.google.ads.api.services.targetingideas.TargetingIdeaService#getBulkKeywordIdeas(TargetingIdeaSelector)} method.
@@ -8760,7 +8698,7 @@ if (!class_exists("RelatedToQuerySearchParameter", false)) {
   }
 }
 
-if (!class_exists("RelatedToUrlSearchParameter", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RelatedToUrlSearchParameter", false)) {
   /**
    * A {@link SearchParameter} for {@code KEYWORD} and {@code PLACEMENT}
    * {@link IdeaType}s that specifies a set of URLs that results should
@@ -8815,7 +8753,7 @@ if (!class_exists("RelatedToUrlSearchParameter", false)) {
   }
 }
 
-if (!class_exists("AdGroupBidLandscape", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscape", false)) {
   /**
    * Represents data about a bidlandscape for an adgroup.
    * 
@@ -8878,7 +8816,7 @@ if (!class_exists("TargetingIdeaService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class TargetingIdeaService extends AdWordsSoapClient {
+  class TargetingIdeaService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "TargetingIdeaService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201402";
@@ -8895,188 +8833,187 @@ if (!class_exists("TargetingIdeaService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdGroupBidLandscape" => "AdGroupBidLandscape",
-      "AdGroupCriterionError" => "AdGroupCriterionError",
-      "AdGroupCriterionLimitExceeded" => "AdGroupCriterionLimitExceeded",
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "BidLandscape" => "BidLandscape",
-      "BidLandscape.LandscapePoint" => "BidLandscapeLandscapePoint",
-      "BiddingError" => "BiddingError",
-      "BudgetError" => "BudgetError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "CriterionBidLandscape" => "CriterionBidLandscape",
-      "CriterionError" => "CriterionError",
-      "CriterionPolicyError" => "CriterionPolicyError",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityCountLimitExceeded" => "EntityCountLimitExceeded",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "Paging" => "Paging",
-      "Placement" => "Placement",
-      "Platform" => "Platform",
-      "PolicyViolationError" => "PolicyViolationError",
-      "PolicyViolationError.Part" => "PolicyViolationErrorPart",
-      "PolicyViolationKey" => "PolicyViolationKey",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StatsQueryError" => "StatsQueryError",
-      "StringLengthError" => "StringLengthError",
-      "DataEntry" => "DataEntry",
-      "TargetError" => "TargetError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AdGroupBidLandscape.Type" => "AdGroupBidLandscapeType",
-      "AdGroupCriterionError.Reason" => "AdGroupCriterionErrorReason",
-      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "AdGroupCriterionLimitExceededCriteriaLimitType",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "BiddingError.Reason" => "BiddingErrorReason",
-      "BudgetError.Reason" => "BudgetErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "CriterionError.Reason" => "CriterionErrorReason",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityCountLimitExceeded.Reason" => "EntityCountLimitExceededReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StatsQueryError.Reason" => "StatsQueryErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "AdFormatSpec" => "AdFormatSpec",
-      "AdFormatSpecListAttribute" => "AdFormatSpecListAttribute",
-      "AdSpec" => "AdSpec",
-      "AdSpecListAttribute" => "AdSpecListAttribute",
-      "AdSpecListSearchParameter" => "AdSpecListSearchParameter",
-      "Attribute" => "Attribute",
-      "BidLandscapeAttribute" => "BidLandscapeAttribute",
-      "BooleanAttribute" => "BooleanAttribute",
-      "CategoryProductsAndServicesSearchParameter" => "CategoryProductsAndServicesSearchParameter",
-      "CompetitionSearchParameter" => "CompetitionSearchParameter",
-      "CriterionAttribute" => "CriterionAttribute",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "DisplayAdSpec" => "DisplayAdSpec",
-      "DisplayAdSpec.AdSizeSpec" => "DisplayAdSpecAdSizeSpec",
-      "DisplayType" => "DisplayType",
-      "DoubleAttribute" => "DoubleAttribute",
-      "DoubleComparisonOperation" => "DoubleComparisonOperation",
-      "ExcludedKeywordSearchParameter" => "ExcludedKeywordSearchParameter",
-      "FlashDisplayType" => "FlashDisplayType",
-      "HtmlDisplayType" => "HtmlDisplayType",
-      "IdeaTextFilterSearchParameter" => "IdeaTextFilterSearchParameter",
-      "IdeaTypeAttribute" => "IdeaTypeAttribute",
-      "ImageDisplayType" => "ImageDisplayType",
-      "InStreamAdInfo" => "InStreamAdInfo",
-      "InStreamAdInfoAttribute" => "InStreamAdInfoAttribute",
-      "InStreamAdSpec" => "InStreamAdSpec",
-      "IncludeAdultContentSearchParameter" => "IncludeAdultContentSearchParameter",
-      "IntegerAttribute" => "IntegerAttribute",
-      "IntegerSetAttribute" => "IntegerSetAttribute",
-      "KeywordAttribute" => "KeywordAttribute",
-      "LanguageSearchParameter" => "LanguageSearchParameter",
-      "LocationSearchParameter" => "LocationSearchParameter",
-      "LongAttribute" => "LongAttribute",
-      "LongComparisonOperation" => "LongComparisonOperation",
-      "LongRangeAttribute" => "LongRangeAttribute",
-      "MatchesRegexError" => "MatchesRegexError",
-      "MoneyAttribute" => "MoneyAttribute",
-      "MonthlySearchVolume" => "MonthlySearchVolume",
-      "MonthlySearchVolumeAttribute" => "MonthlySearchVolumeAttribute",
-      "NetworkSearchParameter" => "NetworkSearchParameter",
-      "OpportunityIdeaTypeAttribute" => "OpportunityIdeaTypeAttribute",
-      "PlacementAttribute" => "PlacementAttribute",
-      "PlacementTypeAttribute" => "PlacementTypeAttribute",
-      "PlacementTypeSearchParameter" => "PlacementTypeSearchParameter",
-      "Range" => "Range",
-      "RelatedToQuerySearchParameter" => "RelatedToQuerySearchParameter",
-      "RelatedToUrlSearchParameter" => "RelatedToUrlSearchParameter",
-      "SearchParameter" => "SearchParameter",
-      "SearchVolumeDeltaSearchParameter" => "SearchVolumeDeltaSearchParameter",
-      "SearchVolumeSearchParameter" => "SearchVolumeSearchParameter",
-      "SeedAdGroupIdSearchParameter" => "SeedAdGroupIdSearchParameter",
-      "StringAttribute" => "StringAttribute",
-      "TargetingIdea" => "TargetingIdea",
-      "TargetingIdeaError" => "TargetingIdeaError",
-      "TargetingIdeaPage" => "TargetingIdeaPage",
-      "TargetingIdeaSelector" => "TargetingIdeaSelector",
-      "TextAdSpec" => "TextAdSpec",
-      "TrafficEstimatorError" => "TrafficEstimatorError",
-      "Type_AttributeMapEntry" => "Type_AttributeMapEntry",
-      "WebpageDescriptor" => "WebpageDescriptor",
-      "WebpageDescriptorAttribute" => "WebpageDescriptorAttribute",
-      "AttributeType" => "AttributeType",
-      "CompetitionSearchParameter.Level" => "CompetitionSearchParameterLevel",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "DisplayAdSpec.ActivationOption" => "DisplayAdSpecActivationOption",
-      "HtmlDisplayType.HtmlOption" => "HtmlDisplayTypeHtmlOption",
-      "IdeaType" => "IdeaType",
-      "InStreamAdSpec.InStreamType" => "InStreamAdSpecInStreamType",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "OpportunityIdeaType" => "OpportunityIdeaType",
-      "RequestType" => "RequestType",
-      "SiteConstants.AdFormat" => "SiteConstantsAdFormat",
-      "SiteConstants.PlacementType" => "SiteConstantsPlacementType",
-      "TargetingIdeaError.Reason" => "TargetingIdeaErrorReason",
-      "TrafficEstimatorError.Reason" => "TrafficEstimatorErrorReason",
-      "get" => "TargetingIdeaServiceGet",
-      "getResponse" => "TargetingIdeaServiceGetResponse",
-      "getBulkKeywordIdeas" => "GetBulkKeywordIdeas",
-      "getBulkKeywordIdeasResponse" => "GetBulkKeywordIdeasResponse",
+      "AdGroupBidLandscape" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscape",
+      "AdGroupCriterionError" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionError",
+      "AdGroupCriterionLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceeded",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "BidLandscape" => "Google_Api_Ads_AdWords_v201402\\BidLandscape",
+      "BidLandscape.LandscapePoint" => "Google_Api_Ads_AdWords_v201402\\BidLandscapeLandscapePoint",
+      "BiddingError" => "Google_Api_Ads_AdWords_v201402\\BiddingError",
+      "BudgetError" => "Google_Api_Ads_AdWords_v201402\\BudgetError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "CriterionBidLandscape" => "Google_Api_Ads_AdWords_v201402\\CriterionBidLandscape",
+      "CriterionError" => "Google_Api_Ads_AdWords_v201402\\CriterionError",
+      "CriterionPolicyError" => "Google_Api_Ads_AdWords_v201402\\CriterionPolicyError",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EntityCountLimitExceeded" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceeded",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201402\\NetworkSetting",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "Paging" => "Google_Api_Ads_AdWords_v201402\\Paging",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Platform" => "Google_Api_Ads_AdWords_v201402\\Platform",
+      "PolicyViolationError" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationError",
+      "PolicyViolationError.Part" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationErrorPart",
+      "PolicyViolationKey" => "Google_Api_Ads_AdWords_v201402\\PolicyViolationKey",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StatsQueryError" => "Google_Api_Ads_AdWords_v201402\\StatsQueryError",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "DataEntry" => "Google_Api_Ads_AdWords_v201402\\DataEntry",
+      "TargetError" => "Google_Api_Ads_AdWords_v201402\\TargetError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AdGroupBidLandscape.Type" => "Google_Api_Ads_AdWords_v201402\\AdGroupBidLandscapeType",
+      "AdGroupCriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionErrorReason",
+      "AdGroupCriterionLimitExceeded.CriteriaLimitType" => "Google_Api_Ads_AdWords_v201402\\AdGroupCriterionLimitExceededCriteriaLimitType",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "BiddingError.Reason" => "Google_Api_Ads_AdWords_v201402\\BiddingErrorReason",
+      "BudgetError.Reason" => "Google_Api_Ads_AdWords_v201402\\BudgetErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "CriterionError.Reason" => "Google_Api_Ads_AdWords_v201402\\CriterionErrorReason",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityCountLimitExceeded.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityCountLimitExceededReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StatsQueryError.Reason" => "Google_Api_Ads_AdWords_v201402\\StatsQueryErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201402\\TargetErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "AdFormatSpec" => "Google_Api_Ads_AdWords_v201402\\AdFormatSpec",
+      "AdFormatSpecListAttribute" => "Google_Api_Ads_AdWords_v201402\\AdFormatSpecListAttribute",
+      "AdSpec" => "Google_Api_Ads_AdWords_v201402\\AdSpec",
+      "AdSpecListAttribute" => "Google_Api_Ads_AdWords_v201402\\AdSpecListAttribute",
+      "AdSpecListSearchParameter" => "Google_Api_Ads_AdWords_v201402\\AdSpecListSearchParameter",
+      "Attribute" => "Google_Api_Ads_AdWords_v201402\\Attribute",
+      "BidLandscapeAttribute" => "Google_Api_Ads_AdWords_v201402\\BidLandscapeAttribute",
+      "BooleanAttribute" => "Google_Api_Ads_AdWords_v201402\\BooleanAttribute",
+      "CategoryProductsAndServicesSearchParameter" => "Google_Api_Ads_AdWords_v201402\\CategoryProductsAndServicesSearchParameter",
+      "CompetitionSearchParameter" => "Google_Api_Ads_AdWords_v201402\\CompetitionSearchParameter",
+      "CriterionAttribute" => "Google_Api_Ads_AdWords_v201402\\CriterionAttribute",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeError",
+      "DisplayAdSpec" => "Google_Api_Ads_AdWords_v201402\\DisplayAdSpec",
+      "DisplayAdSpec.AdSizeSpec" => "Google_Api_Ads_AdWords_v201402\\DisplayAdSpecAdSizeSpec",
+      "DisplayType" => "Google_Api_Ads_AdWords_v201402\\DisplayType",
+      "DoubleAttribute" => "Google_Api_Ads_AdWords_v201402\\DoubleAttribute",
+      "ExcludedKeywordSearchParameter" => "Google_Api_Ads_AdWords_v201402\\ExcludedKeywordSearchParameter",
+      "FlashDisplayType" => "Google_Api_Ads_AdWords_v201402\\FlashDisplayType",
+      "HtmlDisplayType" => "Google_Api_Ads_AdWords_v201402\\HtmlDisplayType",
+      "IdeaTextFilterSearchParameter" => "Google_Api_Ads_AdWords_v201402\\IdeaTextFilterSearchParameter",
+      "IdeaTypeAttribute" => "Google_Api_Ads_AdWords_v201402\\IdeaTypeAttribute",
+      "ImageDisplayType" => "Google_Api_Ads_AdWords_v201402\\ImageDisplayType",
+      "InStreamAdInfo" => "Google_Api_Ads_AdWords_v201402\\InStreamAdInfo",
+      "InStreamAdInfoAttribute" => "Google_Api_Ads_AdWords_v201402\\InStreamAdInfoAttribute",
+      "InStreamAdSpec" => "Google_Api_Ads_AdWords_v201402\\InStreamAdSpec",
+      "IncludeAdultContentSearchParameter" => "Google_Api_Ads_AdWords_v201402\\IncludeAdultContentSearchParameter",
+      "IntegerAttribute" => "Google_Api_Ads_AdWords_v201402\\IntegerAttribute",
+      "IntegerSetAttribute" => "Google_Api_Ads_AdWords_v201402\\IntegerSetAttribute",
+      "KeywordAttribute" => "Google_Api_Ads_AdWords_v201402\\KeywordAttribute",
+      "LanguageSearchParameter" => "Google_Api_Ads_AdWords_v201402\\LanguageSearchParameter",
+      "LocationSearchParameter" => "Google_Api_Ads_AdWords_v201402\\LocationSearchParameter",
+      "LongAttribute" => "Google_Api_Ads_AdWords_v201402\\LongAttribute",
+      "LongComparisonOperation" => "Google_Api_Ads_AdWords_v201402\\LongComparisonOperation",
+      "LongRangeAttribute" => "Google_Api_Ads_AdWords_v201402\\LongRangeAttribute",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexError",
+      "MoneyAttribute" => "Google_Api_Ads_AdWords_v201402\\MoneyAttribute",
+      "MonthlySearchVolume" => "Google_Api_Ads_AdWords_v201402\\MonthlySearchVolume",
+      "MonthlySearchVolumeAttribute" => "Google_Api_Ads_AdWords_v201402\\MonthlySearchVolumeAttribute",
+      "NetworkSearchParameter" => "Google_Api_Ads_AdWords_v201402\\NetworkSearchParameter",
+      "OpportunityIdeaTypeAttribute" => "Google_Api_Ads_AdWords_v201402\\OpportunityIdeaTypeAttribute",
+      "PlacementAttribute" => "Google_Api_Ads_AdWords_v201402\\PlacementAttribute",
+      "PlacementTypeAttribute" => "Google_Api_Ads_AdWords_v201402\\PlacementTypeAttribute",
+      "PlacementTypeSearchParameter" => "Google_Api_Ads_AdWords_v201402\\PlacementTypeSearchParameter",
+      "Range" => "Google_Api_Ads_AdWords_v201402\\Range",
+      "RelatedToQuerySearchParameter" => "Google_Api_Ads_AdWords_v201402\\RelatedToQuerySearchParameter",
+      "RelatedToUrlSearchParameter" => "Google_Api_Ads_AdWords_v201402\\RelatedToUrlSearchParameter",
+      "SearchParameter" => "Google_Api_Ads_AdWords_v201402\\SearchParameter",
+      "SearchVolumeSearchParameter" => "Google_Api_Ads_AdWords_v201402\\SearchVolumeSearchParameter",
+      "SeedAdGroupIdSearchParameter" => "Google_Api_Ads_AdWords_v201402\\SeedAdGroupIdSearchParameter",
+      "StringAttribute" => "Google_Api_Ads_AdWords_v201402\\StringAttribute",
+      "TargetingIdea" => "Google_Api_Ads_AdWords_v201402\\TargetingIdea",
+      "TargetingIdeaError" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaError",
+      "TargetingIdeaPage" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaPage",
+      "TargetingIdeaSelector" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaSelector",
+      "TextAdSpec" => "Google_Api_Ads_AdWords_v201402\\TextAdSpec",
+      "TrafficEstimatorError" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorError",
+      "Type_AttributeMapEntry" => "Google_Api_Ads_AdWords_v201402\\Type_AttributeMapEntry",
+      "WebpageDescriptor" => "Google_Api_Ads_AdWords_v201402\\WebpageDescriptor",
+      "WebpageDescriptorAttribute" => "Google_Api_Ads_AdWords_v201402\\WebpageDescriptorAttribute",
+      "AttributeType" => "Google_Api_Ads_AdWords_v201402\\AttributeType",
+      "CompetitionSearchParameter.Level" => "Google_Api_Ads_AdWords_v201402\\CompetitionSearchParameterLevel",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason",
+      "DisplayAdSpec.ActivationOption" => "Google_Api_Ads_AdWords_v201402\\DisplayAdSpecActivationOption",
+      "HtmlDisplayType.HtmlOption" => "Google_Api_Ads_AdWords_v201402\\HtmlDisplayTypeHtmlOption",
+      "IdeaType" => "Google_Api_Ads_AdWords_v201402\\IdeaType",
+      "InStreamAdSpec.InStreamType" => "Google_Api_Ads_AdWords_v201402\\InStreamAdSpecInStreamType",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason",
+      "OpportunityIdeaType" => "Google_Api_Ads_AdWords_v201402\\OpportunityIdeaType",
+      "RequestType" => "Google_Api_Ads_AdWords_v201402\\RequestType",
+      "SiteConstants.AdFormat" => "Google_Api_Ads_AdWords_v201402\\SiteConstantsAdFormat",
+      "SiteConstants.PlacementType" => "Google_Api_Ads_AdWords_v201402\\SiteConstantsPlacementType",
+      "TargetingIdeaError.Reason" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaErrorReason",
+      "TrafficEstimatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\TargetingIdeaServiceGetResponse",
+      "getBulkKeywordIdeas" => "Google_Api_Ads_AdWords_v201402\\GetBulkKeywordIdeas",
+      "getBulkKeywordIdeasResponse" => "Google_Api_Ads_AdWords_v201402\\GetBulkKeywordIdeasResponse",
     );
 
 
@@ -9162,3 +9099,4 @@ if (!class_exists("TargetingIdeaService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/AdWords/v201402/TrafficEstimatorService.php
+++ b/src/Google/Api/Ads/AdWords/v201402/TrafficEstimatorService.php
@@ -26,11 +26,11 @@
  * @license    http://www.apache.org/licenses/LICENSE-2.0 Apache License,
  *             Version 2.0
  */
+namespace Google_Api_Ads_AdWords_v201402;
 
-/** Required classes. **/
 require_once "Google/Api/Ads/AdWords/Lib/AdWordsSoapClient.php";
 
-if (!class_exists("ApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiError", false)) {
   /**
    * The API error base class that provides details about an error that occurred
    * while processing a service request.
@@ -131,7 +131,7 @@ if (!class_exists("ApiError", false)) {
   }
 }
 
-if (!class_exists("ApplicationException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApplicationException", false)) {
   /**
    * Base class for exceptions.
    * 
@@ -214,7 +214,7 @@ if (!class_exists("ApplicationException", false)) {
   }
 }
 
-if (!class_exists("AuthenticationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationError", false)) {
   /**
    * Errors returned when Authentication failed.
    * 
@@ -263,7 +263,7 @@ if (!class_exists("AuthenticationError", false)) {
   }
 }
 
-if (!class_exists("AuthorizationError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationError", false)) {
   /**
    * Errors encountered when trying to authorize a user.
    * 
@@ -312,7 +312,7 @@ if (!class_exists("AuthorizationError", false)) {
   }
 }
 
-if (!class_exists("ClientTermsError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsError", false)) {
   /**
    * Error due to user not accepting the AdWords terms of service.
    * 
@@ -361,7 +361,7 @@ if (!class_exists("ClientTermsError", false)) {
   }
 }
 
-if (!class_exists("CollectionSizeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeError", false)) {
   /**
    * Errors associated with the size of the given collection being
    * out of bounds.
@@ -376,6 +376,12 @@ if (!class_exists("CollectionSizeError", false)) {
 
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
     const XSI_TYPE = "CollectionSizeError";
+
+    /**
+     * @access public
+     * @var tnsCollectionSizeErrorReason
+     */
+    public $reason;
 
     /**
      * Gets the namesapce of this class
@@ -393,8 +399,9 @@ if (!class_exists("CollectionSizeError", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
+    public function __construct($reason = null, $fieldPath = null, $trigger = null, $errorString = null, $ApiErrorType = null) {
       parent::__construct();
+      $this->reason = $reason;
       $this->fieldPath = $fieldPath;
       $this->trigger = $trigger;
       $this->errorString = $errorString;
@@ -404,7 +411,7 @@ if (!class_exists("CollectionSizeError", false)) {
   }
 }
 
-if (!class_exists("ComparableValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ComparableValue", false)) {
   /**
    * Comparable types for constructing ranges with.
    * 
@@ -480,7 +487,7 @@ if (!class_exists("ComparableValue", false)) {
   }
 }
 
-if (!class_exists("Criterion", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Criterion", false)) {
   /**
    * Represents a criterion (such as a keyword, placement, or vertical).
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -571,7 +578,7 @@ if (!class_exists("Criterion", false)) {
   }
 }
 
-if (!class_exists("DatabaseError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseError", false)) {
   /**
    * Errors that are thrown due to a database access problem.
    * 
@@ -620,7 +627,7 @@ if (!class_exists("DatabaseError", false)) {
   }
 }
 
-if (!class_exists("DateError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateError", false)) {
   /**
    * Errors associated with invalid dates and date ranges.
    * 
@@ -669,7 +676,7 @@ if (!class_exists("DateError", false)) {
   }
 }
 
-if (!class_exists("DistinctError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctError", false)) {
   /**
    * Errors related to distinct ids or content.
    * 
@@ -718,7 +725,7 @@ if (!class_exists("DistinctError", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDenied", false)) {
   /**
    * Reports permission problems trying to access an entity.
    * 
@@ -767,7 +774,7 @@ if (!class_exists("EntityAccessDenied", false)) {
   }
 }
 
-if (!class_exists("EntityNotFound", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFound", false)) {
   /**
    * An id did not correspond to an entity, or it referred to an entity which does not belong to the
    * customer.
@@ -817,7 +824,7 @@ if (!class_exists("EntityNotFound", false)) {
   }
 }
 
-if (!class_exists("IdError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdError", false)) {
   /**
    * Errors associated with the ids.
    * 
@@ -866,7 +873,7 @@ if (!class_exists("IdError", false)) {
   }
 }
 
-if (!class_exists("InternalApiError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiError", false)) {
   /**
    * Indicates that a server-side error has occured. {@code InternalApiError}s
    * are generally not the result of an invalid request or message sent by the
@@ -917,7 +924,7 @@ if (!class_exists("InternalApiError", false)) {
   }
 }
 
-if (!class_exists("Keyword", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Keyword", false)) {
   /**
    * Represents a keyword.
    * <span class="constraint AdxEnabled">This is disabled for AdX when it is contained within Operators: ADD, SET.</span>
@@ -973,10 +980,10 @@ if (!class_exists("Keyword", false)) {
   }
 }
 
-if (!class_exists("Language", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Language", false)) {
   /**
    * Represents a Language criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type is only targetable.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1030,10 +1037,10 @@ if (!class_exists("Language", false)) {
   }
 }
 
-if (!class_exists("Location", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Location", false)) {
   /**
    * Represents Location criterion.
-   * <p>A criterion of this type can only be created using an ID. A criterion of this type can be either targeted or excluded.
+   * <p>A criterion of this type can only be created using an ID.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
    * 
    * 
@@ -1101,7 +1108,7 @@ if (!class_exists("Location", false)) {
   }
 }
 
-if (!class_exists("MobileAppCategory", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileAppCategory", false)) {
   /**
    * Represents the mobile app category to be targeted.
    * <a href="/adwords/api/docs/appendix/mobileappcategories">View the complete list of
@@ -1159,7 +1166,7 @@ if (!class_exists("MobileAppCategory", false)) {
   }
 }
 
-if (!class_exists("MobileApplication", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MobileApplication", false)) {
   /**
    * Represents the mobile application to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -1215,7 +1222,7 @@ if (!class_exists("MobileApplication", false)) {
   }
 }
 
-if (!class_exists("Money", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Money", false)) {
   /**
    * Represents a money amount.
    * 
@@ -1261,7 +1268,7 @@ if (!class_exists("Money", false)) {
   }
 }
 
-if (!class_exists("NetworkSetting", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NetworkSetting", false)) {
   /**
    * Network settings for a Campaign.
    * 
@@ -1326,7 +1333,7 @@ if (!class_exists("NetworkSetting", false)) {
   }
 }
 
-if (!class_exists("NotEmptyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyError", false)) {
   /**
    * Errors corresponding with violation of a NOT EMPTY check.
    * 
@@ -1375,7 +1382,7 @@ if (!class_exists("NotEmptyError", false)) {
   }
 }
 
-if (!class_exists("NullError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullError", false)) {
   /**
    * Errors associated with violation of a NOT NULL check.
    * 
@@ -1424,7 +1431,7 @@ if (!class_exists("NullError", false)) {
   }
 }
 
-if (!class_exists("NumberValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NumberValue", false)) {
   /**
    * Number value types for constructing number valued ranges.
    * 
@@ -1463,7 +1470,7 @@ if (!class_exists("NumberValue", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDenied", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDenied", false)) {
   /**
    * Operation not permitted due to the invoked service's access policy.
    * 
@@ -1512,7 +1519,7 @@ if (!class_exists("OperationAccessDenied", false)) {
   }
 }
 
-if (!class_exists("OperatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorError", false)) {
   /**
    * Errors due to the use of unsupported operations.
    * 
@@ -1561,7 +1568,7 @@ if (!class_exists("OperatorError", false)) {
   }
 }
 
-if (!class_exists("Placement", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Placement", false)) {
   /**
    * A placement used for modifying bids for sites when targeting the content
    * network.
@@ -1611,7 +1618,7 @@ if (!class_exists("Placement", false)) {
   }
 }
 
-if (!class_exists("Product", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Product", false)) {
   /**
    * Product targeting criteria, represents a filter for products in the
    * product feed that is defined by the advertiser. The criteria is used to
@@ -1670,7 +1677,7 @@ if (!class_exists("Product", false)) {
   }
 }
 
-if (!class_exists("ProductCondition", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductCondition", false)) {
   /**
    * Conditions to filter the products defined in product feed for targeting.
    * The condition is defined as operand=argument.
@@ -1722,7 +1729,7 @@ if (!class_exists("ProductCondition", false)) {
   }
 }
 
-if (!class_exists("ProductConditionOperand", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ProductConditionOperand", false)) {
   /**
    * Attribute for the product condition.
    * 
@@ -1766,7 +1773,7 @@ if (!class_exists("ProductConditionOperand", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckError", false)) {
   /**
    * Encapsulates the errors thrown during developer quota checks.
    * 
@@ -1815,7 +1822,7 @@ if (!class_exists("QuotaCheckError", false)) {
   }
 }
 
-if (!class_exists("RangeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeError", false)) {
   /**
    * A list of all errors associated with the Range constraint.
    * 
@@ -1864,7 +1871,7 @@ if (!class_exists("RangeError", false)) {
   }
 }
 
-if (!class_exists("RateExceededError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededError", false)) {
   /**
    * Signals that a call failed because a measured rate exceeded.
    * 
@@ -1934,7 +1941,7 @@ if (!class_exists("RateExceededError", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyError", false)) {
   /**
    * Errors from attempting to write to read-only fields.
    * 
@@ -1983,7 +1990,7 @@ if (!class_exists("ReadOnlyError", false)) {
   }
 }
 
-if (!class_exists("RegionCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeError", false)) {
   /**
    * A list of all errors associated with the @RegionCode constraints.
    * 
@@ -2032,7 +2039,7 @@ if (!class_exists("RegionCodeError", false)) {
   }
 }
 
-if (!class_exists("RejectedError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedError", false)) {
   /**
    * Indicates that a field was rejected due to compatibility issues.
    * 
@@ -2081,7 +2088,7 @@ if (!class_exists("RejectedError", false)) {
   }
 }
 
-if (!class_exists("RequestError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestError", false)) {
   /**
    * Encapsulates the generic errors thrown when there's an error with user
    * request.
@@ -2131,7 +2138,7 @@ if (!class_exists("RequestError", false)) {
   }
 }
 
-if (!class_exists("RequiredError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredError", false)) {
   /**
    * Errors due to missing required field.
    * 
@@ -2180,7 +2187,7 @@ if (!class_exists("RequiredError", false)) {
   }
 }
 
-if (!class_exists("SizeLimitError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitError", false)) {
   /**
    * Indicates that the number of entries in the request or response exceeds the system limit.
    * 
@@ -2229,7 +2236,7 @@ if (!class_exists("SizeLimitError", false)) {
   }
 }
 
-if (!class_exists("SoapRequestHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapRequestHeader", false)) {
   /**
    * Defines the required and optional elements within the header of a SOAP request.
    * 
@@ -2301,7 +2308,7 @@ if (!class_exists("SoapRequestHeader", false)) {
   }
 }
 
-if (!class_exists("SoapResponseHeader", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SoapResponseHeader", false)) {
   /**
    * Defines the elements within the header of a SOAP response.
    * 
@@ -2373,7 +2380,7 @@ if (!class_exists("SoapResponseHeader", false)) {
   }
 }
 
-if (!class_exists("StringLengthError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthError", false)) {
   /**
    * Errors associated with the length of the given string being
    * out of bounds.
@@ -2423,7 +2430,7 @@ if (!class_exists("StringLengthError", false)) {
   }
 }
 
-if (!class_exists("TargetError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetError", false)) {
   /**
    * A list of all the error codes being used by the common targeting package.
    * 
@@ -2472,7 +2479,7 @@ if (!class_exists("TargetError", false)) {
   }
 }
 
-if (!class_exists("CriterionUserInterest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserInterest", false)) {
   /**
    * User Interest represents a particular interest-based vertical to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2528,7 +2535,7 @@ if (!class_exists("CriterionUserInterest", false)) {
   }
 }
 
-if (!class_exists("CriterionUserList", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserList", false)) {
   /**
    * UserList - represents a user list that is defined by the advertiser to be targeted.
    * <span class="constraint AdxEnabled">This is enabled for AdX.</span>
@@ -2591,7 +2598,7 @@ if (!class_exists("CriterionUserList", false)) {
   }
 }
 
-if (!class_exists("Vertical", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Vertical", false)) {
   /**
    * Use verticals to target or exclude placements in the Google Display Network
    * based on the category into which the placement falls (for example, "Pets &amp;
@@ -2658,7 +2665,7 @@ if (!class_exists("Vertical", false)) {
   }
 }
 
-if (!class_exists("AdxErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxErrorReason", false)) {
   /**
    * The reasons for the AdX error.
    * 
@@ -2695,7 +2702,7 @@ if (!class_exists("AdxErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthenticationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason", false)) {
   /**
    * The single reason for the authentication failure.
    * 
@@ -2732,7 +2739,7 @@ if (!class_exists("AuthenticationErrorReason", false)) {
   }
 }
 
-if (!class_exists("AuthorizationErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2769,7 +2776,7 @@ if (!class_exists("AuthorizationErrorReason", false)) {
   }
 }
 
-if (!class_exists("ClientTermsErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason", false)) {
   /**
    * Enums for the various reasons an error can be thrown as a result of
    * ClientTerms violation.
@@ -2807,7 +2814,44 @@ if (!class_exists("ClientTermsErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason", false)) {
+  /**
+   * The reasons for the target error.
+   * 
+   * 
+   * 
+   * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
+   * @package Google_Api_Ads_AdWords_v201402
+   * @subpackage v201402
+   */
+  class CollectionSizeErrorReason {
+
+    const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/cm/v201402";
+    const XSI_TYPE = "CollectionSizeError.Reason";
+
+    /**
+     * Gets the namesapce of this class
+     * @return the namespace of this class
+     */
+    public function getNamespace() {
+      return self::WSDL_NAMESPACE;
+    }
+
+    /**
+     * Gets the xsi:type name of this class
+     * @return the xsi:type name of this class
+     */
+    public function getXsiTypeName() {
+      return self::XSI_TYPE;
+    }
+
+    public function __construct() {
+    }
+
+  }
+}
+
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionType", false)) {
   /**
    * The types of criteria.
    * 
@@ -2844,7 +2888,7 @@ if (!class_exists("CriterionType", false)) {
   }
 }
 
-if (!class_exists("DatabaseErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason", false)) {
   /**
    * The reasons for the database error.
    * 
@@ -2881,7 +2925,7 @@ if (!class_exists("DatabaseErrorReason", false)) {
   }
 }
 
-if (!class_exists("DateErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DateErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -2918,7 +2962,7 @@ if (!class_exists("DateErrorReason", false)) {
   }
 }
 
-if (!class_exists("DistinctErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DistinctErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -2955,7 +2999,7 @@ if (!class_exists("DistinctErrorReason", false)) {
   }
 }
 
-if (!class_exists("EntityAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason", false)) {
   /**
    * User did not have read access.
    * 
@@ -2992,7 +3036,7 @@ if (!class_exists("EntityAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("EntityNotFoundReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason", false)) {
   /**
    * The specified id refered to an entity which either doesn't exist or is not accessible to the
    * customer. e.g. campaign belongs to another customer.
@@ -3030,7 +3074,7 @@ if (!class_exists("EntityNotFoundReason", false)) {
   }
 }
 
-if (!class_exists("IdErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\IdErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3067,7 +3111,7 @@ if (!class_exists("IdErrorReason", false)) {
   }
 }
 
-if (!class_exists("InternalApiErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason", false)) {
   /**
    * The single reason for the internal API error.
    * 
@@ -3104,7 +3148,7 @@ if (!class_exists("InternalApiErrorReason", false)) {
   }
 }
 
-if (!class_exists("KeywordMatchType", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordMatchType", false)) {
   /**
    * Match type of a keyword. i.e. the way we match a keyword string with
    * search queries.
@@ -3142,7 +3186,7 @@ if (!class_exists("KeywordMatchType", false)) {
   }
 }
 
-if (!class_exists("LocationTargetingStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus", false)) {
   /**
    * Enum that represents the different Targeting Status values for a Location criterion.
    * 
@@ -3179,7 +3223,7 @@ if (!class_exists("LocationTargetingStatus", false)) {
   }
 }
 
-if (!class_exists("NotEmptyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3216,7 +3260,7 @@ if (!class_exists("NotEmptyErrorReason", false)) {
   }
 }
 
-if (!class_exists("NullErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\NullErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3253,7 +3297,7 @@ if (!class_exists("NullErrorReason", false)) {
   }
 }
 
-if (!class_exists("OperationAccessDeniedReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason", false)) {
   /**
    * The reasons for the operation access error.
    * 
@@ -3290,7 +3334,7 @@ if (!class_exists("OperationAccessDeniedReason", false)) {
   }
 }
 
-if (!class_exists("OperatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\OperatorErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3327,7 +3371,7 @@ if (!class_exists("OperatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("QuotaCheckErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason", false)) {
   /**
    * Enums for all the reasons an error can be thrown to the user during
    * billing quota checks.
@@ -3365,7 +3409,7 @@ if (!class_exists("QuotaCheckErrorReason", false)) {
   }
 }
 
-if (!class_exists("RangeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RangeErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3402,7 +3446,7 @@ if (!class_exists("RangeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RateExceededErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason", false)) {
   /**
    * The reason for the rate exceeded error.
    * 
@@ -3439,7 +3483,7 @@ if (!class_exists("RateExceededErrorReason", false)) {
   }
 }
 
-if (!class_exists("ReadOnlyErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3476,7 +3520,7 @@ if (!class_exists("ReadOnlyErrorReason", false)) {
   }
 }
 
-if (!class_exists("RegionCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason", false)) {
   /**
    * The reasons for the validation error.
    * 
@@ -3513,7 +3557,7 @@ if (!class_exists("RegionCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("RejectedErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RejectedErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3550,7 +3594,7 @@ if (!class_exists("RejectedErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequestErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequestErrorReason", false)) {
   /**
    * Error reason is unknown.
    * 
@@ -3587,7 +3631,7 @@ if (!class_exists("RequestErrorReason", false)) {
   }
 }
 
-if (!class_exists("RequiredErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\RequiredErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3624,7 +3668,7 @@ if (!class_exists("RequiredErrorReason", false)) {
   }
 }
 
-if (!class_exists("SizeLimitErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason", false)) {
   /**
    * The reasons for Ad Scheduling errors.
    * 
@@ -3661,7 +3705,7 @@ if (!class_exists("SizeLimitErrorReason", false)) {
   }
 }
 
-if (!class_exists("StringLengthErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3698,7 +3742,7 @@ if (!class_exists("StringLengthErrorReason", false)) {
   }
 }
 
-if (!class_exists("TargetErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TargetErrorReason", false)) {
   /**
    * The reasons for the target error.
    * 
@@ -3735,7 +3779,7 @@ if (!class_exists("TargetErrorReason", false)) {
   }
 }
 
-if (!class_exists("CriterionUserListMembershipStatus", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus", false)) {
   /**
    * Membership status of the user list.
    * 
@@ -3772,7 +3816,7 @@ if (!class_exists("CriterionUserListMembershipStatus", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeError", false)) {
   /**
    * Errors for currency codes.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3817,7 +3861,7 @@ if (!class_exists("CurrencyCodeError", false)) {
   }
 }
 
-if (!class_exists("Estimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\Estimate", false)) {
   /**
    * Abstract class representing an reply to an {@link EstimateRequest}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3889,7 +3933,7 @@ if (!class_exists("Estimate", false)) {
   }
 }
 
-if (!class_exists("EstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\EstimateRequest", false)) {
   /**
    * Abstract class representing a request to estimate stats.
    * @package Google_Api_Ads_AdWords_v201402
@@ -3961,7 +4005,7 @@ if (!class_exists("EstimateRequest", false)) {
   }
 }
 
-if (!class_exists("KeywordEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordEstimate", false)) {
   /**
    * Represents the traffic estimate result for a single keyword.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4017,7 +4061,7 @@ if (!class_exists("KeywordEstimate", false)) {
   }
 }
 
-if (!class_exists("KeywordEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\KeywordEstimateRequest", false)) {
   /**
    * Represents a keyword to be estimated.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4073,7 +4117,7 @@ if (!class_exists("KeywordEstimateRequest", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexError", false)) {
   /**
    * Errors associated with a given string not matching the provided
    * regular expression.
@@ -4119,9 +4163,12 @@ if (!class_exists("MatchesRegexError", false)) {
   }
 }
 
-if (!class_exists("StatsEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\StatsEstimate", false)) {
   /**
-   * Represents a set of stats for a traffic estimate.
+   * Represents a set of stats for a daily traffic estimate.
+   * As of v201406 {@code averageCpc}, {@code averagePosition} and {@code clickThroughRate} will be
+   * {@code null} when not defined (respectively, if {@code clicksPerDay} or
+   * {@code impressionsPerDay} are 0).
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
@@ -4146,6 +4193,12 @@ if (!class_exists("StatsEstimate", false)) {
      * @access public
      * @var double
      */
+    public $clickThroughRate;
+
+    /**
+     * @access public
+     * @var double
+     */
     public $clicksPerDay;
 
     /**
@@ -4153,12 +4206,6 @@ if (!class_exists("StatsEstimate", false)) {
      * @var double
      */
     public $impressionsPerDay;
-
-    /**
-     * @access public
-     * @var double
-     */
-    public $clickThroughRate;
 
     /**
      * @access public
@@ -4182,19 +4229,19 @@ if (!class_exists("StatsEstimate", false)) {
       return self::XSI_TYPE;
     }
 
-    public function __construct($averageCpc = null, $averagePosition = null, $clicksPerDay = null, $impressionsPerDay = null, $clickThroughRate = null, $totalCost = null) {
+    public function __construct($averageCpc = null, $averagePosition = null, $clickThroughRate = null, $clicksPerDay = null, $impressionsPerDay = null, $totalCost = null) {
       $this->averageCpc = $averageCpc;
       $this->averagePosition = $averagePosition;
+      $this->clickThroughRate = $clickThroughRate;
       $this->clicksPerDay = $clicksPerDay;
       $this->impressionsPerDay = $impressionsPerDay;
-      $this->clickThroughRate = $clickThroughRate;
       $this->totalCost = $totalCost;
     }
 
   }
 }
 
-if (!class_exists("TrafficEstimatorError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorError", false)) {
   /**
    * Base error class for
    * {@link com.google.ads.api.services.trafficestimator.TrafficEstimatorService}.
@@ -4240,7 +4287,7 @@ if (!class_exists("TrafficEstimatorError", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorResult", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorResult", false)) {
   /**
    * Contains results of traffic estimation request.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4280,7 +4327,7 @@ if (!class_exists("TrafficEstimatorResult", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorSelector", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorSelector", false)) {
   /**
    * Contains a list of campaigns to perform a traffic estimate on.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4320,7 +4367,7 @@ if (!class_exists("TrafficEstimatorSelector", false)) {
   }
 }
 
-if (!class_exists("CurrencyCodeErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason", false)) {
   /**
    * Encodes the reason (cause) of a particular {@link CurrencyCodeError}.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4353,7 +4400,7 @@ if (!class_exists("CurrencyCodeErrorReason", false)) {
   }
 }
 
-if (!class_exists("MatchesRegexErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason", false)) {
   /**
    * The reasons for the target error.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4386,7 +4433,7 @@ if (!class_exists("MatchesRegexErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorErrorReason", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorErrorReason", false)) {
   /**
    * When the request with {@code null} campaign ID in
    * {@link com.google.ads.api.services.trafficestimator.CampaignEstimateRequest}
@@ -4423,7 +4470,7 @@ if (!class_exists("TrafficEstimatorErrorReason", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorServiceGet", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorServiceGet", false)) {
   /**
    * <span class="constraint Required">This field is required and should not be {@code null}.</span>
    * 
@@ -4472,7 +4519,7 @@ if (!class_exists("TrafficEstimatorServiceGet", false)) {
   }
 }
 
-if (!class_exists("TrafficEstimatorServiceGetResponse", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\TrafficEstimatorServiceGetResponse", false)) {
   /**
    * 
    * @package Google_Api_Ads_AdWords_v201402
@@ -4512,7 +4559,7 @@ if (!class_exists("TrafficEstimatorServiceGetResponse", false)) {
   }
 }
 
-if (!class_exists("AdxError", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdxError", false)) {
   /**
    * Errors that are thrown when a non-AdX feature is accessed by an AdX customer.
    * 
@@ -4561,7 +4608,7 @@ if (!class_exists("AdxError", false)) {
   }
 }
 
-if (!class_exists("ApiException", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\ApiException", false)) {
   /**
    * Exception class for holding a list of service errors.
    * 
@@ -4608,7 +4655,7 @@ if (!class_exists("ApiException", false)) {
   }
 }
 
-if (!class_exists("DoubleValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\DoubleValue", false)) {
   /**
    * Number value type for constructing double valued ranges.
    * 
@@ -4653,7 +4700,7 @@ if (!class_exists("DoubleValue", false)) {
   }
 }
 
-if (!class_exists("LongValue", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\LongValue", false)) {
   /**
    * Number value type for constructing long valued ranges.
    * 
@@ -4698,7 +4745,7 @@ if (!class_exists("LongValue", false)) {
   }
 }
 
-if (!class_exists("AdGroupEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupEstimate", false)) {
   /**
    * Represents the estimate results for a single ad group.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4747,7 +4794,7 @@ if (!class_exists("AdGroupEstimate", false)) {
   }
 }
 
-if (!class_exists("AdGroupEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\AdGroupEstimateRequest", false)) {
   /**
    * Represents an ad group that will be estimated. Ad groups may be all
    * new or all existing, or a mixture of new and existing. Only existing
@@ -4813,7 +4860,7 @@ if (!class_exists("AdGroupEstimateRequest", false)) {
   }
 }
 
-if (!class_exists("CampaignEstimate", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignEstimate", false)) {
   /**
    * Represents the estimate results for a single campaign.
    * @package Google_Api_Ads_AdWords_v201402
@@ -4862,7 +4909,7 @@ if (!class_exists("CampaignEstimate", false)) {
   }
 }
 
-if (!class_exists("CampaignEstimateRequest", false)) {
+if (!class_exists("Google_Api_Ads_AdWords_v201402\\CampaignEstimateRequest", false)) {
   /**
    * Represents a campaign that will be estimated.<p>
    * 
@@ -4953,7 +5000,7 @@ if (!class_exists("TrafficEstimatorService", false)) {
    * @package Google_Api_Ads_AdWords_v201402
    * @subpackage v201402
    */
-  class TrafficEstimatorService extends AdWordsSoapClient {
+  class TrafficEstimatorService extends Google_Api_Ads_AdWords_v201402\Google_Api_Ads_AdWords_Lib_AdWordsSoapClient {
 
     const SERVICE_NAME = "TrafficEstimatorService";
     const WSDL_NAMESPACE = "https://adwords.google.com/api/adwords/o/v201402";
@@ -4970,106 +5017,107 @@ if (!class_exists("TrafficEstimatorService", false)) {
      * @var array
      */
     public static $classmap = array(
-      "AdxError" => "AdxError",
-      "ApiError" => "ApiError",
-      "ApiException" => "ApiException",
-      "ApplicationException" => "ApplicationException",
-      "AuthenticationError" => "AuthenticationError",
-      "AuthorizationError" => "AuthorizationError",
-      "ClientTermsError" => "ClientTermsError",
-      "CollectionSizeError" => "CollectionSizeError",
-      "ComparableValue" => "ComparableValue",
-      "Criterion" => "Criterion",
-      "DatabaseError" => "DatabaseError",
-      "DateError" => "DateError",
-      "DistinctError" => "DistinctError",
-      "DoubleValue" => "DoubleValue",
-      "EntityAccessDenied" => "EntityAccessDenied",
-      "EntityNotFound" => "EntityNotFound",
-      "IdError" => "IdError",
-      "InternalApiError" => "InternalApiError",
-      "Keyword" => "Keyword",
-      "Language" => "Language",
-      "Location" => "Location",
-      "LongValue" => "LongValue",
-      "MobileAppCategory" => "MobileAppCategory",
-      "MobileApplication" => "MobileApplication",
-      "Money" => "Money",
-      "NetworkSetting" => "NetworkSetting",
-      "NotEmptyError" => "NotEmptyError",
-      "NullError" => "NullError",
-      "NumberValue" => "NumberValue",
-      "OperationAccessDenied" => "OperationAccessDenied",
-      "OperatorError" => "OperatorError",
-      "Placement" => "Placement",
-      "Product" => "Product",
-      "ProductCondition" => "ProductCondition",
-      "ProductConditionOperand" => "ProductConditionOperand",
-      "QuotaCheckError" => "QuotaCheckError",
-      "RangeError" => "RangeError",
-      "RateExceededError" => "RateExceededError",
-      "ReadOnlyError" => "ReadOnlyError",
-      "RegionCodeError" => "RegionCodeError",
-      "RejectedError" => "RejectedError",
-      "RequestError" => "RequestError",
-      "RequiredError" => "RequiredError",
-      "SizeLimitError" => "SizeLimitError",
-      "SoapHeader" => "SoapRequestHeader",
-      "SoapResponseHeader" => "SoapResponseHeader",
-      "StringLengthError" => "StringLengthError",
-      "TargetError" => "TargetError",
-      "CriterionUserInterest" => "CriterionUserInterest",
-      "CriterionUserList" => "CriterionUserList",
-      "Vertical" => "Vertical",
-      "AdxError.Reason" => "AdxErrorReason",
-      "AuthenticationError.Reason" => "AuthenticationErrorReason",
-      "AuthorizationError.Reason" => "AuthorizationErrorReason",
-      "ClientTermsError.Reason" => "ClientTermsErrorReason",
-      "Criterion.Type" => "CriterionType",
-      "DatabaseError.Reason" => "DatabaseErrorReason",
-      "DateError.Reason" => "DateErrorReason",
-      "DistinctError.Reason" => "DistinctErrorReason",
-      "EntityAccessDenied.Reason" => "EntityAccessDeniedReason",
-      "EntityNotFound.Reason" => "EntityNotFoundReason",
-      "IdError.Reason" => "IdErrorReason",
-      "InternalApiError.Reason" => "InternalApiErrorReason",
-      "KeywordMatchType" => "KeywordMatchType",
-      "LocationTargetingStatus" => "LocationTargetingStatus",
-      "NotEmptyError.Reason" => "NotEmptyErrorReason",
-      "NullError.Reason" => "NullErrorReason",
-      "OperationAccessDenied.Reason" => "OperationAccessDeniedReason",
-      "OperatorError.Reason" => "OperatorErrorReason",
-      "QuotaCheckError.Reason" => "QuotaCheckErrorReason",
-      "RangeError.Reason" => "RangeErrorReason",
-      "RateExceededError.Reason" => "RateExceededErrorReason",
-      "ReadOnlyError.Reason" => "ReadOnlyErrorReason",
-      "RegionCodeError.Reason" => "RegionCodeErrorReason",
-      "RejectedError.Reason" => "RejectedErrorReason",
-      "RequestError.Reason" => "RequestErrorReason",
-      "RequiredError.Reason" => "RequiredErrorReason",
-      "SizeLimitError.Reason" => "SizeLimitErrorReason",
-      "StringLengthError.Reason" => "StringLengthErrorReason",
-      "TargetError.Reason" => "TargetErrorReason",
-      "CriterionUserList.MembershipStatus" => "CriterionUserListMembershipStatus",
-      "AdGroupEstimate" => "AdGroupEstimate",
-      "AdGroupEstimateRequest" => "AdGroupEstimateRequest",
-      "CampaignEstimate" => "CampaignEstimate",
-      "CampaignEstimateRequest" => "CampaignEstimateRequest",
-      "CurrencyCodeError" => "CurrencyCodeError",
-      "Estimate" => "Estimate",
-      "EstimateRequest" => "EstimateRequest",
-      "KeywordEstimate" => "KeywordEstimate",
-      "KeywordEstimateRequest" => "KeywordEstimateRequest",
-      "MatchesRegexError" => "MatchesRegexError",
-      "StatsEstimate" => "StatsEstimate",
-      "TrafficEstimatorError" => "TrafficEstimatorError",
-      "TrafficEstimatorResult" => "TrafficEstimatorResult",
-      "TrafficEstimatorSelector" => "TrafficEstimatorSelector",
-      "CurrencyCodeError.Reason" => "CurrencyCodeErrorReason",
-      "MatchesRegexError.Reason" => "MatchesRegexErrorReason",
-      "TrafficEstimatorError.Reason" => "TrafficEstimatorErrorReason",
-      "get" => "TrafficEstimatorServiceGet",
-      "getResponse" => "TrafficEstimatorServiceGetResponse",
+      "AdxError" => "Google_Api_Ads_AdWords_v201402\\AdxError",
+      "ApiError" => "Google_Api_Ads_AdWords_v201402\\ApiError",
+      "ApiException" => "Google_Api_Ads_AdWords_v201402\\ApiException",
+      "ApplicationException" => "Google_Api_Ads_AdWords_v201402\\ApplicationException",
+      "AuthenticationError" => "Google_Api_Ads_AdWords_v201402\\AuthenticationError",
+      "AuthorizationError" => "Google_Api_Ads_AdWords_v201402\\AuthorizationError",
+      "ClientTermsError" => "Google_Api_Ads_AdWords_v201402\\ClientTermsError",
+      "CollectionSizeError" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeError",
+      "ComparableValue" => "Google_Api_Ads_AdWords_v201402\\ComparableValue",
+      "Criterion" => "Google_Api_Ads_AdWords_v201402\\Criterion",
+      "DatabaseError" => "Google_Api_Ads_AdWords_v201402\\DatabaseError",
+      "DateError" => "Google_Api_Ads_AdWords_v201402\\DateError",
+      "DistinctError" => "Google_Api_Ads_AdWords_v201402\\DistinctError",
+      "DoubleValue" => "Google_Api_Ads_AdWords_v201402\\DoubleValue",
+      "EntityAccessDenied" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDenied",
+      "EntityNotFound" => "Google_Api_Ads_AdWords_v201402\\EntityNotFound",
+      "IdError" => "Google_Api_Ads_AdWords_v201402\\IdError",
+      "InternalApiError" => "Google_Api_Ads_AdWords_v201402\\InternalApiError",
+      "Keyword" => "Google_Api_Ads_AdWords_v201402\\Keyword",
+      "Language" => "Google_Api_Ads_AdWords_v201402\\Language",
+      "Location" => "Google_Api_Ads_AdWords_v201402\\Location",
+      "LongValue" => "Google_Api_Ads_AdWords_v201402\\LongValue",
+      "MobileAppCategory" => "Google_Api_Ads_AdWords_v201402\\MobileAppCategory",
+      "MobileApplication" => "Google_Api_Ads_AdWords_v201402\\MobileApplication",
+      "Money" => "Google_Api_Ads_AdWords_v201402\\Money",
+      "NetworkSetting" => "Google_Api_Ads_AdWords_v201402\\NetworkSetting",
+      "NotEmptyError" => "Google_Api_Ads_AdWords_v201402\\NotEmptyError",
+      "NullError" => "Google_Api_Ads_AdWords_v201402\\NullError",
+      "NumberValue" => "Google_Api_Ads_AdWords_v201402\\NumberValue",
+      "OperationAccessDenied" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDenied",
+      "OperatorError" => "Google_Api_Ads_AdWords_v201402\\OperatorError",
+      "Placement" => "Google_Api_Ads_AdWords_v201402\\Placement",
+      "Product" => "Google_Api_Ads_AdWords_v201402\\Product",
+      "ProductCondition" => "Google_Api_Ads_AdWords_v201402\\ProductCondition",
+      "ProductConditionOperand" => "Google_Api_Ads_AdWords_v201402\\ProductConditionOperand",
+      "QuotaCheckError" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckError",
+      "RangeError" => "Google_Api_Ads_AdWords_v201402\\RangeError",
+      "RateExceededError" => "Google_Api_Ads_AdWords_v201402\\RateExceededError",
+      "ReadOnlyError" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyError",
+      "RegionCodeError" => "Google_Api_Ads_AdWords_v201402\\RegionCodeError",
+      "RejectedError" => "Google_Api_Ads_AdWords_v201402\\RejectedError",
+      "RequestError" => "Google_Api_Ads_AdWords_v201402\\RequestError",
+      "RequiredError" => "Google_Api_Ads_AdWords_v201402\\RequiredError",
+      "SizeLimitError" => "Google_Api_Ads_AdWords_v201402\\SizeLimitError",
+      "SoapHeader" => "Google_Api_Ads_AdWords_v201402\\SoapRequestHeader",
+      "SoapResponseHeader" => "Google_Api_Ads_AdWords_v201402\\SoapResponseHeader",
+      "StringLengthError" => "Google_Api_Ads_AdWords_v201402\\StringLengthError",
+      "TargetError" => "Google_Api_Ads_AdWords_v201402\\TargetError",
+      "CriterionUserInterest" => "Google_Api_Ads_AdWords_v201402\\CriterionUserInterest",
+      "CriterionUserList" => "Google_Api_Ads_AdWords_v201402\\CriterionUserList",
+      "Vertical" => "Google_Api_Ads_AdWords_v201402\\Vertical",
+      "AdxError.Reason" => "Google_Api_Ads_AdWords_v201402\\AdxErrorReason",
+      "AuthenticationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthenticationErrorReason",
+      "AuthorizationError.Reason" => "Google_Api_Ads_AdWords_v201402\\AuthorizationErrorReason",
+      "ClientTermsError.Reason" => "Google_Api_Ads_AdWords_v201402\\ClientTermsErrorReason",
+      "CollectionSizeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CollectionSizeErrorReason",
+      "Criterion.Type" => "Google_Api_Ads_AdWords_v201402\\CriterionType",
+      "DatabaseError.Reason" => "Google_Api_Ads_AdWords_v201402\\DatabaseErrorReason",
+      "DateError.Reason" => "Google_Api_Ads_AdWords_v201402\\DateErrorReason",
+      "DistinctError.Reason" => "Google_Api_Ads_AdWords_v201402\\DistinctErrorReason",
+      "EntityAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityAccessDeniedReason",
+      "EntityNotFound.Reason" => "Google_Api_Ads_AdWords_v201402\\EntityNotFoundReason",
+      "IdError.Reason" => "Google_Api_Ads_AdWords_v201402\\IdErrorReason",
+      "InternalApiError.Reason" => "Google_Api_Ads_AdWords_v201402\\InternalApiErrorReason",
+      "KeywordMatchType" => "Google_Api_Ads_AdWords_v201402\\KeywordMatchType",
+      "LocationTargetingStatus" => "Google_Api_Ads_AdWords_v201402\\LocationTargetingStatus",
+      "NotEmptyError.Reason" => "Google_Api_Ads_AdWords_v201402\\NotEmptyErrorReason",
+      "NullError.Reason" => "Google_Api_Ads_AdWords_v201402\\NullErrorReason",
+      "OperationAccessDenied.Reason" => "Google_Api_Ads_AdWords_v201402\\OperationAccessDeniedReason",
+      "OperatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\OperatorErrorReason",
+      "QuotaCheckError.Reason" => "Google_Api_Ads_AdWords_v201402\\QuotaCheckErrorReason",
+      "RangeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RangeErrorReason",
+      "RateExceededError.Reason" => "Google_Api_Ads_AdWords_v201402\\RateExceededErrorReason",
+      "ReadOnlyError.Reason" => "Google_Api_Ads_AdWords_v201402\\ReadOnlyErrorReason",
+      "RegionCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\RegionCodeErrorReason",
+      "RejectedError.Reason" => "Google_Api_Ads_AdWords_v201402\\RejectedErrorReason",
+      "RequestError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequestErrorReason",
+      "RequiredError.Reason" => "Google_Api_Ads_AdWords_v201402\\RequiredErrorReason",
+      "SizeLimitError.Reason" => "Google_Api_Ads_AdWords_v201402\\SizeLimitErrorReason",
+      "StringLengthError.Reason" => "Google_Api_Ads_AdWords_v201402\\StringLengthErrorReason",
+      "TargetError.Reason" => "Google_Api_Ads_AdWords_v201402\\TargetErrorReason",
+      "CriterionUserList.MembershipStatus" => "Google_Api_Ads_AdWords_v201402\\CriterionUserListMembershipStatus",
+      "AdGroupEstimate" => "Google_Api_Ads_AdWords_v201402\\AdGroupEstimate",
+      "AdGroupEstimateRequest" => "Google_Api_Ads_AdWords_v201402\\AdGroupEstimateRequest",
+      "CampaignEstimate" => "Google_Api_Ads_AdWords_v201402\\CampaignEstimate",
+      "CampaignEstimateRequest" => "Google_Api_Ads_AdWords_v201402\\CampaignEstimateRequest",
+      "CurrencyCodeError" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeError",
+      "Estimate" => "Google_Api_Ads_AdWords_v201402\\Estimate",
+      "EstimateRequest" => "Google_Api_Ads_AdWords_v201402\\EstimateRequest",
+      "KeywordEstimate" => "Google_Api_Ads_AdWords_v201402\\KeywordEstimate",
+      "KeywordEstimateRequest" => "Google_Api_Ads_AdWords_v201402\\KeywordEstimateRequest",
+      "MatchesRegexError" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexError",
+      "StatsEstimate" => "Google_Api_Ads_AdWords_v201402\\StatsEstimate",
+      "TrafficEstimatorError" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorError",
+      "TrafficEstimatorResult" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorResult",
+      "TrafficEstimatorSelector" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorSelector",
+      "CurrencyCodeError.Reason" => "Google_Api_Ads_AdWords_v201402\\CurrencyCodeErrorReason",
+      "MatchesRegexError.Reason" => "Google_Api_Ads_AdWords_v201402\\MatchesRegexErrorReason",
+      "TrafficEstimatorError.Reason" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorErrorReason",
+      "get" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorServiceGet",
+      "getResponse" => "Google_Api_Ads_AdWords_v201402\\TrafficEstimatorServiceGetResponse",
     );
 
 
@@ -5102,3 +5150,4 @@ if (!class_exists("TrafficEstimatorService", false)) {
     }
   }
 }
+

--- a/src/Google/Api/Ads/Dfp/Lib/api.properties
+++ b/src/Google/Api/Ads/Dfp/Lib/api.properties
@@ -8,7 +8,7 @@ lib.package=GoogleApiAdsDfp
 wsdl2php.proxy=
 ;; If enabled, class names (but not service names) will be prefixed with the
 ;; package name. Ex) Google\Api\Ads\Dfp\LineItem
-wsdl2php.enableNamespaces=False
+wsdl2php.enableNamespaces=True
 ;; Class map to be used if namespace support is not enabled, to work around
 ;; common conflicts, in JSON format.
 wsdl2php.conflictClassmap={"DateTime":"DfpDateTime", "Location":"DfpLocation", "OAuth":"DfpOAuth"}


### PR DESCRIPTION
:no_entry_sign: Do not merge, using this to share results. :no_entry_sign: 

This PR is the result of running the `phing` command with `wsdl2php.enableNamespaces=True` (after a modification to the `build.xml` file. The related bugs are #48 and #45, as this branch is unusable because of those issues.

The [sunset](https://developers.google.com/adwords/api/docs/sunset-dates) for the v201309 library is July 21 (14 days as of this writing). As of right now, I don't have a way to prevent an outage for our users because I cannot get the updated version of the SDK to build for our environment that already uses classes named `Campaign` and `Keyword` extensively.
