### PR TITLE
Adding Guzzle 6 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "ext-openssl": "*",
     "ext-soap": "*",
     "google/auth": "^1.0.0",
-    "guzzlehttp/guzzle": "^7.0",
+    "guzzlehttp/guzzle": "^6.0 || ^7.0",
     "guzzlehttp/psr7": "^1.2",
     "monolog/monolog": "^2.2.0",
     "phpdocumentor/reflection-docblock": "^3.0.3 || ^4.0 || ^5.0",

--- a/src/Google/AdsApi/Common/AdsHeaderFormatter.php
+++ b/src/Google/AdsApi/Common/AdsHeaderFormatter.php
@@ -118,7 +118,8 @@ final class AdsHeaderFormatter
 
     private function formatGuzzleInfo()
     {
-        $guzzleInfoTokens = ['GuzzleHttp/' . ClientInterface::MAJOR_VERSION];
+        $guzzleVersion = defined('GuzzleHttp\ClientInterface::MAJOR_VERSION') ? ClientInterface::MAJOR_VERSION : ClientInterface::VERSION;
+        $guzzleInfoTokens = ['GuzzleHttp/' . $guzzleVersion];
         if (extension_loaded('curl') && function_exists('curl_version')) {
             $guzzleInfoTokens[] = 'curl/' . \curl_version()['version'];
         }


### PR DESCRIPTION
Hi,

I think there are people that are still using Guzzle 6 internally as it is not yet EOL and still open to security fixes:

Version | Status | Packagist | Namespace | Repo | Docs | PSR-7 | PHP Version
-- | -- | -- | -- | -- | -- | -- | --
3.x | EOL | guzzle/guzzle | Guzzle | v3 | v3 | No | &gt;= 5.3.3
4.x | EOL | guzzlehttp/guzzle | GuzzleHttp | v4 | N/A | No | &gt;= 5.4
5.x | EOL | guzzlehttp/guzzle | GuzzleHttp | v5 | v5 | No | &gt;= 5.4
6.x | Security fixes | guzzlehttp/guzzle | GuzzleHttp | v6 | v6 | Yes | &gt;= 5.5
7.x | Latest | guzzlehttp/guzzle | GuzzleHttp | v7 | v7 | Yes | &gt;= 7.2

Thank you!