### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "require-dev": {
     "php": ">=5.5.17",
-    "phpunit/phpunit": "^4.8"
+    "phpunit/phpunit": "^4.8.35"
   },
   "suggest": {
     "php-64bit": ">=5.5.9"

--- a/tests/Google/AdsApi/AdWords/AdWordsGuzzleLogMessageFormatterProviderTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsGuzzleLogMessageFormatterProviderTest.php
@@ -21,7 +21,7 @@ use Google\AdsApi\Common\Testing\FakeHttpPayloadsAndLogsProvider;
 use Google\Auth\FetchAuthTokenInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdWordsGuzzleLogMessageFormatterProvider`.
@@ -30,14 +30,14 @@ use PHPUnit_Framework_TestCase;
  * @small
  */
 class AdWordsGuzzleLogMessageFormatterProviderTest
-    extends PHPUnit_Framework_TestCase {
+    extends TestCase {
 
   private $adWordsGuzzleLogMessageFormatter;
   private $reportDownloadResult;
   private $awql;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/AdWordsHeaderHandlerTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsHeaderHandlerTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\AdWords;
 
 use Google\Auth\FetchAuthTokenInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdWordsHeaderHandler`.
@@ -25,13 +25,13 @@ use PHPUnit_Framework_TestCase;
  * @see AdWordsHeaderHandler
  * @small
  */
-class AdWordsHeaderHandlerTest extends PHPUnit_Framework_TestCase {
+class AdWordsHeaderHandlerTest extends TestCase {
 
   private $adWordsHeaderHandler;
   private $adWordsSessionBuilder;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->adWordsHeaderHandler = new AdWordsHeaderHandler();

--- a/tests/Google/AdsApi/AdWords/AdWordsNormalizerTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsNormalizerTest.php
@@ -21,7 +21,7 @@ use Google\AdsApi\AdWords\Testing\FakeAd;
 use Google\AdsApi\AdWords\Testing\FakeBudget;
 use Google\AdsApi\AdWords\Testing\FakeMoney;
 use Google\AdsApi\AdWords\Testing\FakeMutateResult;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -32,12 +32,12 @@ use Symfony\Component\Serializer\Serializer;
  * @see AdWordsNormalizer
  * @small
  */
-class AdWordsNormalizerTest extends PHPUnit_Framework_TestCase {
+class AdWordsNormalizerTest extends TestCase {
 
   private $serializer;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->serializer = new Serializer(

--- a/tests/Google/AdsApi/AdWords/AdWordsServicesIntegrationTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsServicesIntegrationTest.php
@@ -27,7 +27,7 @@ use Google\AdsApi\Common\Util\Reflection;
 use Google\Auth\FetchAuthTokenInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Integration test for `AdWordsServices`.
@@ -39,7 +39,7 @@ use PHPUnit_Framework_TestCase;
  * @see AdWordsServices
  * @large
  */
-class AdWordsServicesIntegrationTest extends PHPUnit_Framework_TestCase {
+class AdWordsServicesIntegrationTest extends TestCase {
 
   private static $WSDL_FILE_DIR;
 
@@ -50,7 +50,7 @@ class AdWordsServicesIntegrationTest extends PHPUnit_Framework_TestCase {
   private $adWordsServices;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     self::$WSDL_FILE_DIR = __DIR__ . '/../../../../';

--- a/tests/Google/AdsApi/AdWords/AdWordsSessionBuilderTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsSessionBuilderTest.php
@@ -21,7 +21,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,13 +30,13 @@ use Psr\Log\LoggerInterface;
  * @see AdWordsSessionBuilder
  * @small
  */
-class AdWordsSessionBuilderTest extends PHPUnit_Framework_TestCase {
+class AdWordsSessionBuilderTest extends TestCase {
 
   private $adWordsSessionBuilder;
   private $fetchAuthTokenInterfaceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->adWordsSessionBuilder = new AdWordsSessionBuilder();

--- a/tests/Google/AdsApi/AdWords/AdWordsSoapLogMessageFormatterProviderTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsSoapLogMessageFormatterProviderTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\AdWords;
 
 use Google\AdsApi\Common\Testing\FakeSoapPayloadsAndLogsProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdWordsSoapLogMessageFormatterProvider`.
@@ -26,7 +26,7 @@ use PHPUnit_Framework_TestCase;
  * @small
  */
 class AdWordsSoapLogMessageFormatterProviderTest
-    extends PHPUnit_Framework_TestCase {
+    extends TestCase {
 
   private $adWordsSoapLogMessageFormatter;
   private $requestHttpHeadersMock;
@@ -34,7 +34,7 @@ class AdWordsSoapLogMessageFormatterProviderTest
   private $responseSoapXmlMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->adWordsSoapLogMessageFormatter =

--- a/tests/Google/AdsApi/AdWords/BatchJobs/BatchJobUploadStatusTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/BatchJobUploadStatusTest.php
@@ -25,7 +25,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `BatchJobUploadStatus`.
@@ -33,7 +33,7 @@ use PHPUnit_Framework_TestCase;
  * @see BatchJobUploadStatus
  * @small
  */
-class BatchJobUploadStatusTest extends PHPUnit_Framework_TestCase {
+class BatchJobUploadStatusTest extends TestCase {
 
   private static $DUMMY_UPLOAD_URL = 'https://www.googleapis.com/upload';
   private static $DUMMY_RESUMABLE_UPLOAD_URL =
@@ -43,7 +43,7 @@ class BatchJobUploadStatusTest extends PHPUnit_Framework_TestCase {
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/BatchJobs/v201702/BatchJobsDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/v201702/BatchJobsDelegateTest.php
@@ -30,7 +30,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `BatchJobsDelegate`.
@@ -38,7 +38,7 @@ use PHPUnit_Framework_TestCase;
  * @see BatchJobsDelegate
  * @small
  */
-class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
+class BatchJobsDelegateTest extends TestCase {
 
   private static $DUMMY_UPLOAD_URL = 'https://www.googleapis.com/upload';
   private static $DUMMY_RESUMABLE_UPLOAD_URL =
@@ -50,7 +50,7 @@ class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/BatchJobs/v201705/BatchJobsDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/v201705/BatchJobsDelegateTest.php
@@ -30,7 +30,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `BatchJobsDelegate`.
@@ -38,7 +38,7 @@ use PHPUnit_Framework_TestCase;
  * @see BatchJobsDelegate
  * @small
  */
-class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
+class BatchJobsDelegateTest extends TestCase {
 
   private static $DUMMY_UPLOAD_URL = 'https://www.googleapis.com/upload';
   private static $DUMMY_RESUMABLE_UPLOAD_URL =
@@ -50,7 +50,7 @@ class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/BatchJobs/v201708/BatchJobsDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/v201708/BatchJobsDelegateTest.php
@@ -30,7 +30,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `BatchJobsDelegate`.
@@ -38,7 +38,7 @@ use PHPUnit_Framework_TestCase;
  * @see BatchJobsDelegate
  * @small
  */
-class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
+class BatchJobsDelegateTest extends TestCase {
 
   private static $DUMMY_UPLOAD_URL = 'https://www.googleapis.com/upload';
   private static $DUMMY_RESUMABLE_UPLOAD_URL =
@@ -50,7 +50,7 @@ class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/BatchJobs/v201710/BatchJobsDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/BatchJobs/v201710/BatchJobsDelegateTest.php
@@ -30,7 +30,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `BatchJobsDelegate`.
@@ -38,7 +38,7 @@ use PHPUnit_Framework_TestCase;
  * @see BatchJobsDelegate
  * @small
  */
-class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
+class BatchJobsDelegateTest extends TestCase {
 
   private static $DUMMY_UPLOAD_URL = 'https://www.googleapis.com/upload';
   private static $DUMMY_RESUMABLE_UPLOAD_URL =
@@ -50,7 +50,7 @@ class BatchJobsDelegateTest extends PHPUnit_Framework_TestCase {
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/ReportDownloadResultDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/ReportDownloadResultDelegateTest.php
@@ -18,7 +18,7 @@ namespace Google\AdsApi\AdWords\Reporting;
 
 use Google\AdsApi\AdWords\Testing\Reporting\ReportDownloadResultTestProvider;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -27,13 +27,13 @@ use RuntimeException;
  * @see ReportDownloadResultDelegate
  * @small
  */
-class ReportDownloadResultDelegateTest extends PHPUnit_Framework_TestCase {
+class ReportDownloadResultDelegateTest extends TestCase {
 
   private $fakeReport;
   private $reportDownloadResultDelegate;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->fakeReport =

--- a/tests/Google/AdsApi/AdWords/Reporting/v201702/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201702/ReportDownloaderTest.php
@@ -32,7 +32,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -40,12 +40,12 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201702/RequestOptionsFactoryTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201702/RequestOptionsFactoryTest.php
@@ -28,7 +28,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use GuzzleHttp\ClientInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `RequestOptionsFactory`.
@@ -36,7 +36,7 @@ use PHPUnit_Framework_TestCase;
  * @see RequestOptionsFactory
  * @small
  */
-class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
+class RequestOptionsFactoryTest extends TestCase {
 
   private static $DEFAULT_TIMEOUT_IN_SECONDS = 120;
 
@@ -45,7 +45,7 @@ class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
   private $libraryMetadataProviderMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceMock = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201705/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201705/ReportDownloaderTest.php
@@ -32,7 +32,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -40,12 +40,12 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201705/RequestOptionsFactoryTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201705/RequestOptionsFactoryTest.php
@@ -28,7 +28,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use GuzzleHttp\ClientInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `RequestOptionsFactory`.
@@ -36,7 +36,7 @@ use PHPUnit_Framework_TestCase;
  * @see RequestOptionsFactory
  * @small
  */
-class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
+class RequestOptionsFactoryTest extends TestCase {
 
   private static $DEFAULT_TIMEOUT_IN_SECONDS = 120;
 
@@ -45,7 +45,7 @@ class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
   private $libraryMetadataProviderMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceMock = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201708/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201708/ReportDownloaderTest.php
@@ -32,7 +32,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -40,12 +40,12 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201708/RequestOptionsFactoryTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201708/RequestOptionsFactoryTest.php
@@ -28,7 +28,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use GuzzleHttp\ClientInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `RequestOptionsFactory`.
@@ -36,7 +36,7 @@ use PHPUnit_Framework_TestCase;
  * @see RequestOptionsFactory
  * @small
  */
-class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
+class RequestOptionsFactoryTest extends TestCase {
 
   private static $DEFAULT_TIMEOUT_IN_SECONDS = 120;
 
@@ -45,7 +45,7 @@ class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
   private $libraryMetadataProviderMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceMock = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201710/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201710/ReportDownloaderTest.php
@@ -32,7 +32,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -40,12 +40,12 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $adWordsSession;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/AdWords/Reporting/v201710/RequestOptionsFactoryTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/v201710/RequestOptionsFactoryTest.php
@@ -28,7 +28,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use GuzzleHttp\ClientInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `RequestOptionsFactory`.
@@ -36,7 +36,7 @@ use PHPUnit_Framework_TestCase;
  * @see RequestOptionsFactory
  * @small
  */
-class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
+class RequestOptionsFactoryTest extends TestCase {
 
   private static $DEFAULT_TIMEOUT_IN_SECONDS = 120;
 
@@ -45,7 +45,7 @@ class RequestOptionsFactoryTest extends PHPUnit_Framework_TestCase {
   private $libraryMetadataProviderMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceMock = $this

--- a/tests/Google/AdsApi/Common/AdsGuzzleHttpClientFactoryTest.php
+++ b/tests/Google/AdsApi/Common/AdsGuzzleHttpClientFactoryTest.php
@@ -21,7 +21,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdsGuzzleHttpClientFactory`.
@@ -29,7 +29,7 @@ use PHPUnit_Framework_TestCase;
  * @see AdsGuzzleHttpClientFactory
  * @small
  */
-class AdsGuzzleHttpClientFactoryTest extends PHPUnit_Framework_TestCase {
+class AdsGuzzleHttpClientFactoryTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\GuzzleHttpClientFactory::generateHttpClient

--- a/tests/Google/AdsApi/Common/AdsGuzzleProxyHttpHandlerTest.php
+++ b/tests/Google/AdsApi/Common/AdsGuzzleProxyHttpHandlerTest.php
@@ -18,7 +18,7 @@ namespace Google\AdsApi\Common;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -28,10 +28,10 @@ use Psr\Http\Message\ResponseInterface;
  * @see AdsGuzzleProxyHttpHandler
  * @small
  */
-class AdsGuzzleProxyHttpHandlerTest extends PHPUnit_Framework_TestCase {
+class AdsGuzzleProxyHttpHandlerTest extends TestCase {
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->mockRequest =

--- a/tests/Google/AdsApi/Common/AdsHeaderFormatterTest.php
+++ b/tests/Google/AdsApi/Common/AdsHeaderFormatterTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common;
 
 use Google\AdsApi\Common\Testing\ApplicationNames;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `AdsHeaderFormatter`.
@@ -25,13 +25,13 @@ use PHPUnit_Framework_TestCase;
  * @see AdsHeaderFormatter
  * @small
  */
-class AdsHeaderFormatterTest extends PHPUnit_Framework_TestCase {
+class AdsHeaderFormatterTest extends TestCase {
 
   private $applicationNames;
   private $adsHeaderFormatter;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->applicationNames = new ApplicationNames();

--- a/tests/Google/AdsApi/Common/AdsLoggerFactoryTest.php
+++ b/tests/Google/AdsApi/Common/AdsLoggerFactoryTest.php
@@ -18,7 +18,7 @@ namespace Google\AdsApi\Common;
 
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdsLoggerFactory`.
@@ -26,12 +26,12 @@ use PHPUnit_Framework_TestCase;
  * @see AdsLoggerFactory
  * @small
  */
-class AdsLoggerFactoryTest extends PHPUnit_Framework_TestCase {
+class AdsLoggerFactoryTest extends TestCase {
 
   private $adsLoggerFactory;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->adsLoggerFactory = new AdsLoggerFactory();

--- a/tests/Google/AdsApi/Common/AdsSoapClientFactoryTest.php
+++ b/tests/Google/AdsApi/Common/AdsSoapClientFactoryTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common;
 
 use Google\AdsApi\Common\Util\Reflection;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdsSoapClientFactory`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see AdsSoapClientFactory
  * @small
  */
-class AdsSoapClientFactoryTest extends PHPUnit_Framework_TestCase {
+class AdsSoapClientFactoryTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\AdsSoapClientFactory::generateSoapClient

--- a/tests/Google/AdsApi/Common/AdsUtilityRegistryTest.php
+++ b/tests/Google/AdsApi/Common/AdsUtilityRegistryTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdsUtilityRegistry`.
@@ -24,12 +24,12 @@ use PHPUnit_Framework_TestCase;
  * @see AdsUtilityRegistry
  * @small
  */
-class AdsUtilityRegistryTest extends PHPUnit_Framework_TestCase {
+class AdsUtilityRegistryTest extends TestCase {
 
   private $adsUtilityRegistry;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   public function setUp() {
     $this->adsUtilityRegistry = AdsUtilityRegistry::getInstance();

--- a/tests/Google/AdsApi/Common/ConfigurationLoaderTest.php
+++ b/tests/Google/AdsApi/Common/ConfigurationLoaderTest.php
@@ -18,7 +18,7 @@ namespace Google\AdsApi\Common;
 
 use Google\AdsApi\Common\Testing\ConfigurationLoaderTestProvider;
 use Google\AdsApi\Common\Util\EnvironmentalVariables;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ConfigurationLoader`.
@@ -26,12 +26,12 @@ use PHPUnit_Framework_TestCase;
  * @see ConfigurationLoader
  * @small
  */
-class ConfigurationLoaderTest extends PHPUnit_Framework_TestCase {
+class ConfigurationLoaderTest extends TestCase {
 
   private $configurationLoader;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $environmentalVariablesMock = $this

--- a/tests/Google/AdsApi/Common/ConfigurationTest.php
+++ b/tests/Google/AdsApi/Common/ConfigurationTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `Configuration`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see Configuration
  * @small
  */
-class ConfigurationTest extends PHPUnit_Framework_TestCase {
+class ConfigurationTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\Configuration::getConfiguration

--- a/tests/Google/AdsApi/Common/ConnectionSettingsBuilderTest.php
+++ b/tests/Google/AdsApi/Common/ConnectionSettingsBuilderTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ConnectionSettingsBuilder`.
@@ -24,12 +24,12 @@ use PHPUnit_Framework_TestCase;
  * @see ConnectionSettingsBuilder
  * @small
  */
-class ConnectionSettingsBuilderTest extends PHPUnit_Framework_TestCase {
+class ConnectionSettingsBuilderTest extends TestCase {
 
   private $connectionSettingsBuilder;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->connectionSettingsBuilder = new ConnectionSettingsBuilder();

--- a/tests/Google/AdsApi/Common/ConnectionSettingsTest.php
+++ b/tests/Google/AdsApi/Common/ConnectionSettingsTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ConnectionSettings`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see ConnectionSettings
  * @small
  */
-class ConnectionSettingsTest extends PHPUnit_Framework_TestCase {
+class ConnectionSettingsTest extends TestCase {
 
   /**
    * @param array $value the array of proxies to evaluate

--- a/tests/Google/AdsApi/Common/GuzzleLogMessageFormatterTest.php
+++ b/tests/Google/AdsApi/Common/GuzzleLogMessageFormatterTest.php
@@ -20,7 +20,7 @@ use Google\AdsApi\Common\Testing\FakeHttpPayloadsAndLogsProvider;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `GuzzleLogMessageFormatter`.
@@ -28,7 +28,7 @@ use PHPUnit_Framework_TestCase;
  * @see GuzzleLogMessageFormatter
  * @small
  */
-class GuzzleLogMessageFormatterTest extends PHPUnit_Framework_TestCase {
+class GuzzleLogMessageFormatterTest extends TestCase {
 
   private $guzzleLogMessageFormatter;
   private $reportDownloadResult;
@@ -40,7 +40,7 @@ class GuzzleLogMessageFormatterTest extends PHPUnit_Framework_TestCase {
   private $reportDownloadLogOfReportDefinition;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->reportDownloadResult = FakeHttpPayloadsAndLogsProvider

--- a/tests/Google/AdsApi/Common/OAuth2TokenBuilderTest.php
+++ b/tests/Google/AdsApi/Common/OAuth2TokenBuilderTest.php
@@ -19,7 +19,7 @@ namespace Google\AdsApi\Common;
 use Google\AdsApi\Common\Testing\AdsBuildersTestProvider;
 use Google\Auth\Credentials\ServiceAccountCredentials;
 use Google\Auth\Credentials\UserRefreshCredentials;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `OAuth2TokenBuilder`.
@@ -27,13 +27,13 @@ use PHPUnit_Framework_TestCase;
  * @see OAuth2TokenBuilder
  * @small
  */
-class OAuth2TokenBuilderTest extends PHPUnit_Framework_TestCase {
+class OAuth2TokenBuilderTest extends TestCase {
 
   private $oAuth2TokenBuilder;
   private $jsonKeyFilePath;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->oAuth2TokenBuilder = new OAuth2TokenBuilder();

--- a/tests/Google/AdsApi/Common/SoapLogMessageFormatterTest.php
+++ b/tests/Google/AdsApi/Common/SoapLogMessageFormatterTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common;
 
 use Google\AdsApi\Common\Testing\FakeSoapPayloadsAndLogsProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use SoapFault;
 
 /**
@@ -26,7 +26,7 @@ use SoapFault;
  * @see SoapLogMessageFormatter
  * @small
  */
-class SoapLogMessageFormatterTest extends PHPUnit_Framework_TestCase {
+class SoapLogMessageFormatterTest extends TestCase {
 
   private $soapLogMessageFormatter;
   private $requestHttpHeadersMock;
@@ -39,7 +39,7 @@ class SoapLogMessageFormatterTest extends PHPUnit_Framework_TestCase {
   private $mutateResponseSoapXmlMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->soapLogMessageFormatter = new SoapLogMessageFormatter();

--- a/tests/Google/AdsApi/Common/SoapSettingsBuilderTest.php
+++ b/tests/Google/AdsApi/Common/SoapSettingsBuilderTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common;
 
 use Google\AdsApi\Common\Testing\AdsBuildersTestProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `SoapSettingsBuilder`.
@@ -25,12 +25,12 @@ use PHPUnit_Framework_TestCase;
  * @see SoapSettingsBuilder
  * @small
  */
-class SoapSettingsBuilderTest extends PHPUnit_Framework_TestCase {
+class SoapSettingsBuilderTest extends TestCase {
 
   private $soapSettingsBuilder;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->soapSettingsBuilder = new SoapSettingsBuilder();

--- a/tests/Google/AdsApi/Common/Util/EnvironmentalVariablesTest.php
+++ b/tests/Google/AdsApi/Common/Util/EnvironmentalVariablesTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common\Util;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `EnvironmentalVariables`.
@@ -24,12 +24,12 @@ use PHPUnit_Framework_TestCase;
  * @see EnvironmentalVariables
  * @small
  */
-class EnvironmentalVariablesTest extends PHPUnit_Framework_TestCase {
+class EnvironmentalVariablesTest extends TestCase {
 
   private $environmentalVariables;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->environmentalVariables = new EnvironmentalVariables();

--- a/tests/Google/AdsApi/Common/Util/LogMessageScrubbersTest.php
+++ b/tests/Google/AdsApi/Common/Util/LogMessageScrubbersTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common\Util;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `LogMessageScrubbers`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see LogMessageScrubbers
  * @small
  */
-class LogMessageScrubbersTest extends PHPUnit_Framework_TestCase {
+class LogMessageScrubbersTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\Util\LogMessageScrubbers::scrubRequestHttpHeaders

--- a/tests/Google/AdsApi/Common/Util/MapEntriesTest.php
+++ b/tests/Google/AdsApi/Common/Util/MapEntriesTest.php
@@ -18,7 +18,7 @@ namespace Google\AdsApi\Common\Util;
 
 use Google\AdsApi\Common\Testing\FakeInvalidMapEntry;
 use Google\AdsApi\Common\Testing\FakeMapEntry;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `MapEntries`.
@@ -26,7 +26,7 @@ use PHPUnit_Framework_TestCase;
  * @see MapEntries
  * @small
  */
-class MapEntriesTest extends PHPUnit_Framework_TestCase {
+class MapEntriesTest extends TestCase {
 
   /**
    * @param array $mapEntries a list of map entries

--- a/tests/Google/AdsApi/Common/Util/OAuth2TokenRefresherTest.php
+++ b/tests/Google/AdsApi/Common/Util/OAuth2TokenRefresherTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common\Util;
 
 use Google\Auth\FetchAuthTokenInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `OAuth2TokenRefresher`.
@@ -25,13 +25,13 @@ use PHPUnit_Framework_TestCase;
  * @see OAuth2TokenRefresher
  * @small
  */
-class OAuth2TokenRefresherTest extends PHPUnit_Framework_TestCase {
+class OAuth2TokenRefresherTest extends TestCase {
 
   private $fetchAuthTokenInterfaceMock;
   private $oAuth2TokenRefresher;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->fetchAuthTokenInterfaceMock = $this

--- a/tests/Google/AdsApi/Common/Util/SoapHeadersTest.php
+++ b/tests/Google/AdsApi/Common/Util/SoapHeadersTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common\Util;
 
 use Google\AdsApi\Common\Testing\FakeSoapPayloadsAndLogsProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `SoapHeaders`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see SoapHeaders
  * @small
  */
-class SoapHeadersTest extends PHPUnit_Framework_TestCase {
+class SoapHeadersTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\Util\SoapHeaders::getSoapHeaderValue

--- a/tests/Google/AdsApi/Common/Util/SoapRequestsTest.php
+++ b/tests/Google/AdsApi/Common/Util/SoapRequestsTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common\Util;
 
 use Google\AdsApi\Common\Testing\FakeSoapPayloadsAndLogsProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `SoapRequests`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see SoapRequests
  * @small
  */
-class SoapRequestsTest extends PHPUnit_Framework_TestCase {
+class SoapRequestsTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\Util\SoapRequests::replaceReferences

--- a/tests/Google/AdsApi/Dfp/DfpHeaderHandlerTest.php
+++ b/tests/Google/AdsApi/Dfp/DfpHeaderHandlerTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp;
 
 use Google\Auth\FetchAuthTokenInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpHeaderHandler`.
@@ -25,13 +25,13 @@ use PHPUnit_Framework_TestCase;
  * @see DfpHeaderHandler
  * @small
  */
-class DfpHeaderHandlerTest extends PHPUnit_Framework_TestCase {
+class DfpHeaderHandlerTest extends TestCase {
 
   private $dfpHeaderHandler;
   private $dfpSessionBuilder;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->dfpHeaderHandler = new DfpHeaderHandler();

--- a/tests/Google/AdsApi/Dfp/DfpSessionBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/DfpSessionBuilderTest.php
@@ -21,7 +21,7 @@ use Google\Auth\FetchAuthTokenInterface;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,13 +30,13 @@ use Psr\Log\LoggerInterface;
  * @see DfpSessionBuilder
  * @small
  */
-class DfpSessionBuilderTest extends PHPUnit_Framework_TestCase {
+class DfpSessionBuilderTest extends TestCase {
 
   private $dfpSessionBuilder;
   private $fetchAuthTokenInterfaceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->dfpSessionBuilder = new DfpSessionBuilder();

--- a/tests/Google/AdsApi/Dfp/DfpSoapLogMessageFormatterProviderTest.php
+++ b/tests/Google/AdsApi/Dfp/DfpSoapLogMessageFormatterProviderTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp;
 
 use Google\AdsApi\Common\Testing\FakeSoapPayloadsAndLogsProvider;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpSoapLogMessageFormatterProvider`.
@@ -26,7 +26,7 @@ use PHPUnit_Framework_TestCase;
  * @small
  */
 class DfpSoapLogMessageFormatterProviderTest
-    extends PHPUnit_Framework_TestCase {
+    extends TestCase {
 
   private $dfpSoapLogMessageFormatter;
   private $requestHttpHeadersMock;
@@ -34,7 +34,7 @@ class DfpSoapLogMessageFormatterProviderTest
   private $responseSoapXmlMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->dfpSoapLogMessageFormatter =

--- a/tests/Google/AdsApi/Dfp/Util/v201702/DfpDateTimesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201702/DfpDateTimesTest.php
@@ -20,7 +20,7 @@ use DateTime;
 use DateTimeZone;
 use Google\AdsApi\Dfp\v201702\Date;
 use Google\AdsApi\Dfp\v201702\DateTime as DfpDateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDateTimes`.
@@ -28,7 +28,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDateTimes
  * @small
  */
-class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
+class DfpDateTimesTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'America/New_York';
   const TIME_ZONE_ID2 = 'PST8PDT';
@@ -50,7 +50,7 @@ class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
   private $stringDateTimeWithTimeZone3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDateTime1 = '1983-06-02T08:30:15';

--- a/tests/Google/AdsApi/Dfp/Util/v201702/DfpDatesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201702/DfpDatesTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp\Util\v201702;
 
 use Google\AdsApi\Dfp\v201702\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDates`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDates
  * @group small
  */
-class DfpDatesTest extends PHPUnit_Framework_TestCase {
+class DfpDatesTest extends TestCase {
 
   private $dfpDate1;
   private $dfpDate2;
@@ -36,7 +36,7 @@ class DfpDatesTest extends PHPUnit_Framework_TestCase {
   private $stringDate3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDate1 = '1983-06-02';

--- a/tests/Google/AdsApi/Dfp/Util/v201702/PqlTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201702/PqlTest.php
@@ -32,7 +32,7 @@ use Google\AdsApi\Dfp\v201702\Targeting;
 use Google\AdsApi\Dfp\v201702\TargetingValue;
 use Google\AdsApi\Dfp\v201702\TextValue;
 use Google\AdsApi\Dfp\v201702\Value;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `Pql`.
@@ -40,7 +40,7 @@ use PHPUnit_Framework_TestCase;
  * @see Pql
  * @small
  */
-class PqlTest extends PHPUnit_Framework_TestCase {
+class PqlTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'Asia/Shanghai';
 
@@ -68,7 +68,7 @@ class PqlTest extends PHPUnit_Framework_TestCase {
   private $targeting1;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->column1 = new ColumnType('Id');

--- a/tests/Google/AdsApi/Dfp/Util/v201702/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201702/ReportDownloaderTest.php
@@ -28,7 +28,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -36,13 +36,13 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $dfpSession;
   private $reportServiceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/Dfp/Util/v201702/StatementBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201702/StatementBuilderTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Dfp\Util\v201702;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `StatementBuilder`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see StatementBuilder
  * @small
  */
-class StatementBuilderTest extends PHPUnit_Framework_TestCase {
+class StatementBuilderTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Dfp\Util\v201702\StatementBuilder::toStatement

--- a/tests/Google/AdsApi/Dfp/Util/v201705/DfpDateTimesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201705/DfpDateTimesTest.php
@@ -20,7 +20,7 @@ use DateTime;
 use DateTimeZone;
 use Google\AdsApi\Dfp\v201705\Date;
 use Google\AdsApi\Dfp\v201705\DateTime as DfpDateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDateTimes`.
@@ -28,7 +28,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDateTimes
  * @small
  */
-class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
+class DfpDateTimesTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'America/New_York';
   const TIME_ZONE_ID2 = 'PST8PDT';
@@ -50,7 +50,7 @@ class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
   private $stringDateTimeWithTimeZone3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDateTime1 = '1983-06-02T08:30:15';

--- a/tests/Google/AdsApi/Dfp/Util/v201705/DfpDatesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201705/DfpDatesTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp\Util\v201705;
 
 use Google\AdsApi\Dfp\v201705\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDates`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDates
  * @group small
  */
-class DfpDatesTest extends PHPUnit_Framework_TestCase {
+class DfpDatesTest extends TestCase {
 
   private $dfpDate1;
   private $dfpDate2;
@@ -36,7 +36,7 @@ class DfpDatesTest extends PHPUnit_Framework_TestCase {
   private $stringDate3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDate1 = '1983-06-02';

--- a/tests/Google/AdsApi/Dfp/Util/v201705/PqlTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201705/PqlTest.php
@@ -32,7 +32,7 @@ use Google\AdsApi\Dfp\v201705\Targeting;
 use Google\AdsApi\Dfp\v201705\TargetingValue;
 use Google\AdsApi\Dfp\v201705\TextValue;
 use Google\AdsApi\Dfp\v201705\Value;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `Pql`.
@@ -40,7 +40,7 @@ use PHPUnit_Framework_TestCase;
  * @see Pql
  * @small
  */
-class PqlTest extends PHPUnit_Framework_TestCase {
+class PqlTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'Asia/Shanghai';
 
@@ -68,7 +68,7 @@ class PqlTest extends PHPUnit_Framework_TestCase {
   private $targeting1;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->column1 = new ColumnType('Id');

--- a/tests/Google/AdsApi/Dfp/Util/v201705/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201705/ReportDownloaderTest.php
@@ -28,7 +28,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -36,13 +36,13 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $dfpSession;
   private $reportServiceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/Dfp/Util/v201705/StatementBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201705/StatementBuilderTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Dfp\Util\v201705;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `StatementBuilder`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see StatementBuilder
  * @small
  */
-class StatementBuilderTest extends PHPUnit_Framework_TestCase {
+class StatementBuilderTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Dfp\Util\v201705\StatementBuilder::toStatement

--- a/tests/Google/AdsApi/Dfp/Util/v201708/DfpDateTimesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201708/DfpDateTimesTest.php
@@ -20,7 +20,7 @@ use DateTime;
 use DateTimeZone;
 use Google\AdsApi\Dfp\v201708\Date;
 use Google\AdsApi\Dfp\v201708\DateTime as DfpDateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDateTimes`.
@@ -28,7 +28,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDateTimes
  * @small
  */
-class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
+class DfpDateTimesTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'America/New_York';
   const TIME_ZONE_ID2 = 'PST8PDT';
@@ -50,7 +50,7 @@ class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
   private $stringDateTimeWithTimeZone3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDateTime1 = '1983-06-02T08:30:15';

--- a/tests/Google/AdsApi/Dfp/Util/v201708/DfpDatesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201708/DfpDatesTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp\Util\v201708;
 
 use Google\AdsApi\Dfp\v201708\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDates`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDates
  * @group small
  */
-class DfpDatesTest extends PHPUnit_Framework_TestCase {
+class DfpDatesTest extends TestCase {
 
   private $dfpDate1;
   private $dfpDate2;
@@ -36,7 +36,7 @@ class DfpDatesTest extends PHPUnit_Framework_TestCase {
   private $stringDate3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDate1 = '1983-06-02';

--- a/tests/Google/AdsApi/Dfp/Util/v201708/PqlTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201708/PqlTest.php
@@ -32,7 +32,7 @@ use Google\AdsApi\Dfp\v201708\Targeting;
 use Google\AdsApi\Dfp\v201708\TargetingValue;
 use Google\AdsApi\Dfp\v201708\TextValue;
 use Google\AdsApi\Dfp\v201708\Value;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `Pql`.
@@ -40,7 +40,7 @@ use PHPUnit_Framework_TestCase;
  * @see Pql
  * @small
  */
-class PqlTest extends PHPUnit_Framework_TestCase {
+class PqlTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'Asia/Shanghai';
 
@@ -68,7 +68,7 @@ class PqlTest extends PHPUnit_Framework_TestCase {
   private $targeting1;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->column1 = new ColumnType('Id');

--- a/tests/Google/AdsApi/Dfp/Util/v201708/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201708/ReportDownloaderTest.php
@@ -28,7 +28,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -36,13 +36,13 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $dfpSession;
   private $reportServiceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/Dfp/Util/v201708/StatementBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201708/StatementBuilderTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Dfp\Util\v201708;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `StatementBuilder`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see StatementBuilder
  * @small
  */
-class StatementBuilderTest extends PHPUnit_Framework_TestCase {
+class StatementBuilderTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Dfp\Util\v201708\StatementBuilder::toStatement

--- a/tests/Google/AdsApi/Dfp/Util/v201711/DfpDateTimesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/DfpDateTimesTest.php
@@ -20,7 +20,7 @@ use DateTime;
 use DateTimeZone;
 use Google\AdsApi\Dfp\v201711\Date;
 use Google\AdsApi\Dfp\v201711\DateTime as DfpDateTime;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDateTimes`.
@@ -28,7 +28,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDateTimes
  * @small
  */
-class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
+class DfpDateTimesTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'America/New_York';
   const TIME_ZONE_ID2 = 'PST8PDT';
@@ -50,7 +50,7 @@ class DfpDateTimesTest extends PHPUnit_Framework_TestCase {
   private $stringDateTimeWithTimeZone3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDateTime1 = '1983-06-02T08:30:15';

--- a/tests/Google/AdsApi/Dfp/Util/v201711/DfpDatesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/DfpDatesTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Dfp\Util\v201711;
 
 use Google\AdsApi\Dfp\v201711\Date;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `DfpDates`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see DfpDates
  * @group small
  */
-class DfpDatesTest extends PHPUnit_Framework_TestCase {
+class DfpDatesTest extends TestCase {
 
   private $dfpDate1;
   private $dfpDate2;
@@ -36,7 +36,7 @@ class DfpDatesTest extends PHPUnit_Framework_TestCase {
   private $stringDate3;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->stringDate1 = '1983-06-02';

--- a/tests/Google/AdsApi/Dfp/Util/v201711/PqlTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/PqlTest.php
@@ -32,7 +32,7 @@ use Google\AdsApi\Dfp\v201711\Targeting;
 use Google\AdsApi\Dfp\v201711\TargetingValue;
 use Google\AdsApi\Dfp\v201711\TextValue;
 use Google\AdsApi\Dfp\v201711\Value;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `Pql`.
@@ -40,7 +40,7 @@ use PHPUnit_Framework_TestCase;
  * @see Pql
  * @small
  */
-class PqlTest extends PHPUnit_Framework_TestCase {
+class PqlTest extends TestCase {
 
   const TIME_ZONE_ID1 = 'Asia/Shanghai';
 
@@ -68,7 +68,7 @@ class PqlTest extends PHPUnit_Framework_TestCase {
   private $targeting1;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $this->column1 = new ColumnType('Id');

--- a/tests/Google/AdsApi/Dfp/Util/v201711/ReportDownloaderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/ReportDownloaderTest.php
@@ -28,7 +28,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportDownloader`.
@@ -36,13 +36,13 @@ use PHPUnit_Framework_TestCase;
  * @see ReportDownloader
  * @small
  */
-class ReportDownloaderTest extends PHPUnit_Framework_TestCase {
+class ReportDownloaderTest extends TestCase {
 
   private $dfpSession;
   private $reportServiceMock;
 
   /**
-   * @see PHPUnit_Framework_TestCase::setUp
+   * @see PHPUnit\Framework\TestCase::setUp
    */
   protected function setUp() {
     $fetchAuthTokenInterfaceStub = $this

--- a/tests/Google/AdsApi/Dfp/Util/v201711/StatementBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/StatementBuilderTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Dfp\Util\v201711;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for `StatementBuilder`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see StatementBuilder
  * @small
  */
-class StatementBuilderTest extends PHPUnit_Framework_TestCase {
+class StatementBuilderTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Dfp\Util\v201711\StatementBuilder::toStatement


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.