### PR TITLE
Removed support for Symfony 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "guzzlehttp/psr7": "^1.2",
     "monolog/monolog": "^1.17.1 || ^2.0.0",
     "phpdocumentor/reflection-docblock": "^4.0.0 || ^3.0.3",
-    "symfony/serializer": "^2.8.0 || ^3.0.3 || ^4.0.0"
+    "symfony/serializer": "^4.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5",


### PR DESCRIPTION
Those two versions require old PHP versions that we don't support anymore:

This is to avoid the following security risks from symfony/http-foundation that versions 2 and 3 and some of 4 rely on:
* https://github.com/advisories/GHSA-xhh6-956q-4q69
* https://github.com/advisories/GHSA-x92h-wmg2-6hp7