### PR TITLE
Declare PHP extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
     "name": "googleads/googleads-php-lib",
     "description": "Google Ads APIs Client Library for PHP (AdWords and DFP)",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-curl": "*",
+        "ext-openssl": "*",
+        "ext-soap": "*"
     },
     "type": "library",
     "homepage": "https://github.com/googleads/googleads-php-lib",


### PR DESCRIPTION
`composer.json` should declare the PHP runtime dependencies.

This PR adds the PHP extensions listed in README.md.