### PR TITLE
Amend symfony/serializer dep to include version used in symfony 2.8 LTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "guzzlehttp/psr7": "^1.2",
     "monolog/monolog": "^1.17.1",
     "phpdocumentor/reflection-docblock": "^3.0.3",
-    "symfony/serializer": "^3.0.3"
+    "symfony/serializer": "^2.8.0 || ^3.0.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
Symfony 2.8 is in LTS until 2019 ( http://symfony.com/doc/current/contributing/community/releases.html#schedule ), and projects based on it cannot use `googleads-php-lib` due to a dependency conflict.

This change permits the version included in 2.8.  Unit tests pass with this version, and they seem to rely heavily on the serializer.