### PR TITLE
fix bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "ext-openssl": "*",
     "ext-soap": "*",
     "google/auth": "^1.0.0",
-    "guzzlehttp/guzzle": "^6.0",
+    "guzzlehttp/guzzle": "^7.0.1",
     "guzzlehttp/psr7": "^1.2",
     "monolog/monolog": "^1.17.1 || ^2.0.0",
     "phpdocumentor/reflection-docblock": "^3.0.3 || ^4.0 || ^5.0",


### PR DESCRIPTION
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: guzzlehttp/guzzle[7.0.1, 6.5.x-dev].
    - Can only install one of: guzzlehttp/guzzle[6.5.x-dev, 7.0.1].
    - Can only install one of: guzzlehttp/guzzle[6.5.x-dev, 7.0.1].
    - googleads/googleads-php-lib 48.0.0 requires guzzlehttp/guzzle ^6.0 -> satisfiable by guzzlehttp/guzzle[6.5.x-dev].
    - Installation request for googleads/googleads-php-lib ^48.0 -> satisfiable by googleads/googleads-php-lib[48.0.0].
    - Installation request for guzzlehttp/guzzle 7.0.1 -> satisfiable by guzzlehttp/guzzle[7.0.1].


Installation failed, reverting ./composer.json to its original content.