### PR TITLE
Fix URL parameter type in CreateSites example

### DIFF
--- a/examples/AdManager/v202508/SiteService/CreateSites.php
+++ b/examples/AdManager/v202508/SiteService/CreateSites.php
@@ -83,7 +83,7 @@ class CreateSites
         self::runExample(
             new ServiceFactory(),
             $session,
-            intval(self::URL),
+            self::URL,
             intval(self::CHILD_NETWORK_CODE)
         );
     }


### PR DESCRIPTION
There was an issue in the example that forced the URL into an integer value. The API response returned “invalid URL.” After removing the intval(), everything works as expected.