### PR TITLE
Fix $operationType case

### DIFF
--- a/src/Google/AdsApi/AdWords/v201601/billing/BudgetOrderOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/billing/BudgetOrderOperation.php
@@ -12,12 +12,12 @@ class BudgetOrderOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\billing\BudgetOrder $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdCustomizerFeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdCustomizerFeedOperation.php
@@ -12,12 +12,12 @@ class AdCustomizerFeedOperation extends \Google\AdsApi\AdWords\v201601\cm\Operat
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdCustomizerFeed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupAdLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupAdLabelOperation.php
@@ -12,12 +12,12 @@ class AdGroupAdLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Operatio
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupAdLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupAdOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupAdOperation.php
@@ -17,13 +17,13 @@ class AdGroupAdOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupAd $operand
      * @param \Google\AdsApi\AdWords\v201601\cm\ExemptionRequest[] $exemptionRequests
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null, array $exemptionRequests = null)
+    public function __construct($operator = null, $operationType = null, $operand = null, array $exemptionRequests = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
       $this->exemptionRequests = $exemptionRequests;
     }

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupBidModifierOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupBidModifierOperation.php
@@ -12,12 +12,12 @@ class AdGroupBidModifierOperation extends \Google\AdsApi\AdWords\v201601\cm\Oper
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupBidModifier $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupCriterionLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupCriterionLabelOperation.php
@@ -12,12 +12,12 @@ class AdGroupCriterionLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\O
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupCriterionLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupCriterionOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupCriterionOperation.php
@@ -17,13 +17,13 @@ class AdGroupCriterionOperation extends \Google\AdsApi\AdWords\v201601\cm\Operat
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupCriterion $operand
      * @param \Google\AdsApi\AdWords\v201601\cm\ExemptionRequest[] $exemptionRequests
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null, array $exemptionRequests = null)
+    public function __construct($operator = null, $operationType = null, $operand = null, array $exemptionRequests = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
       $this->exemptionRequests = $exemptionRequests;
     }

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupExtensionSettingOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupExtensionSettingOperation.php
@@ -12,12 +12,12 @@ class AdGroupExtensionSettingOperation extends \Google\AdsApi\AdWords\v201601\cm
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupExtensionSetting $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupFeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupFeedOperation.php
@@ -12,12 +12,12 @@ class AdGroupFeedOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupFeed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupLabelOperation.php
@@ -12,12 +12,12 @@ class AdGroupLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroupLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdGroupOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdGroupOperation.php
@@ -12,12 +12,12 @@ class AdGroupOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdGroup $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/AdParamOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/AdParamOperation.php
@@ -12,12 +12,12 @@ class AdParamOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\AdParam $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/BatchJobOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/BatchJobOperation.php
@@ -12,12 +12,12 @@ class BatchJobOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\BatchJob $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/BiddingStrategyOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/BiddingStrategyOperation.php
@@ -12,12 +12,12 @@ class BiddingStrategyOperation extends \Google\AdsApi\AdWords\v201601\cm\Operati
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\SharedBiddingStrategy $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/BudgetOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/BudgetOperation.php
@@ -12,12 +12,12 @@ class BudgetOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\Budget $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignAdExtensionOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignAdExtensionOperation.php
@@ -12,12 +12,12 @@ class CampaignAdExtensionOperation extends \Google\AdsApi\AdWords\v201601\cm\Ope
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignAdExtension $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignCriterionOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignCriterionOperation.php
@@ -12,12 +12,12 @@ class CampaignCriterionOperation extends \Google\AdsApi\AdWords\v201601\cm\Opera
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignCriterion $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignExtensionSettingOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignExtensionSettingOperation.php
@@ -12,12 +12,12 @@ class CampaignExtensionSettingOperation extends \Google\AdsApi\AdWords\v201601\c
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignExtensionSetting $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignFeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignFeedOperation.php
@@ -12,12 +12,12 @@ class CampaignFeedOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignFeed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignLabelOperation.php
@@ -12,12 +12,12 @@ class CampaignLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignOperation.php
@@ -12,12 +12,12 @@ class CampaignOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\Campaign $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CampaignSharedSetOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CampaignSharedSetOperation.php
@@ -12,12 +12,12 @@ class CampaignSharedSetOperation extends \Google\AdsApi\AdWords\v201601\cm\Opera
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CampaignSharedSet $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/ConversionTrackerOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/ConversionTrackerOperation.php
@@ -12,12 +12,12 @@ class ConversionTrackerOperation extends \Google\AdsApi\AdWords\v201601\cm\Opera
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\ConversionTracker $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CustomerExtensionSettingOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CustomerExtensionSettingOperation.php
@@ -12,12 +12,12 @@ class CustomerExtensionSettingOperation extends \Google\AdsApi\AdWords\v201601\c
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CustomerExtensionSetting $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/CustomerFeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/CustomerFeedOperation.php
@@ -12,12 +12,12 @@ class CustomerFeedOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\CustomerFeed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/ExperimentOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/ExperimentOperation.php
@@ -12,12 +12,12 @@ class ExperimentOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\Experiment $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/FeedItemOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/FeedItemOperation.php
@@ -12,12 +12,12 @@ class FeedItemOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\FeedItem $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/FeedMappingOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/FeedMappingOperation.php
@@ -12,12 +12,12 @@ class FeedMappingOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\FeedMapping $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/FeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/FeedOperation.php
@@ -12,12 +12,12 @@ class FeedOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\Feed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/LabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/LabelOperation.php
@@ -12,12 +12,12 @@ class LabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\Label $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/OfflineConversionFeedOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/OfflineConversionFeedOperation.php
@@ -12,12 +12,12 @@ class OfflineConversionFeedOperation extends \Google\AdsApi\AdWords\v201601\cm\O
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\OfflineConversionFeed $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/Operation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/Operation.php
@@ -11,18 +11,18 @@ abstract class Operation
     protected $operator = null;
 
     /**
-     * @var string $OperationType
+     * @var string $operationType
      */
