### PR TITLE
Disabling keep-alive for SOAP calls.

### DIFF
--- a/src/Google/AdsApi/Common/AdsSoapClient.php
+++ b/src/Google/AdsApi/Common/AdsSoapClient.php
@@ -61,6 +61,10 @@ class AdsSoapClient extends SoapClient {
     if (array_key_exists('classmap', $options)) {
       $this->classmap = $options['classmap'];
     }
+    // SoapClient sets keep alive header by default but does not re-use the
+    // connections. Disabling this to avoid running out of FD handles.
+    $options['keep_alive'] = false;
+
     $this->reflection = new Reflection();
     parent::__construct($wsdl, $options);
   }


### PR DESCRIPTION
PHP SoapClient creates keep-alive connections but never reuse them.
Disabling this behavior. Should resolve issues #298 and #287.