### PR TITLE
Require phpdocumentor/reflection-docblock in composer.json. Fixes #168

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "monolog/monolog": "~1.17.1",
     "symfony/serializer": "~3.0.3",
     "ext-openssl": "*",
-    "ext-soap": "*"
+    "ext-soap": "*",
+    "phpdocumentor/reflection-docblock": "^3.1"
   },
   "suggest": {
     "php-64bit": ">=5.5.9"


### PR DESCRIPTION
Dependency needed for class AdWordsNormalize