### PR TITLE
Fix bug with fromString param and handle errors from parse ini functions

### DIFF
--- a/src/Google/AdsApi/Common/ConfigurationLoader.php
+++ b/src/Google/AdsApi/Common/ConfigurationLoader.php
@@ -44,7 +44,14 @@ class ConfigurationLoader {
       throw new InvalidArgumentException(
           'File not found: ' . $configIniFilePath);
     } else {
-      return new Configuration(parse_ini_file($configIniFilePath, true));
+      $data = parse_ini_file($configIniFilePath, true);
+
+      if (FALSE === $data) {
+        throw new InvalidArgumentException(
+            'Invalid ini config file: ' . $configIniFilePath);
+      } else {
+        return new Configuration($data);
+      }
     }
   }
 
@@ -55,7 +62,14 @@ class ConfigurationLoader {
    * @param string $iniString the string holding the contents of an *.ini file
    */
   public function fromString($iniString) {
-    return new Configuration(parse_ini_string($configIniFilePath, true));
+    $data = parse_ini_string($iniString, true);
+
+    if (FALSE === $data) {
+      throw new InvalidArgumentException(
+          'Invalid ini config string: ' . $iniString);
+    } else {
+      return new Configuration($data);
+    }
   }
 }
 

--- a/src/Google/AdsApi/Common/OAuth2TokenBuilder.php
+++ b/src/Google/AdsApi/Common/OAuth2TokenBuilder.php
@@ -50,6 +50,10 @@ class OAuth2TokenBuilder implements AdsBuilder {
     return $this->from($this->configurationLoader->fromFile($path));
   }
 
+  public function fromString($string = null) {
+	return $this->from($this->configurationLoader->fromString($string));
+  }
+
   /**
    * @see AdsBuilder::from()
    */


### PR DESCRIPTION
This PR basically is a small fix for fromString() which never process the right string (it seems a typo in the var for passing the data) and add a extra checking for files INI that could break the configuration loading throwing a exception if invalid errors were found.