### PR TITLE
Fix undefined session error in BatchJob

### DIFF
--- a/src/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegate.php
+++ b/src/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegate.php
@@ -73,7 +73,7 @@ final class BatchJobsDelegate {
       $stack->before(
           'http_errors',
           GuzzleLogMessageHandler::log(
-              $this->session->getBatchJobsUtilLogger())
+              $session->getBatchJobsUtilLogger())
       );
       $this->httpClient = new Client(['handler' => $stack]);
     } else {


### PR DESCRIPTION
When we want use the BatchJob (in symfony) , we have the following error.

[Symfony\Component\Debug\Exception\ContextErrorException]                                        
  Notice: Undefined property: Google\AdsApi\AdWords\BatchJobs\v201609\BatchJobsDelegate::$session

This little fix, solve this error.