### PR TITLE
Use BatchJobStatus enum constants in examples try2

### DIFF
--- a/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
+++ b/examples/AdWords/v201607/CampaignManagement/AddCompleteCampaignsUsingBatchJob.php
@@ -135,9 +135,9 @@ class AddCompleteCampaignsUsingBatchJob {
           $batchJob->getStatus());
 
       $pollAttempts++;
-      if ($batchJob->getStatus() !== 'ACTIVE' &&
-          $batchJob->getStatus() !== 'AWAITING_FILE' &&
-          $batchJob->getStatus() !== 'CANCELING') {
+      if ($batchJob->getStatus() !== BatchJobStatus::ACTIVE &&
+          $batchJob->getStatus() !== BatchJobStatus::AWAITING_FILE &&
+          $batchJob->getStatus() !== BatchJobStatus::CANCELING) {
         $isPending = false;
       }
     } while ($isPending && $pollAttempts <= self::MAX_POLL_ATTEMPTS);


### PR DESCRIPTION
Use BatchJobStatus class enum constants that should be always more legit than know the final string value used.