### PR TITLE
Fix issue 236

### DIFF
--- a/src/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegate.php
+++ b/src/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegate.php
@@ -97,7 +97,7 @@ final class BatchJobsDelegate {
         },
         'denormalize' => function($value, $type) {
           if ($type === 'int' || $type === 'integer') {
-            return intval($value);
+            return $value + 0;
           } else if ($type === 'float' || $type === 'double') {
             return floatval($value);
           } else if ($type === 'bool' || $type === 'boolean') {

--- a/src/Google/AdsApi/AdWords/Testing/BatchJobs/v201609/BatchJobsTestProvider.php
+++ b/src/Google/AdsApi/AdWords/Testing/BatchJobs/v201609/BatchJobsTestProvider.php
@@ -100,6 +100,15 @@ class BatchJobsTestProvider {
     $mutateResult2->setResult($operand);
     $mutateResult2->setIndex(1);
 
-    return [$mutateResult1, $mutateResult2];
+    $campaign = new FakeCampaign();
+    $campaign->setId(9223372036854775900);
+    $campaign->setName('Test large ID');
+    $operand = new FakeOperand();
+    $operand->setCampaign($campaign);
+    $mutateResult3 = new FakeMutateResult();
+    $mutateResult3->setResult($operand);
+    $mutateResult3->setIndex(2);
+
+    return [$mutateResult1, $mutateResult2, $mutateResult3];
   }
 }

--- a/src/Google/AdsApi/AdWords/Testing/BatchJobs/v201609/batch-job-mutate-response.xml
+++ b/src/Google/AdsApi/AdWords/Testing/BatchJobs/v201609/batch-job-mutate-response.xml
@@ -24,4 +24,14 @@
     </result>
     <index>1</index>
   </rval>
+  <rval>
+    <result>
+      <Campaign>
+        <id>9223372036854775900</id>
+        <name>Test large ID</name>
+        <Operand.Type></Operand.Type>
+      </Campaign>
+    </result>
+    <index>2</index>
+  </rval>
 </mutateResponse>

--- a/tests/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/v201609/BatchJobsDelegateTest.php
@@ -260,6 +260,13 @@ class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
         $actualCampaign->getIsServing());
     $this->assertSame($expectedCampaign->getOperandType(),
         $actualCampaign->getOperandType());
+
+    $this->assertSame($expectedMutateResults[2]->getIndex(),
+        $actualMutateResults[2]->getIndex());
+    $expectedCampaign = $expectedMutateResults[2]->getResult()->getCampaign();
+    $actualCampaign = $actualMutateResults[2]->getResult()->getCampaign();
+    $this->assertSame($expectedCampaign->getId(), $actualCampaign->getId());
+    $this->assertSame($expectedCampaign->getName(), $actualCampaign->getName());
   }
 
   /**


### PR DESCRIPTION
Resubmit with tests

FYI, executing phpunit gave me 2 failures.

```
1) Google\AdsApi\Common\SoapLogMessageFormatterTest::testFormatDetailed
Failed asserting that two strings are identical.
...
\googleads-php-lib\tests\Google\AdsApi\Common\SoapLogMessageFormatterTest.php:128

2) Google\AdsApi\Common\SoapLogMessageFormatterTest::testFormatDetailedWithScrubbing
Failed asserting that two strings are identical.
...
\googleads-php-lib\tests\Google\AdsApi\Common\SoapLogMessageFormatterTest.php:147
```

Maybe it's ok since it looks like a Windows thing:
`#Warning: Strings contain different line endings!`