### PR TITLE
ProductPartitions::showAdGroupTree() - Check if child index was already exists

### DIFF
--- a/src/Google/AdsApi/AdWords/Shopping/v201702/ProductPartitions.php
+++ b/src/Google/AdsApi/AdWords/Shopping/v201702/ProductPartitions.php
@@ -241,7 +241,9 @@ final class ProductPartitions {
       if ($page->getEntries() !== null) {
         $totalNumEntries = $page->getTotalNumEntries();
         foreach ($page->getEntries() as $adGroupCriterion) {
-          $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          if (!array_key_exists($adGroupCriterion->getCriterion()->getId(), $children)) {
+            $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          }
 
           if ($adGroupCriterion->getCriterion()->getParentCriterionId()
               !== null) {

--- a/src/Google/AdsApi/AdWords/Shopping/v201705/ProductPartitions.php
+++ b/src/Google/AdsApi/AdWords/Shopping/v201705/ProductPartitions.php
@@ -241,7 +241,9 @@ final class ProductPartitions {
       if ($page->getEntries() !== null) {
         $totalNumEntries = $page->getTotalNumEntries();
         foreach ($page->getEntries() as $adGroupCriterion) {
-          $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          if (!array_key_exists($adGroupCriterion->getCriterion()->getId(), $children)) {
+            $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          }
 
           if ($adGroupCriterion->getCriterion()->getParentCriterionId()
               !== null) {

--- a/src/Google/AdsApi/AdWords/Shopping/v201708/ProductPartitions.php
+++ b/src/Google/AdsApi/AdWords/Shopping/v201708/ProductPartitions.php
@@ -241,7 +241,9 @@ final class ProductPartitions {
       if ($page->getEntries() !== null) {
         $totalNumEntries = $page->getTotalNumEntries();
         foreach ($page->getEntries() as $adGroupCriterion) {
-          $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          if (!array_key_exists($adGroupCriterion->getCriterion()->getId(), $children)) {
+            $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          }
 
           if ($adGroupCriterion->getCriterion()->getParentCriterionId()
               !== null) {

--- a/src/Google/AdsApi/AdWords/Shopping/v201710/ProductPartitions.php
+++ b/src/Google/AdsApi/AdWords/Shopping/v201710/ProductPartitions.php
@@ -241,7 +241,9 @@ final class ProductPartitions {
       if ($page->getEntries() !== null) {
         $totalNumEntries = $page->getTotalNumEntries();
         foreach ($page->getEntries() as $adGroupCriterion) {
-          $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          if (!array_key_exists($adGroupCriterion->getCriterion()->getId(), $children)) {
+            $children[$adGroupCriterion->getCriterion()->getId()] = [];
+          }
 
           if ($adGroupCriterion->getCriterion()->getParentCriterionId()
               !== null) {


### PR DESCRIPTION
In the ProductPartitions class, the $children array indexes in showAdGroupTree() are being overridden with a new empty array in the loop, ~line 244.