### PR TITLE
Fix date range value notation

### DIFF
--- a/examples/AdWords/v201809/AccountManagement/GetAccountChanges.php
+++ b/examples/AdWords/v201809/AccountManagement/GetAccountChanges.php
@@ -74,8 +74,8 @@ class GetAccountChanges
 
         // Set the date time range, from 24 hours ago until now.
         $dateTimeRange = new DateTimeRange();
-        $dateTimeRange->setMin(date('Ymd his', strtotime('-1 day')));
-        $dateTimeRange->setMax(date('Ymd his'));
+        $dateTimeRange->setMin(date('Ymd His T', strtotime('-1 day')));
+        $dateTimeRange->setMax(date('Ymd His T'));
 
         // Create selector.
         $selector = new CustomerSyncSelector();


### PR DESCRIPTION
This now uses 24h (instead of 12h) and specifies the timezone.