### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Google/AdsApi/AdWords/AdWordsServicesIntegrationTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsServicesIntegrationTest.php
@@ -124,7 +124,7 @@ class AdWordsServicesIntegrationTest extends TestCase {
     // Check that the campaign service (which is a SOAP client) has deserialized
     // the SOAP XML response to the Campaign object correctly.
     $actualCampaigns = $page->getEntries();
-    $this->assertSame(count($expectedCampaigns), count($actualCampaigns));
+    $this->assertCount(count($expectedCampaigns), $actualCampaigns);
 
     for ($i = 0; $i < count($actualCampaigns); $i++) {
       $expectedCampaign = $expectedCampaigns[$i];

--- a/tests/Google/AdsApi/AdWords/AdWordsSessionBuilderTest.php
+++ b/tests/Google/AdsApi/AdWords/AdWordsSessionBuilderTest.php
@@ -122,8 +122,8 @@ class AdWordsSessionBuilderTest extends TestCase {
     $this->assertSame(
         'ABcdeFGH93KL-NOPQ_STUv', $adWordsSession->getDeveloperToken());
     $this->assertSame('report downloader', $adWordsSession->getUserAgent());
-    $this->assertTrue(filter_var(
-        $adWordsSession->getEndpoint(), FILTER_VALIDATE_URL) !== false);
+    $this->assertNotFalse(filter_var(
+        $adWordsSession->getEndpoint(), FILTER_VALIDATE_URL));
     $this->assertNull($adWordsSession->getClientCustomerId());
     $this->assertNotNull($adWordsSession->isPartialFailure());
     $this->assertNotNull($adWordsSession->isIncludeUtilitiesInUserAgent());
@@ -268,8 +268,8 @@ class AdWordsSessionBuilderTest extends TestCase {
         $adWordsSession->getOAuth2Credential());
     $this->assertInstanceOf(
         LoggerInterface::class, $adWordsSession->getSoapLogger());
-    $this->assertTrue(filter_var(
-        $adWordsSession->getEndpoint(), FILTER_VALIDATE_URL) !== false);
+    $this->assertNotFalse(filter_var(
+        $adWordsSession->getEndpoint(), FILTER_VALIDATE_URL));
     $this->assertNull($adWordsSession->getClientCustomerId());
     $this->assertNotNull($adWordsSession->isPartialFailure());
     $this->assertNotNull($adWordsSession->isIncludeUtilitiesInUserAgent());

--- a/tests/Google/AdsApi/AdWords/ReportSettingsBuilderTest.php
+++ b/tests/Google/AdsApi/AdWords/ReportSettingsBuilderTest.php
@@ -17,7 +17,7 @@
 namespace Google\AdsApi\Common;
 
 use Google\AdsApi\AdWords\ReportSettingsBuilder;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `ReportSettingsBuilder`.
@@ -25,7 +25,7 @@ use PHPUnit_Framework_TestCase;
  * @see ReportSettingsBuilder
  * @small
  */
-class ReportSettingsBuilderTest extends PHPUnit_Framework_TestCase {
+class ReportSettingsBuilderTest extends TestCase {
 
   private $reportSettingsBuilder;
 

--- a/tests/Google/AdsApi/AdWords/Reporting/ReportDownloadResultDelegateTest.php
+++ b/tests/Google/AdsApi/AdWords/Reporting/ReportDownloadResultDelegateTest.php
@@ -82,7 +82,7 @@ class ReportDownloadResultDelegateTest extends TestCase {
         tempnam(sys_get_temp_dir(), 'criteria-report-')
     );
     $this->reportDownloadResultDelegate->saveToFile($filePath);
-    $this->assertSame($this->fakeReport, file_get_contents($filePath));
+    $this->assertStringEqualsFile($filePath, $this->fakeReport);
   }
 
   /**

--- a/tests/Google/AdsApi/Common/AdsSoapClientTest.php
+++ b/tests/Google/AdsApi/Common/AdsSoapClientTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `AdsSoapClient`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see AdsSoapClient
  * @small
  */
-class AdsSoapClientTest extends PHPUnit_Framework_TestCase {
+class AdsSoapClientTest extends TestCase {
 
   /**
    * @covers Google\AdsApi\Common\AdsSoapClient::getLocalWsdlPath

--- a/tests/Google/AdsApi/Common/SuppressTriggerErrorTestCase.php
+++ b/tests/Google/AdsApi/Common/SuppressTriggerErrorTestCase.php
@@ -16,12 +16,12 @@
  */
 namespace Google\AdsApi\Common;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * A test case that needs suppression of trigger_error().
  */
-class SuppressTriggerErrorTestCase extends PHPUnit_Framework_TestCase {
+class SuppressTriggerErrorTestCase extends TestCase {
 
   /**
    * @see PHPUnit_Framework_TestCase::setUp

--- a/tests/Google/AdsApi/Common/Util/MapEntriesTest.php
+++ b/tests/Google/AdsApi/Common/Util/MapEntriesTest.php
@@ -60,7 +60,7 @@ class MapEntriesTest extends TestCase {
       array $expectedMapEntries, array $map) {
     $actualMapEntries =
         MapEntries::fromAssociativeArray($map, FakeMapEntry::class);
-    $this->assertSame(count($expectedMapEntries), count($actualMapEntries));
+    $this->assertCount(count($expectedMapEntries), $actualMapEntries);
 
     foreach ($actualMapEntries as $i => $actualMapEntry) {
       $this->assertSame(

--- a/tests/Google/AdsApi/Dfp/DfpSessionBuilderTest.php
+++ b/tests/Google/AdsApi/Dfp/DfpSessionBuilderTest.php
@@ -102,8 +102,8 @@ class DfpSessionBuilderTest extends TestCase {
     $this->assertSame('12345678', $dfpSession->getNetworkCode());
     $this->assertSame(
         'google report runner', $dfpSession->getApplicationName());
-    $this->assertTrue(
-        filter_var($dfpSession->getEndpoint(), FILTER_VALIDATE_URL) !== false);
+    $this->assertNotFalse(
+        filter_var($dfpSession->getEndpoint(), FILTER_VALIDATE_URL));
     $this->assertNotNull($dfpSession->getSoapSettings());
   }
 
@@ -224,8 +224,8 @@ class DfpSessionBuilderTest extends TestCase {
     $this->assertSame('12345678', $dfpSession->getNetworkCode());
     $this->assertSame(
         'Google report runner', $dfpSession->getApplicationName());
-    $this->assertTrue(
-        filter_var($dfpSession->getEndpoint(), FILTER_VALIDATE_URL) !== false);
+    $this->assertNotFalse(
+        filter_var($dfpSession->getEndpoint(), FILTER_VALIDATE_URL));
     $this->assertInstanceOf(FetchAuthTokenInterface::class,
         $dfpSession->getOAuth2Credential());
     $this->assertNotNull($dfpSession->getSoapSettings());

--- a/tests/Google/AdsApi/Dfp/Util/v201711/CsvFilesTest.php
+++ b/tests/Google/AdsApi/Dfp/Util/v201711/CsvFilesTest.php
@@ -16,7 +16,7 @@
  */
 namespace Google\AdsApi\Dfp\Util\v201711;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for `CsvFiles`.
@@ -24,7 +24,7 @@ use PHPUnit_Framework_TestCase;
  * @see CsvFiles
  * @group small
  */
-class CsvFilesTest extends PHPUnit_Framework_TestCase {
+class CsvFilesTest extends TestCase {
 
   const IN_MEMORY_FILE_PATH = 'php://temp/maxmemory:1024';
   private $resultSet;
@@ -86,12 +86,12 @@ class CsvFilesTest extends PHPUnit_Framework_TestCase {
 
     // Verify that the data is consistent after writing and reading CSV.
     $expectedRowCount = count($this->resultSet);
-    $this->assertEquals($expectedRowCount, count($actualData));
+    $this->assertCount($expectedRowCount, $actualData);
     for ($i = 0; $i < $expectedRowCount; $i++) {
       $expectedRow = $this->resultSet[$i];
       $actualRow = $actualData[$i];
       $expectedFieldCount = count($expectedRow);
-      $this->assertEquals($expectedFieldCount, count($actualRow));
+      $this->assertCount($expectedFieldCount, $actualRow);
       for ($j = 0; $j < $expectedFieldCount; $j++) {
         $this->assertEquals($expectedRow[$j], $actualRow[$j],
             sprintf("Mismatch found at row %d, col %d\n", $i, $j));


### PR DESCRIPTION
I've refactored some tests, using:
- `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase` (see #396);
- `assertCount` instead of `count` function;
- `assertNotFalse` instead of strict comparison `!==` with `false` keyword;
- `assertStringEqualsFile` instead of `file_get_contents` function.