### PR TITLE
Bring back Symfony 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "guzzlehttp/psr7": "^1.2",
     "monolog/monolog": "^1.17.1 || ^2.0.0",
     "phpdocumentor/reflection-docblock": "^3.0.3 || ^4.0 || ^5.0",
-    "symfony/serializer": "^4.4.0 || ^5.0.0"
+    "symfony/serializer": "^3.0.3 || ^4.4.0 || ^5.0.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.5",


### PR DESCRIPTION
`Symfony 3` is a LTS, and has security fixes scheduled till November 2021: https://symfony.com/releases.
This partially reverts https://github.com/googleads/googleads-php-lib/pull/632.