### PR TITLE
why check !isset($settingsIniPath) should be !$settingsIniPath

### DIFF
--- a/src/Google/Api/Ads/AdWords/Lib/AdWordsUser.php
+++ b/src/Google/Api/Ads/AdWords/Lib/AdWordsUser.php
@@ -139,7 +139,7 @@ class AdWordsUser extends AdsUser {
     $this->SetClientCustomerId($clientCustomerId);
     $this->SetDeveloperToken($developerToken);
 
-    if (!isset($settingsIniPath)) {
+    if (!$settingsIniPath) {
       $settingsIniPath = dirname(__FILE__) . '/../settings.ini';
     }
 


### PR DESCRIPTION
it will ALWAYS be set, it's passed as an argument to the method, `!isset($settingsIniPath)` will always be `false`.