### PR TITLE
Use BatchJobStatus enum constants in examples

### DIFF
--- a/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
+++ b/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
@@ -112,10 +112,9 @@ function AddCompleteCampaignUsingBatchJobExample(AdWordsUser $user) {
         $batchJob->status);
 
     $pollAttempts++;
-    if (!in_array($batchJob->status, array(
-      BatchJobStatus::ACTIVE, 
-      BatchJobStatus::AWAITING_FILE, 
-      BatchJobStatus::CANCELING))) {
+    if ($batchJob->status !== BatchJobStatus::ACTIVE &&
+        $batchJob->status !== BatchJobStatus::AWAITING_FILE &&
+        $batchJob->status !== BatchJobStatus::CANCELING) {
       $isPending = false;
     }
   } while ($isPending && $pollAttempts <= MAX_POLL_ATTEMPTS);

--- a/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
+++ b/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
@@ -112,9 +112,10 @@ function AddCompleteCampaignUsingBatchJobExample(AdWordsUser $user) {
         $batchJob->status);
 
     $pollAttempts++;
-    if ($batchJob->status !== 'ACTIVE' &&
-        $batchJob->status !== 'AWAITING_FILE' &&
-        $batchJob->status !== 'CANCELING') {
+    if (!in_array($batchJob->status, array(
+      BatchJobStatus::ACTIVE, 
+      BatchJobStatus::AWAITING_FILE, 
+      BatchJobStatus::CANCELING))) {
       $isPending = false;
     }
   } while ($isPending && $pollAttempts <= MAX_POLL_ATTEMPTS);


### PR DESCRIPTION
1) Use in_array() as elegant way to compare several status values and avoid large if conditions.
2) Use BatchJobStatus class enum constants that should be always more legit than know the final string value used.
3) Avoid to access three times to attribute object $batchJob->status in conditions (microoptimization useful for "save" some nanosec in polling).