### PR TITLE
Add revocation methods to OAuth2Handler

### DIFF
--- a/src/Google/Api/Ads/Common/Util/OAuth2Handler.php
+++ b/src/Google/Api/Ads/Common/Util/OAuth2Handler.php
@@ -43,6 +43,7 @@ abstract class OAuth2Handler {
   const DEFAULT_REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob';
   const AUTHORIZE_ENDPOINT = 'https://accounts.google.com/o/oauth2/auth';
   const ACCESS_ENDPOINT = 'https://accounts.google.com/o/oauth2/token';
+  const REVOKE_ENDPOINT = 'https://accounts.google.com/o/oauth2/revoke';
 
   private $server;
   protected $scope;
@@ -207,6 +208,13 @@ abstract class OAuth2Handler {
   public abstract function RefreshAccessToken(array $credentials);
 
   /**
+   * Refreshes the access or refresh token.
+   * @param array $credentials: ['token' => 'xxx']
+   * @return array the credentials
+   */
+  public abstract function RevokeToken(array $credentials);
+
+  /**
    * Formats OAuth2 credentials for use in a URL.
    * For example: access_token=token.
    * @param array $credentials the OAuth2 credentials
@@ -252,6 +260,15 @@ abstract class OAuth2Handler {
    */
   protected function GetAccessEndpoint($params = NULL) {
     return $this->GetEndpoint(self::ACCESS_ENDPOINT, $params);
+  }
+
+  /**
+   * Gets the revocation endpoint using the given server and parameters.
+   * @param array $params the parameters to include in the endpoint
+   * @return string the revocation endpoint
+   */
+  protected function GetRevocationEndpoint($params = NULL) {
+    return $this->GetEndpoint(self::REVOKE_ENDPOINT, $params);
   }
 
   /**

--- a/src/Google/Api/Ads/Common/Util/SimpleOAuth2Handler.php
+++ b/src/Google/Api/Ads/Common/Util/SimpleOAuth2Handler.php
@@ -51,7 +51,7 @@ class SimpleOAuth2Handler extends OAuth2Handler {
   }
 
   /**
-   * @see OAuth2Hanlder::GetAccessToken()
+   * @see OAuth2Handler::GetAccessToken()
    */
   public function GetAccessToken(array $credentials, $code,
       $redirectUri = NULL) {
@@ -76,7 +76,25 @@ class SimpleOAuth2Handler extends OAuth2Handler {
   }
 
   /**
-   * @see OAuth2Hanlder::RefreshAccessToken()
+   * @see OAuth2Handler::GetRevokeToken()
+   */
+  public function RevokeToken(array $credentials) {
+    if (empty($credentials['client_id'])) {
+      throw new OAuth2Exception('client_id required.');
+    }
+    if (empty($credentials['client_secret'])) {
+      throw new OAuth2Exception('client_secret required.');
+    }
+    $params = array(
+        'token' => $credentials['refresh_token'],
+    );
+    $endpoint = $this->GetRevocationEndpoint();
+    $response = $this->MakeRequest($endpoint, $params);
+    return $response;
+  }
+
+  /**
+   * @see OAuth2Handler::RefreshAccessToken()
    */
   public function RefreshAccessToken(array $credentials) {
     if (empty($credentials['refresh_token'])) {


### PR DESCRIPTION
I noticed OAuth2Handler had no revocation methods which made it rather difficult to revoke tokens.
I was thinking something akin to this, what do you think? Not tested because not confirmed.

Cheers