-    protected $OperationType = null;
+    protected $operationType = null;
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      */
-    public function __construct($operator = null, $OperationType = null)
+    public function __construct($operator = null, $operationType = null)
     {
       $this->operator = $operator;
-      $this->OperationType = $OperationType;
+      $this->operationType = $operationType;
     }
 
     /**
@@ -48,16 +48,16 @@ abstract class Operation
      */
     public function getOperationType()
     {
-      return $this->OperationType;
+      return $this->operationType;
     }
 
     /**
-     * @param string $OperationType
+     * @param string $operationType
      * @return \Google\AdsApi\AdWords\v201601\cm\Operation
      */
-    public function setOperationType($OperationType)
+    public function setOperationType($operationType)
     {
-      $this->OperationType = $OperationType;
+      $this->operationType = $operationType;
       return $this;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/SharedCriterionOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/SharedCriterionOperation.php
@@ -12,12 +12,12 @@ class SharedCriterionOperation extends \Google\AdsApi\AdWords\v201601\cm\Operati
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\SharedCriterion $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/cm/SharedSetOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/cm/SharedSetOperation.php
@@ -12,12 +12,12 @@ class SharedSetOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\cm\SharedSet $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/express/ExpressBusinessOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/express/ExpressBusinessOperation.php
@@ -12,12 +12,12 @@ class ExpressBusinessOperation extends \Google\AdsApi\AdWords\v201601\cm\Operati
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\express\ExpressBusiness $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/express/PromotionOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/express/PromotionOperation.php
@@ -12,12 +12,12 @@ class PromotionOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\express\Promotion $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/mcm/AccountLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/mcm/AccountLabelOperation.php
@@ -12,12 +12,12 @@ class AccountLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\mcm\AccountLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/mcm/LinkOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/mcm/LinkOperation.php
@@ -12,12 +12,12 @@ class LinkOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\mcm\ManagedCustomerLink $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/mcm/ManagedCustomerLabelOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/mcm/ManagedCustomerLabelOperation.php
@@ -12,12 +12,12 @@ class ManagedCustomerLabelOperation extends \Google\AdsApi\AdWords\v201601\cm\Op
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\mcm\ManagedCustomerLabel $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/mcm/ManagedCustomerOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/mcm/ManagedCustomerOperation.php
@@ -12,12 +12,12 @@ class ManagedCustomerOperation extends \Google\AdsApi\AdWords\v201601\cm\Operati
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\mcm\ManagedCustomer $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/mcm/MoveOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/mcm/MoveOperation.php
@@ -17,13 +17,13 @@ class MoveOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\mcm\ManagedCustomerLink $operand
      * @param int $oldManagerCustomerId
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null, $oldManagerCustomerId = null)
+    public function __construct($operator = null, $operationType = null, $operand = null, $oldManagerCustomerId = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
       $this->oldManagerCustomerId = $oldManagerCustomerId;
     }

--- a/src/Google/AdsApi/AdWords/v201601/rm/MutateMembersOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/rm/MutateMembersOperation.php
@@ -12,12 +12,12 @@ class MutateMembersOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\rm\MutateMembersOperand $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 

--- a/src/Google/AdsApi/AdWords/v201601/rm/UserListOperation.php
+++ b/src/Google/AdsApi/AdWords/v201601/rm/UserListOperation.php
@@ -12,12 +12,12 @@ class UserListOperation extends \Google\AdsApi\AdWords\v201601\cm\Operation
 
     /**
      * @param string $operator
-     * @param string $OperationType
+     * @param string $operationType
      * @param \Google\AdsApi\AdWords\v201601\rm\UserList $operand
      */
-    public function __construct($operator = null, $OperationType = null, $operand = null)
+    public function __construct($operator = null, $operationType = null, $operand = null)
     {
-      parent::__construct($operator, $OperationType);
+      parent::__construct($operator, $operationType);
       $this->operand = $operand;
     }
 


### PR DESCRIPTION
`$OperationType` uses a CamelCase notation, whereas all other variables use a camelCase convention. This replaces it with `$operationType`.

Tested with `mutate()`, still works as expected.