### PR TITLE
Add support for symfony/serializer v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "guzzlehttp/psr7": "^1.7 || ^2.0",
     "monolog/monolog": "^2.2.0 || ^3.0",
     "phpdocumentor/reflection-docblock": "^3.0.3 || ^4.0 || ^5.0",
-    "symfony/serializer": "^3.0.3 || ^4.4.0 || ^5.0.0 || ^6.0.0 || ^7.0",
+    "symfony/serializer": "^3.0.3 || ^4.4.0 || ^5.0.0 || ^6.0.0 || ^7.0 || ^8.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
## Summary

Adds `^8.0` to the `symfony/serializer` version constraint in `composer.json`, allowing this library to be installed alongside Symfony 8.x projects.

## Details

The `symfony/serializer` package is declared as a dependency but is not directly used anywhere in the library's source code — the library relies on PHP's native SOAP extension for serialization. The Symfony 8.0 Serializer changelog contains breaking changes (removed `CsvEncoder::ESCAPE_CHAR_KEY`, changed `NameConverterInterface` signatures, removed `AdvancedNameConverterInterface`, etc.), but none of these affect this library since no Serializer classes are referenced.

This is the same pattern as previous PRs: #798 (v7), #638 (v5), #401 (v4).

Fixes #811